### PR TITLE
Frontend P10 cardstock foil disabled 

### DIFF
--- a/MPCAutofill/cardpicker/frontend/js/review.js
+++ b/MPCAutofill/cardpicker/frontend/js/review.js
@@ -157,13 +157,11 @@ export function handleP10Foil() {
   const e = document.getElementById("cardstock-dropdown");
   const selectedCardstock = e.options[e.selectedIndex].value;
 
-  const foilCheckBox = document.getElementById("cardstock-foil");
-
   if (selectedCardstock === "(P10) Plastic") {
     $(document.getElementById("cardstock-foil")).bootstrapToggle("off"); // Turns it off
-    $(document.getElementById("cardstock-foil")).bootstrapToggle('disable') // Disables the checkbox when P10 is selected
+    $(document.getElementById("cardstock-foil")).bootstrapToggle("disable"); // Disables the checkbox when P10 is selected
   } else {
-    $(document.getElementById("cardstock-foil")).bootstrapToggle('enable') // Enable the checkbox when P10 is selected
+    $(document.getElementById("cardstock-foil")).bootstrapToggle("enable"); // Enable the checkbox when P10 is selected
   }
 }
 

--- a/MPCAutofill/cardpicker/frontend/js/review.js
+++ b/MPCAutofill/cardpicker/frontend/js/review.js
@@ -151,6 +151,22 @@ export function generate_xml() {
   download("cards.xml", xml);
 }
 
+export function handleP10Foil() {
+  // Cardstock P10 is not available as foil.
+  // Tool tips are unfortunately not supported by bootstrap toggles.
+  const e = document.getElementById("cardstock-dropdown");
+  const selectedCardstock = e.options[e.selectedIndex].value;
+
+  const foilCheckBox = document.getElementById("cardstock-foil");
+
+  if (selectedCardstock === "(P10) Plastic") {
+    $(document.getElementById("cardstock-foil")).bootstrapToggle("off"); // Turns it off
+    $(document.getElementById("cardstock-foil")).bootstrapToggle('disable') // Disables the checkbox when P10 is selected
+  } else {
+    $(document.getElementById("cardstock-foil")).bootstrapToggle('enable') // Enable the checkbox when P10 is selected
+  }
+}
+
 export function download_all() {
   // TODO: can we rewrite this to zip up the requested images?
   // TODO: or download individually without opening one billion windows?

--- a/MPCAutofill/cardpicker/templates/cardpicker/review.html
+++ b/MPCAutofill/cardpicker/templates/cardpicker/review.html
@@ -114,7 +114,7 @@
                        data-size="md">
                 {# dropdown to select cardstock #}
                 <div class="form-group">
-                    <select class="form-select" 
+                    <select class="form-select"
                             id="cardstock-dropdown"
                             onclick="Library.review.handleP10Foil();">
                         <option selected="selected">

--- a/MPCAutofill/cardpicker/templates/cardpicker/review.html
+++ b/MPCAutofill/cardpicker/templates/cardpicker/review.html
@@ -114,7 +114,9 @@
                        data-size="md">
                 {# dropdown to select cardstock #}
                 <div class="form-group">
-                    <select class="form-select" id="cardstock-dropdown">
+                    <select class="form-select" 
+                            id="cardstock-dropdown"
+                            onclick="Library.review.handleP10Foil();">
                         <option selected="selected">
                             (S30) Standard Smooth
                         </option>


### PR DESCRIPTION
Hey this deals with #64 with the aim of disabling foil from being selected when p10 cardstock is selected.
Tried setting up the google drive api key but from the instructions I wasn't 100% sure what key to use. Hopefully it runs with the selected one.