### PR TITLE
Add new option to autofill.py to export cards to PDF

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,9 @@ coverage.xml
 *.py,cover
 .hypothesis/
 .pytest_cache/
+autofill/export/
+autofill/tests/export/
+
 cover/
 
 # Translations

--- a/autofill/autofill.py
+++ b/autofill/autofill.py
@@ -24,7 +24,7 @@ os.system("")  # enables ansi escape characters in terminal
     "--exportpdf",
     default=False,
     help="Create a PDF export of the card images and do not create a project for MPC.",
-    is_flag=True
+    is_flag=True,
 )
 def main(skipsetup: bool, browser: str, exportpdf: bool) -> None:
     try:

--- a/autofill/autofill.py
+++ b/autofill/autofill.py
@@ -20,9 +20,15 @@ os.system("")  # enables ansi escape characters in terminal
     type=click.Choice(sorted(browsers.keys()), case_sensitive=False),
     help="Web browser to automate.",
 )
-def main(skipsetup: bool, browser: str) -> None:
+@click.option(
+    "--exportpdf",
+    default=False,
+    help="Create a PDF export of the card images and do not create a project for MPC.",
+    is_flag=True
+)
+def main(skipsetup: bool, browser: str, exportpdf: bool) -> None:
     try:
-        AutofillDriver(driver_callable=browsers[browser]).execute(skipsetup)
+        AutofillDriver(driver_callable=browsers[browser], export_pdf=exportpdf).execute(skipsetup)
     except Exception as e:
         print(f"An uncaught exception occurred: {TEXT_BOLD}{e}{TEXT_END}")
         input("Press Enter to exit.")

--- a/autofill/autofill.py
+++ b/autofill/autofill.py
@@ -3,6 +3,7 @@ import os
 import click
 from src.constants import browsers
 from src.driver import AutofillDriver
+from src.pdf_maker import PdfExporter
 from src.utils import TEXT_BOLD, TEXT_END
 
 # https://stackoverflow.com/questions/12492810/python-how-can-i-make-the-ansi-escape-codes-to-work-also-in-windows
@@ -28,7 +29,10 @@ os.system("")  # enables ansi escape characters in terminal
 )
 def main(skipsetup: bool, browser: str, exportpdf: bool) -> None:
     try:
-        AutofillDriver(driver_callable=browsers[browser], export_pdf=exportpdf).execute(skipsetup)
+        if exportpdf:
+            PdfExporter().execute()
+        else:
+            AutofillDriver(driver_callable=browsers[browser]).execute(skipsetup)
     except Exception as e:
         print(f"An uncaught exception occurred: {TEXT_BOLD}{e}{TEXT_END}")
         input("Press Enter to exit.")

--- a/autofill/readme.md
+++ b/autofill/readme.md
@@ -38,6 +38,9 @@ Some notes on how editing an existing project with `--skipsetup` works:
 ### Specifying a Browser
 By default, the tool will configure a driver for Google Chrome. The three major Chromium-based browsers are supported (Chrome, Edge, and Brave), and you can specify which browser should be used to configure the driver with the `--browser` command line argument.
 
+### Exporting to PDF
+You can optionally export the downloaded images to a PDF which can be uploaded to a card printing site by using the `--exportpdfs` command line argument. Once the images are downloaded, press enter and you'll be presented with a few questions. If you plan to upload the PDFs to MakePlayingCards, select `yes` when asked about storing the separate faces in their own PDF. If you plan to use DriveThruCards, select `no` for that question, and then set the number of cards to include per exported file. If using DriveThruCards, be aware that they have a file size upload limit of 1gb, so depending on the file size of the selected images, your order may need to be set to a lower number, like 30 or 40 cards.
+
 ## Developer Guide
 ### Running the Source Code
 From the base repo directory:

--- a/autofill/readme.md
+++ b/autofill/readme.md
@@ -58,13 +58,13 @@ From the base repo directory:
 * The resultant executable will be in `/autofill/dist`.
 
 ### Running the Test Suite
-Two tests in `src/tests.py` (at the bottom of the file) are marked as skip as they don't work consistently in GitHub Actions. I suggest commenting out the `pytest.mark.skip()` lines when running tests on your machine to run these. Note that they can take a couple of minutes to run as they put through small orders with MPC.
+Two tests in `tests/test_desktop_client.py` (at the bottom of the file) are marked as skip as they don't work consistently in GitHub Actions. I suggest commenting out the `pytest.mark.skip()` lines when running tests on your machine to run these. Note that they can take a couple of minutes to run as they put through small orders with MPC.
 From the base repo directory:
 * `cd autofill`,
 * Activate virtual environment or create one with `venv`,
 * Install requirements - `pip install -r requirements.txt`,
-* `cd src`,
-* Run tests - `coverage run -m pytest tests.py`,
+* `cd tests`,
+* Run tests - `coverage run -m pytest test_desktop_client.py`,
 * Report on code coverage: `coverage report`.
 
 ### XML Specification

--- a/autofill/requirements.txt
+++ b/autofill/requirements.txt
@@ -4,6 +4,7 @@ colorama
 coverage
 defusedxml
 enlighten
+fpdf2
 InquirerPy
 numpy
 pre-commit

--- a/autofill/src/driver.py
+++ b/autofill/src/driver.py
@@ -15,6 +15,7 @@ from selenium.webdriver.support.expected_conditions import invisibility_of_eleme
 from selenium.webdriver.support.ui import Select, WebDriverWait
 from src.constants import THREADS, States
 from src.order import CardImage, CardImageCollection, CardOrder
+from src.pdf_maker import PdfExporter
 from src.utils import (
     TEXT_BOLD,
     TEXT_END,
@@ -23,7 +24,6 @@ from src.utils import (
     time_to_hours_minutes_seconds,
 )
 from src.webdrivers import get_chrome_driver
-from src.pdf_maker import PdfExporter
 
 
 @attr.s
@@ -434,7 +434,7 @@ class AutofillDriver:
                         """
                     )
                 )
-                
+
                 exporter = PdfExporter(order=self.order)
                 exporter.execute()
                 return

--- a/autofill/src/driver.py
+++ b/autofill/src/driver.py
@@ -23,6 +23,7 @@ from src.utils import (
     time_to_hours_minutes_seconds,
 )
 from src.webdrivers import get_chrome_driver
+from src.pdf_maker import PdfExporter
 
 
 @attr.s
@@ -32,6 +33,7 @@ class AutofillDriver:
     )  # delay initialisation until XML is selected and parsed
     driver_callable: Callable[[bool], WebDriver] = attr.ib(default=get_chrome_driver)
     headless: bool = attr.ib(default=False)
+    export_pdf: bool = attr.ib(default=False)
     starting_url: str = attr.ib(
         init=False,
         default="https://www.makeplayingcards.com/design/custom-blank-card.html",
@@ -78,6 +80,8 @@ class AutofillDriver:
     def __attrs_post_init__(self) -> None:
         self.configure_bars()
         self.order.print_order_overview()
+        if self.export_pdf:
+            return
         self.initialise_driver()
         self.driver.get(self.starting_url)
         self.set_state(States.defining_order)
@@ -419,6 +423,21 @@ class AutofillDriver:
                     )
                 )
                 self.redefine_order()
+
+            elif self.export_pdf:
+                input(
+                    textwrap.dedent(
+                        f"""
+                        The program has been started with {TEXT_BOLD}--exportpdf{TEXT_END}, which will generate a
+                        PDF containing the images. These cards can be taken to a printer to be printed and cut down.
+                        Please wait for the images to download and press Enter.
+                        """
+                    )
+                )
+                
+                exporter = PdfExporter(order=self.order)
+                exporter.execute()
+                return
 
             else:
                 print(

--- a/autofill/src/pdf_maker.py
+++ b/autofill/src/pdf_maker.py
@@ -1,0 +1,134 @@
+import os
+
+import attr
+import InquirerPy
+from fpdf import FPDF
+
+from src.order import CardOrder
+from src.utils import ValidationException
+
+
+@attr.s
+class PdfExporter:
+    pdf: FPDF = attr.ib(default=None)
+    order: CardOrder = attr.ib(default=None)
+    card_width_in_inches: float = attr.ib(default=2.73)
+    card_height_in_inches: float = attr.ib(default=3.71)
+    file_num: int = attr.ib(default=1)
+    number_of_cards_per_file: int = attr.ib(default=100)
+    paths_by_slot: dict = attr.ib(default={})
+    save_path: str = attr.ib(default="")
+    separate_faces: bool = attr.ib(default=False)
+    current_face: str = attr.ib(default="all")
+
+    def __attrs_post_init__(self) -> None:
+        self.ask_questions()
+        self.generate_file_path()
+        self.collect_images()
+
+    def ask_questions(self):
+        questions = [
+            {
+                "type": "list",
+                "name": "split_faces",
+                "message": "Do you want the front and back of the cards in separate PDFs? (required for MPC).",
+                "default": 0,
+                "choices": [InquirerPy.base.control.Choice(False, name="No"),
+                            InquirerPy.base.control.Choice(True, name="Yes")]
+            },
+            {
+                "type": "number",
+                "name": "cards_per_file",
+                "message": "How many cards should be included in the generated files? Note: The more cards per file, " +
+                           "the longer the processing will take and the larger the file size will be.",
+                "default": 60,
+                "when": lambda result: result["split_faces"] is False,
+                "transformer": lambda result: 1 if int(result) < 1 else int(result)
+            }
+        ]
+        answers = InquirerPy.prompt(questions)
+        if answers["split_faces"]:
+            self.separate_faces = True
+            self.number_of_cards_per_file = 1
+        else:
+            self.number_of_cards_per_file = 1 if int(answers["cards_per_file"]) < 1 else int(answers["cards_per_file"])
+
+    def generate_file_path(self) -> None:
+        file_name = os.path.splitext(os.path.basename(self.order.name))[0]
+        self.save_path = "export/%s/" % file_name
+        os.makedirs(self.save_path, exist_ok=True)
+        if self.separate_faces:
+            for face in ['backs', 'fronts']:
+                os.makedirs(self.save_path + face, exist_ok=True)
+
+    def generate_pdf(self) -> None:
+        pdf = FPDF('P', 'in', (self.card_width_in_inches, self.card_height_in_inches))
+        self.pdf = pdf
+
+    def add_image(self, image_path: str) -> None:
+        self.pdf.add_page()
+        self.pdf.image(image_path, x=0, y=0, w=self.card_width_in_inches, h=self.card_height_in_inches)
+
+    def save_file(self) -> None:
+        extra = ''
+        if self.separate_faces:
+            extra = "%s/" % self.current_face
+        self.pdf.output(self.save_path + extra + str(self.file_num) + '.pdf')
+
+    def collect_images(self) -> None:
+        backs_by_slots = {}
+        for card in self.order.backs.cards:
+            for slot in card.slots:
+                backs_by_slots[slot] = card.file_path
+
+        fronts_by_slots = {}
+        for card in self.order.fronts.cards:
+            for slot in card.slots:
+                fronts_by_slots[slot] = card.file_path
+
+        paths_by_slot = {}
+        for slot in fronts_by_slots.keys():
+            paths_by_slot[slot] = (backs_by_slots.get(slot, backs_by_slots[0]), fronts_by_slots[slot])
+        self.paths_by_slot = paths_by_slot
+
+    def execute(self) -> None:
+        if self.separate_faces:
+            self.number_of_cards_per_file = 1
+            self.export_separate_faces()
+        else:
+            self.export()
+
+        print('Finished exporting files! They should be accessible at %s' % self.save_path)
+
+    def export(self) -> None:
+        for slot in sorted(self.paths_by_slot.keys()):
+            (back_path, front_path) = self.paths_by_slot[slot]
+            print('Working on slot %s' % str(slot))
+            if slot == 0:
+                self.generate_pdf()
+            elif slot % self.number_of_cards_per_file == 0:
+                print('Saving PDF #%s' % str(self.file_num))
+                self.save_file()
+                self.file_num = self.file_num + 1
+                self.generate_pdf()
+            print('Adding images for slot %s' % str(slot))
+            self.add_image(back_path)
+            self.add_image(front_path)
+
+        print('Saving PDF #%s' % str(self.file_num))
+        self.save_file()
+
+    def export_separate_faces(self) -> None:
+        all_faces = ['backs', 'fronts']
+        for slot in sorted(self.paths_by_slot.keys()):
+            image_paths_tuple = self.paths_by_slot[slot]
+            print('Working on slot ' + str(slot))
+            for face in all_faces:
+                face_index = all_faces.index(face)
+                self.current_face = face
+                self.generate_pdf()
+                self.add_image(image_paths_tuple[face_index])
+                print('Saving %s PDF for slot %s' % (face, str(slot)))
+                self.save_file()
+                if face_index == 1:
+                    self.file_num = self.file_num + 1

--- a/autofill/src/pdf_maker.py
+++ b/autofill/src/pdf_maker.py
@@ -3,7 +3,6 @@ import os
 import attr
 import InquirerPy
 from fpdf import FPDF
-
 from src.order import CardOrder
 from src.utils import ValidationException
 
@@ -16,7 +15,7 @@ class PdfExporter:
     card_height_in_inches: float = attr.ib(default=3.71)
     file_num: int = attr.ib(default=1)
     number_of_cards_per_file: int = attr.ib(default=100)
-    paths_by_slot: dict = attr.ib(default={})
+    paths_by_slot: dict[int, tuple[str, str]] = attr.ib(default={})
     save_path: str = attr.ib(default="")
     separate_faces: bool = attr.ib(default=False)
     current_face: str = attr.ib(default="all")
@@ -26,25 +25,27 @@ class PdfExporter:
         self.generate_file_path()
         self.collect_images()
 
-    def ask_questions(self):
+    def ask_questions(self) -> None:
         questions = [
             {
                 "type": "list",
                 "name": "split_faces",
                 "message": "Do you want the front and back of the cards in separate PDFs? (required for MPC).",
                 "default": 0,
-                "choices": [InquirerPy.base.control.Choice(False, name="No"),
-                            InquirerPy.base.control.Choice(True, name="Yes")]
+                "choices": [
+                    InquirerPy.base.control.Choice(False, name="No"),
+                    InquirerPy.base.control.Choice(True, name="Yes"),
+                ],
             },
             {
                 "type": "number",
                 "name": "cards_per_file",
-                "message": "How many cards should be included in the generated files? Note: The more cards per file, " +
-                           "the longer the processing will take and the larger the file size will be.",
+                "message": "How many cards should be included in the generated files? Note: The more cards per file, "
+                + "the longer the processing will take and the larger the file size will be.",
                 "default": 60,
                 "when": lambda result: result["split_faces"] is False,
-                "transformer": lambda result: 1 if int(result) < 1 else int(result)
-            }
+                "transformer": lambda result: 1 if int(result) < 1 else int(result),
+            },
         ]
         answers = InquirerPy.prompt(questions)
         if answers["split_faces"]:
@@ -54,15 +55,18 @@ class PdfExporter:
             self.number_of_cards_per_file = 1 if int(answers["cards_per_file"]) < 1 else int(answers["cards_per_file"])
 
     def generate_file_path(self) -> None:
-        file_name = os.path.splitext(os.path.basename(self.order.name))[0]
+        basename = os.path.basename(str(self.order.name))
+        if not basename:
+            basename = "cards.xml"
+        file_name = os.path.splitext(basename)[0]
         self.save_path = "export/%s/" % file_name
         os.makedirs(self.save_path, exist_ok=True)
         if self.separate_faces:
-            for face in ['backs', 'fronts']:
+            for face in ["backs", "fronts"]:
                 os.makedirs(self.save_path + face, exist_ok=True)
 
     def generate_pdf(self) -> None:
-        pdf = FPDF('P', 'in', (self.card_width_in_inches, self.card_height_in_inches))
+        pdf = FPDF("P", "in", (self.card_width_in_inches, self.card_height_in_inches))
         self.pdf = pdf
 
     def add_image(self, image_path: str) -> None:
@@ -70,10 +74,10 @@ class PdfExporter:
         self.pdf.image(image_path, x=0, y=0, w=self.card_width_in_inches, h=self.card_height_in_inches)
 
     def save_file(self) -> None:
-        extra = ''
+        extra = ""
         if self.separate_faces:
             extra = "%s/" % self.current_face
-        self.pdf.output(self.save_path + extra + str(self.file_num) + '.pdf')
+        self.pdf.output(self.save_path + extra + str(self.file_num) + ".pdf")
 
     def collect_images(self) -> None:
         backs_by_slots = {}
@@ -88,7 +92,7 @@ class PdfExporter:
 
         paths_by_slot = {}
         for slot in fronts_by_slots.keys():
-            paths_by_slot[slot] = (backs_by_slots.get(slot, backs_by_slots[0]), fronts_by_slots[slot])
+            paths_by_slot[slot] = (str(backs_by_slots.get(slot, backs_by_slots[0])), str(fronts_by_slots[slot]))
         self.paths_by_slot = paths_by_slot
 
     def execute(self) -> None:
@@ -98,37 +102,37 @@ class PdfExporter:
         else:
             self.export()
 
-        print('Finished exporting files! They should be accessible at %s' % self.save_path)
+        print("Finished exporting files! They should be accessible at %s" % self.save_path)
 
     def export(self) -> None:
         for slot in sorted(self.paths_by_slot.keys()):
             (back_path, front_path) = self.paths_by_slot[slot]
-            print('Working on slot %s' % str(slot))
+            print("Working on slot %s" % str(slot))
             if slot == 0:
                 self.generate_pdf()
             elif slot % self.number_of_cards_per_file == 0:
-                print('Saving PDF #%s' % str(self.file_num))
+                print("Saving PDF #%s" % str(self.file_num))
                 self.save_file()
                 self.file_num = self.file_num + 1
                 self.generate_pdf()
-            print('Adding images for slot %s' % str(slot))
+            print("Adding images for slot %s" % str(slot))
             self.add_image(back_path)
             self.add_image(front_path)
 
-        print('Saving PDF #%s' % str(self.file_num))
+        print("Saving PDF #%s" % str(self.file_num))
         self.save_file()
 
     def export_separate_faces(self) -> None:
-        all_faces = ['backs', 'fronts']
+        all_faces = ["backs", "fronts"]
         for slot in sorted(self.paths_by_slot.keys()):
             image_paths_tuple = self.paths_by_slot[slot]
-            print('Working on slot ' + str(slot))
+            print("Working on slot " + str(slot))
             for face in all_faces:
                 face_index = all_faces.index(face)
                 self.current_face = face
                 self.generate_pdf()
                 self.add_image(image_paths_tuple[face_index])
-                print('Saving %s PDF for slot %s' % (face, str(slot)))
+                print("Saving %s PDF for slot %s" % (face, str(slot)))
                 self.save_file()
                 if face_index == 1:
                     self.file_num = self.file_num + 1

--- a/autofill/src/utils.py
+++ b/autofill/src/utils.py
@@ -136,3 +136,19 @@ def time_to_hours_minutes_seconds(t: float) -> tuple[int, int, int]:
     mins = int(floor(t / 60) - hours * 60)
     secs = int(t - (mins * 60) - (hours * 3600))
     return hours, mins, secs
+
+
+def remove_directories(directory_list: list[str]) -> None:
+    for directory in directory_list:
+        try:
+            os.rmdir(directory)
+        except Exception:
+            pass
+
+
+def remove_files(file_list: list[str]) -> None:
+    for file in file_list:
+        try:
+            os.remove(file)
+        except Exception:
+            pass

--- a/autofill/tests/test_desktop_client.py
+++ b/autofill/tests/test_desktop_client.py
@@ -776,15 +776,6 @@ def test_pdf_export_complete_3_cards_single_file(monkeypatch, card_order_valid):
     def do_nothing(_):
         return None
 
-    def replace_execute(self, skip_setup=False):
-        with ThreadPoolExecutor(max_workers=3) as pool:
-            self.order.fronts.download_images(pool, self.download_bar)
-            self.order.backs.download_images(pool, self.download_bar)
-
-    monkeypatch.setattr("src.driver.AutofillDriver.execute", replace_execute)
-    autofill_driver = AutofillDriver(order=card_order_valid, export_pdf=True)
-    autofill_driver.execute(skip_setup=False)
-
     monkeypatch.setattr("src.pdf_maker.PdfExporter.ask_questions", do_nothing)
     card_order_valid.name = "test_order.xml"
     pdf_exporter = PdfExporter(order=card_order_valid)
@@ -804,15 +795,6 @@ def test_pdf_export_complete_3_cards_separate_files(monkeypatch, card_order_vali
     def do_nothing(_):
         return None
 
-    def replace_execute(self, skip_setup=False):
-        with ThreadPoolExecutor(max_workers=3) as pool:
-            self.order.fronts.download_images(pool, self.download_bar)
-            self.order.backs.download_images(pool, self.download_bar)
-
-    monkeypatch.setattr("src.driver.AutofillDriver.execute", replace_execute)
-    autofill_driver = AutofillDriver(order=card_order_valid, export_pdf=True)
-    autofill_driver.execute(skip_setup=False)
-
     monkeypatch.setattr("src.pdf_maker.PdfExporter.ask_questions", do_nothing)
     card_order_valid.name = "test_order.xml"
     pdf_exporter = PdfExporter(order=card_order_valid, number_of_cards_per_file=1)
@@ -829,15 +811,6 @@ def test_pdf_export_complete_3_cards_separate_files(monkeypatch, card_order_vali
 def test_pdf_export_complete_separate_faces(monkeypatch, card_order_valid):
     def do_nothing(_):
         return None
-
-    def replace_execute(self, skip_setup=False):
-        with ThreadPoolExecutor(max_workers=3) as pool:
-            self.order.fronts.download_images(pool, self.download_bar)
-            self.order.backs.download_images(pool, self.download_bar)
-
-    monkeypatch.setattr("src.driver.AutofillDriver.execute", replace_execute)
-    autofill_driver = AutofillDriver(order=card_order_valid, export_pdf=True)
-    autofill_driver.execute(skip_setup=False)
 
     monkeypatch.setattr("src.pdf_maker.PdfExporter.ask_questions", do_nothing)
     card_order_valid.name = "test_order.xml"
@@ -864,7 +837,7 @@ def test_pdf_export_complete_separate_faces(monkeypatch, card_order_valid):
 # region test driver.py
 
 
-@pytest.mark.skip()  # marking as skip because this test can be inconsistent when run on ci/cd
+# @pytest.mark.skip()  # marking as skip because this test can be inconsistent when run on ci/cd
 def test_card_order_complete_run_single_cardback(input_enter, card_order_valid):
     autofill_driver = AutofillDriver(order=card_order_valid, headless=True)
     autofill_driver.execute(skip_setup=False)
@@ -872,7 +845,7 @@ def test_card_order_complete_run_single_cardback(input_enter, card_order_valid):
     assert len(autofill_driver.driver.find_elements(by=By.CLASS_NAME, value="m-itemside")) == 3
 
 
-@pytest.mark.skip()  # marking as skip because this test can be inconsistent when run on ci/cd
+# @pytest.mark.skip()  # marking as skip because this test can be inconsistent when run on ci/cd
 def test_card_order_complete_run_multiple_cardbacks(input_enter, card_order_multiple_cardbacks):
     autofill_driver = AutofillDriver(order=card_order_multiple_cardbacks, headless=True)
     autofill_driver.execute(skip_setup=False)


### PR DESCRIPTION
Option for PDF export is invoked by adding the `--exportpdf` option to autofill.py. Images are downloaded, then you press Enter to go through a few quick options.

First, it asks if you want to split front and back faces into their own file. This is required for uploading PDFs to MPC, and it updates a setting to force only 1 face of 1 card per file.

The next option, if you say no to the previous option, is to select the number of cards to include in the PDF. DriveThruCards has a maximum PDF upload size of 1gb, so this number may need to be adjusted based on the file size of the images used.

Files are exported to exports/<XML filename>/<export number>.pdf (or exports/<XML filename>/<"fronts" or "backs">/<card slot number number>.pdf