### PR TITLE
Improve image uploading logic

### DIFF
--- a/autofill/src/driver.py
+++ b/autofill/src/driver.py
@@ -33,10 +33,7 @@ class AutofillDriver:
     )  # delay initialisation until XML is selected and parsed
     driver_callable: Callable[[bool], WebDriver] = attr.ib(default=get_chrome_driver)
     headless: bool = attr.ib(default=False)
-    starting_url: str = attr.ib(
-        init=False,
-        default="https://www.makeplayingcards.com/design/custom-blank-card.html",
-    )
+    starting_url: str = attr.ib(init=False, default="https://www.makeplayingcards.com/design/custom-blank-card.html")
     order: CardOrder = attr.ib(default=attr.Factory(CardOrder.from_xml_in_folder))
     state: str = attr.ib(init=False, default=States.initialising)
     action: Optional[str] = attr.ib(init=False, default=None)
@@ -44,6 +41,7 @@ class AutofillDriver:
     status_bar: enlighten.StatusBar = attr.ib(init=False, default=False)
     download_bar: enlighten.Counter = attr.ib(init=False, default=None)
     upload_bar: enlighten.Counter = attr.ib(init=False, default=None)
+    file_path_to_pid_map: dict[str, str] = {}
 
     # region initialisation
     def initialise_driver(self) -> None:
@@ -199,28 +197,58 @@ class AutofillDriver:
             f"PageLayout.prototype.checkEmptyImage({self.get_element_for_slot_js(slot)})", return_=True
         )
 
-    def upload_image(self, image: CardImage) -> Optional[str]:
+    def get_all_uploaded_image_pids(self) -> list[str]:
+        if pid_string := self.execute_javascript("oDesignImage.dn_getImageList()", return_=True):
+            return pid_string.split(";")
+        return []
+
+    def get_number_of_uploaded_images(self) -> int:
+        return len(self.get_all_uploaded_image_pids())
+
+    def attempt_to_upload_image(self, image: CardImage) -> None:
         """
-        Uploads the given CardImage. Returns the image's PID in MPC.
+        A single attempt at uploading `image` to MPC.
         """
 
-        if image.file_exists():
+        # an image definitely shouldn't be uploading here, but doesn't hurt to make sure
+        while self.is_image_currently_uploading():
+            time.sleep(0.5)
+
+        # send the image contents to mpc
+        self.driver.find_element(by=By.ID, value="uploadId").send_keys(image.file_path)
+        time.sleep(1)
+
+        # wait for the image to finish uploading
+        while self.is_image_currently_uploading():
+            time.sleep(0.5)
+
+    def upload_image(self, image: CardImage, max_tries: int = 3) -> Optional[str]:
+        """
+        Uploads the given CardImage with `max_tries` attempts. Returns the image's PID in MPC.
+        """
+
+        if image.file_path is not None and image.file_exists():
+            if image.file_path in self.file_path_to_pid_map.keys():
+                return self.file_path_to_pid_map[image.file_path]
+
             self.set_state(self.state, f'Uploading "{image.name}"')
+            get_number_of_uploaded_images = self.get_number_of_uploaded_images()
 
-            # an image definitely shouldn't be uploading here, but doesn't hurt to make sure
-            while self.is_image_currently_uploading():
-                time.sleep(0.5)
-
-            # upload image to mpc
-            self.driver.find_element(by=By.ID, value="uploadId").send_keys(image.file_path)
-            time.sleep(1)
-
-            while self.is_image_currently_uploading():
-                time.sleep(0.5)
-
-            # return PID of last uploaded image
-            return self.execute_javascript("oDesignImage.dn_getImageList()", return_=True).split(";")[-1]
-
+            tries = 0
+            while True:
+                self.attempt_to_upload_image(image)
+                if self.get_number_of_uploaded_images() > get_number_of_uploaded_images:
+                    # a new image has been uploaded - assume the last image in the editor is the one we just uploaded
+                    pid = self.get_all_uploaded_image_pids()[-1]
+                    self.file_path_to_pid_map[image.file_path] = pid
+                    return pid
+                tries += 1
+                if tries >= max_tries:
+                    print(
+                        f'Attempted to upload image {TEXT_BOLD}"{image.name}"{TEXT_END} {max_tries} times, '
+                        f"but no attempt succeeded! Skipping this image."
+                    )
+                    return None
         else:
             print(
                 f'Image {TEXT_BOLD}"{image.name}"{TEXT_END} at path {TEXT_BOLD}{image.file_path}{TEXT_END} does '
@@ -332,6 +360,9 @@ class AutofillDriver:
     def page_to_fronts(self) -> None:
         self.assert_state(States.paging_to_fronts)
 
+        # reset this between fronts and backs
+        self.file_path_to_pid_map = {}
+
         # Accept current settings and move to next step
         self.execute_javascript(
             "doPersonalize('https://www.makeplayingcards.com/products/pro_item_process_flow.aspx');"
@@ -356,6 +387,9 @@ class AutofillDriver:
 
     def page_to_backs(self, skip_setup: bool) -> None:
         self.assert_state(States.paging_to_backs)
+
+        # reset this between fronts and backs
+        self.file_path_to_pid_map = {}
 
         self.next_step()
         self.wait()


### PR DESCRIPTION
# Description
This PR is intended to solve the issues described in https://github.com/chilli-axe/mpc-autofill/issues/83

My understanding of the issue is:
* The tool's image uploading code assumes that image uploads are guaranteed to succeed once they begin
* There's some sort of timeout built into MPC where image uploads can terminate midway through
* The tool recognises that the upload has "finished" and retrieves the PID of the last uploaded image, then inserts this image into the slots for the image it tried to upload. This is what causes duplicates of images into slots they don't belong in
* This only becomes relevant when MPC is under heavy strain so I cannot reliably reproduce this issue

I've improved the image uploading code in the following ways:
* It no longer assumes that image uploads are guaranteed to succeed - whether or not an image upload succeeded is determined by checking if the number of uploaded images has increased
* It will attempt to upload each image three times before deciding it's a lost cause and moving on (to prevent the tool from stalling forever)
* If an image has been uploaded previously, that PID will be reused

# Checklist
* [x] I have installed `pre-commit` and run the hooks with `pre-commit run`.
* [x] I have updated any related tests for code I modified or added new tests where appropriate.
    * Covered by existing end-to-end tests 
* [x] I have updated any relevant documentation or created new documentation where appropriate.
    * None necessary
* [x] Manual testing
    * [x] Successfully run the tool on a 100 card order with a single cardback
    * [x] Successfully run the tool on a 612 card order with multiple cardbacks