### PR TITLE
Fixed problem with env in settings.py and updated README about ALLOWED_HOSTS

### DIFF
--- a/MPCAutofill/MPCAutofill/settings.py
+++ b/MPCAutofill/MPCAutofill/settings.py
@@ -23,17 +23,17 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # Production-specific settings kept in local_settings.py
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = env("DJANGO_SECRET_KEY", default="-")
+SECRET_KEY = env("DJANGO_SECRET_KEY", default="Change me in .env")
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = env("DJANGO_DEBUG", default=False)
+DEBUG = env("DJANGO_DEBUG", default="false").lower() == "true"
 
-ALLOWED_HOSTS = env("ALLOWED_HOSTS", default=["localhost", "127.0.0.1"])
+ALLOWED_HOSTS = env("DJANGO_ALLOWED_HOSTS", default="localhost 127.0.0.1").split()
 
 # Google Analytics GTAG
 GTAG = env("GTAG", default="")
 
-PREPEND_WWW = env("PREPEND_WWW", default=False)
+PREPEND_WWW = env("PREPEND_WWW", default="false").lower() == "true"
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/3.0/howto/deployment/checklist/

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Two alternative installation methods are described in the following. At this poi
 
 The easiest way to get MPCAutofill running as quickly as possible is by using Docker containers. The [docker](docker/) sub-folder includes all necessary scripts to automatically set up and run MPCAutofill with all its dependencies. The only tools you need are Docker and Docker-compose.
 
-In case you are deploying to production, also make sure to put a random secret into `docker/django/env.txt`, e.g., by running `sed -i "s/DJANGO_SECRET_KEY=.*/DJANGO_SECRET_KEY=$(openssl rand -base64 12)/g" docker/django/env.txt`.
+_Notes for production:_ First and foremost, make sure to put a random secret into `docker/django/env.txt`, e.g., by running `sed -i "s/DJANGO_SECRET_KEY=.*/DJANGO_SECRET_KEY=$(openssl rand -base64 12)/g" docker/django/env.txt`. In the same file, you might also want to add `DJANGO_ALLOWED_HOSTS="*"` to allow access to the website from other hosts.
 
 ### Docker on Linux
 

--- a/docker/django/env.txt
+++ b/docker/django/env.txt
@@ -1,5 +1,7 @@
 DJANGO_SECRET_KEY=SehrGeheim123
 DJANGO_DEBUG=False
+# Uncomment the following line to allow acess from other machines.
+# DJANGO_ALLOWED_HOSTS="*"
 DATABASE_ENGINE=django.db.backends.postgresql
 DATABASE_NAME=mpcautofill
 ELASTICSEARCH_HOST=elasticsearch


### PR DESCRIPTION
A couple of improvements from user feedback on discord.
Apparently, environment variables coming from `env` are string by default and not automatically cast to higher-level types such as lists. To ensure correct behavior, I rewrote the `env` lines in `settings.py` to only depend on strings.
I also added a small note on `DJANGO_ALLOWED_HOSTS` to the README as it caused some trouble in a setup.