### PR TITLE
Updated Docker for local file support branch

### DIFF
--- a/MPCAutofill/MPCAutofill/settings.py
+++ b/MPCAutofill/MPCAutofill/settings.py
@@ -14,11 +14,6 @@ import os
 
 from environ import Env
 
-# local file indexing
-LOCAL_FILE_INDEX = r""  # for example: r"C:\Users\John Doe\Desktop\MPC Cards"
-
-DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
-
 env = Env()
 env.read_env()
 
@@ -34,6 +29,11 @@ SECRET_KEY = env("DJANGO_SECRET_KEY", default="-")
 DEBUG = env("DJANGO_DEBUG", default=False)
 
 ALLOWED_HOSTS = env("ALLOWED_HOSTS", default=["localhost", "127.0.0.1"])
+
+# local file indexing
+LOCAL_FILE_INDEX = env("DJANGO_LOCAL_FILES", default=r"") # for example: r"C:\Users\John Doe\Desktop\MPC Cards"
+
+DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 # Google Analytics GTAG
 GTAG = env("GTAG", default="")

--- a/docker/django/Dockerfile
+++ b/docker/django/Dockerfile
@@ -44,19 +44,21 @@ RUN ./docker/django/check_client_secrets.sh && \
 # Install cronjobs
 RUN cp docker/django/crontab.txt /etc/crontab
 
-# Create a non-root user and add permission to access the /MPCAutofill folder
-RUN adduser -u 5678 --disabled-password --gecos "" mpcautofill && \
-    chown -R mpcautofill /MPCAutofill
+# Create a non-root user and add permission to access the /MPCAutofill and /cards
+RUN mkdir -p /cards && \
+    adduser -u 5678 --disabled-password --gecos "" mpcautofill && \
+    chown -R mpcautofill /MPCAutofill /cards
 USER mpcautofill
 
 # Place environment file
 RUN cp docker/django/env.txt MPCAutofill/MPCAutofill/.env
 
-# Prepare folder for static files (create now as user for permissions)
-RUN mkdir -p static
+# Collect static files now. This ensures write permissions on the mounted static/
+# folder and /cards is not yet mounted, therefore no cards will be copied.
+WORKDIR /MPCAutofill/MPCAutofill
+RUN python3 manage.py collectstatic --noinput
 
 # Prepare to start
 EXPOSE 8000
-WORKDIR /MPCAutofill/MPCAutofill
 ENTRYPOINT ["/MPCAutofill/docker/django/entrypoint.sh"]
 CMD ["gunicorn", "MPCAutofill.wsgi:application", "--bind", "0.0.0.0:8000"]

--- a/docker/django/entrypoint.sh
+++ b/docker/django/entrypoint.sh
@@ -19,9 +19,6 @@ done
 
 # Check if we are running for the first time
 if ! python3 manage.py migrate --check; then
-    # Gather static files
-    python3 manage.py collectstatic --noinput
-
     # Run migrations and populate database
     echo "Migrate Django database..."
     python3 manage.py migrate

--- a/docker/django/env.txt
+++ b/docker/django/env.txt
@@ -1,5 +1,6 @@
 DJANGO_SECRET_KEY=SehrGeheim123
 DJANGO_DEBUG=False
+DJANGO_LOCAL_FILES=/cards
 DATABASE_ENGINE=django.db.backends.postgresql
 DATABASE_NAME=mpcautofill
 ELASTICSEARCH_HOST=elasticsearch

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -41,6 +41,7 @@ services:
     volumes:
       # Writes to
       - django_static:/MPCAutofill/static
+      - ${MPCAUTOFILL_LOCAL_FILES}:/cards
     expose:
       - 8000
     depends_on:
@@ -56,8 +57,9 @@ services:
     volumes:
       # Reads from
       - django_static:/MPCAutofill/static
+      - ${MPCAUTOFILL_LOCAL_FILES}:/cards
     ports:
-      - 8000:80
+      - ${MPCAUTOFILL_HTTP_PORT:-8000}:80
     depends_on:
       - django
 

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -15,7 +15,12 @@ server {
     }
 
     # Serving of static files via shared volume
+    location ~ /static/(admin|cardpicker|css|js)/(.*) {
+        alias /MPCAutofill/static/$1/$2;
+    }
+
+    # Everything else in static should be a card
     location /static/ {
-        alias /MPCAutofill/static/;
+        alias /cards/;
     }
 }


### PR DESCRIPTION
A few comments on the local file support branch:

1. Pip shows an error: `ERROR: inquirer 2.7.0 has requirement blessed==1.17.6, but you'll have blessed 1.19.0 which is incompatible.` But it neither stops the build nor shows any other problems (yet).
2. Having the cards directly under `/static/` could be problematic. There could be a collision with other static files, although unlikely. Having the cards under, e.g., `/static/cards/` instead would also simplify the Nginx configuration and make it more robust. At the moment, two different sources must be considered when files in `/static/` are requested. Not sure if such a change in the path would be easily doable.
3. Since Docker sees only internal mounting points, the paths in the order files are invalid for the host system (see below). I think it would be better to have the path/id be `http://localhost:8000/static/Former Orders/Jace, the Mind Sculptor (Extended).png` instead. Then, autofill could just grab the file from that path.
```
<card>
    <id>/cards/Former Orders/Jace, the Mind Sculptor (Extended).png</id>
    <slots>1</slots>
    <name>Jace, the Mind Sculptor (Extended).png</name>
    <query>jace</query>
</card>
```