### PR TITLE
Validation logic to fail out when p10 and foil are chosen.

### DIFF
--- a/autofill/src/order.py
+++ b/autofill/src/order.py
@@ -223,6 +223,8 @@ class Details:
             raise ValidationException(f"Order bracket {self.bracket} not supported!")
         if self.stock not in [x.value for x in constants.Cardstocks]:
             raise ValidationException(f"Order cardstock {self.stock} not supported!")
+        if self.stock == constants.Cardstocks.P10 and self.foil == True:
+            raise ValidationException(f"Order cardstock {self.stock} is not supported in foil!")
 
     def __attrs_post_init__(self) -> None:
         try:


### PR DESCRIPTION
Added logic in the Details class to check for P10 card stock and foil being chosen. If both are chosen it raises an exception and warn the user. 
This related to #64. 