### PR TITLE
Improved Readme, fixed Docker on Windows when using git.

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ Once you finished the Docker Desktop installation and restarted your machine, do
 
 ### Q&A: Common Problems
 
+_Docker-compose fails with "/bin/sh: 1: ./docker/django/check_client_secrets.sh: not found"!_ This error appears on Windows when using git to check out the repository. (For some reason, `COPY . /MPCAutofill` does not copy any files.) As a workaround, download the repostitory as zip file instead.
+
 _The website just gives me "502 Bad Gateway"!_ The Django instance isn't ready yet, probably still scanning cards. Have a look at the docker output. Use `docker-compose logs django` if you started them detached.
 
 _I changed some files but it looks like Docker didn't adopt those changes!_ All files including `drives.csv` are part of the image and not updated automatically. Try `docker-compose up --build --force-recreate` to rebuild all images and containers, and to make sure that all changes are reflected in Docker.

--- a/README.md
+++ b/README.md
@@ -77,8 +77,6 @@ Once you finished the Docker Desktop installation and restarted your machine, do
 
 _Docker-compose fails with "docker.errors.DockerException: Error while fetching server API version: (2, 'CreateFile', 'The system cannot find the file specified.')"!_ Your docker daemon isn't running. Just start Docker Desktop, wait for a couple of seconds, and try again.
 
-_Docker-compose fails with "/bin/sh: 1: ./docker/django/check_client_secrets.sh: not found"!_ This error appears when you are using git to check out the repository on Windows. (For some reason, `COPY . /MPCAutofill` does not copy any files to the image.) As a workaround, just download the repostitory as zip file instead.
-
 _The website just gives me "502 Bad Gateway"!_ The Django instance isn't ready yet, probably still scanning cards. Have a look at the docker output. Use `docker-compose logs django` if you started them detached.
 
 _I changed some files but it looks like Docker didn't adopt those changes!_ All files including `drives.csv` are part of the image and not updated automatically. Try `docker-compose up --build --force-recreate` to rebuild all images and containers, and to make sure that all changes are reflected in Docker.

--- a/README.md
+++ b/README.md
@@ -75,7 +75,9 @@ Once you finished the Docker Desktop installation and restarted your machine, do
 
 ### Q&A: Common Problems
 
-_Docker-compose fails with "/bin/sh: 1: ./docker/django/check_client_secrets.sh: not found"!_ This error appears on Windows when using git to check out the repository. (For some reason, `COPY . /MPCAutofill` does not copy any files.) As a workaround, download the repostitory as zip file instead.
+_Docker-compose fails with "docker.errors.DockerException: Error while fetching server API version: (2, 'CreateFile', 'The system cannot find the file specified.')"!_ Your docker daemon isn't running. Just start Docker Desktop, wait for a couple of seconds, and try again.
+
+_Docker-compose fails with "/bin/sh: 1: ./docker/django/check_client_secrets.sh: not found"!_ This error appears when you are using git to check out the repository on Windows. (For some reason, `COPY . /MPCAutofill` does not copy any files to the image.) As a workaround, just download the repostitory as zip file instead.
 
 _The website just gives me "502 Bad Gateway"!_ The Django instance isn't ready yet, probably still scanning cards. Have a look at the docker output. Use `docker-compose logs django` if you started them detached.
 

--- a/docker/django/Dockerfile
+++ b/docker/django/Dockerfile
@@ -10,6 +10,7 @@ ENV PYTHONUNBUFFERED=1
 # Install tools and additional dependencies
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
+        dos2unix \
         python3-pip python3-dev \
         gcc netcat curl cron \
     && rm -rf /var/lib/apt/lists/*
@@ -26,11 +27,14 @@ WORKDIR /MPCAutofill
 RUN pip3 install gunicorn wheel
 RUN pip3 install -r requirements.txt
 
-# Copy entire repository
-COPY . /MPCAutofill
+# Copy relevant files from repository
+COPY docker /MPCAutofill/docker
+COPY MPCAutofill /MPCAutofill/MPCAutofill
 
-# Make sure that all scripts are executable
-RUN chmod +x docker/django/*.sh
+# Make sure that all scripts are executable, and in case we
+# checked out under Windows with CRLF, convert line endings
+RUN chmod +x docker/django/*.sh && \
+    find . -type f -exec dos2unix {} \;
 
 # Let's be nice to the user and give some clear error message
 # if they missed to install any of the mandatory files.


### PR DESCRIPTION
There is a problem with a Dockerfile when the repository is checked out via git on Windows. ~~When the Dockerfile are processed, the repository is _not_ copied into the docker image; the responsible line `COPY . /MPCAutofill` seems to have no effect.~~ This problem only exists when git is used - the zip file works as intended. I couldn't figure out what causes this problem, so I at least wanted to point it out in the README.

Edit: The actual problem was that Git on Windows changes all line endings from LF to CRLF, causing problems in bash scripts when copied back into the docker images.