### PR TITLE
Fix overwriting of `.env` file when using `docker compose up`

### DIFF
--- a/MPCAutofill/MPCAutofill/.env.dist
+++ b/MPCAutofill/MPCAutofill/.env.dist
@@ -8,7 +8,7 @@ SECRET_KEY=secret
 GTAG=your_gtag
 
 # Change allowed hosts to * to allow outside access
-ALLOWED_HOSTS=("localhost","127.0.0.1")
+ALLOWED_HOSTS=localhost,127.0.0.1
 PREPEND_WWW=False
 
 # Postgres Database, create username/pass for security

--- a/MPCAutofill/MPCAutofill/.env.dist
+++ b/MPCAutofill/MPCAutofill/.env.dist
@@ -26,7 +26,7 @@ LANG_CODE=en-us
 TIME_ZONE=America/New_York
 
 # Elasticsearch
-ELASTICSEARCH_HOST=localhost
+ELASTICSEARCH_HOST=elasticsearch
 
 # Static directory
 STATIC=static

--- a/MPCAutofill/MPCAutofill/.env.dist
+++ b/MPCAutofill/MPCAutofill/.env.dist
@@ -8,7 +8,7 @@ SECRET_KEY=secret
 GTAG=your_gtag
 
 # Change allowed hosts to * to allow outside access
-ALLOWED_HOSTS=localhost,127.0.0.1
+ALLOWED_HOSTS=("localhost","127.0.0.1")
 PREPEND_WWW=False
 
 # Postgres Database, create username/pass for security

--- a/MPCAutofill/cardpicker/dfc_pairs.py
+++ b/MPCAutofill/cardpicker/dfc_pairs.py
@@ -54,6 +54,11 @@ def sync_dfcs() -> None:
     meld_data = query_scryfall_paginated(MELD_URL)
     print(f"Identified {len(meld_data)} meld pieces")
     for item in meld_data:
+        if "all_parts" not in item:
+            card_name = item["name"]
+            print(f"Skipping {card_name} (missing key 'all_parts')")
+            continue
+
         card_part_singleton_list = list(filter(lambda part: part["name"] == item["name"], item["all_parts"]))
         meld_result_singleton_list = list(filter(lambda part: part["component"] == "meld_result", item["all_parts"]))
 

--- a/docker/django/Dockerfile
+++ b/docker/django/Dockerfile
@@ -60,8 +60,8 @@ RUN adduser -u 5678 --disabled-password --gecos "" mpcautofill && \
     chown -R mpcautofill /MPCAutofill
 USER mpcautofill
 
-# Place environment file
-RUN cp docker/django/env.txt MPCAutofill/MPCAutofill/.env
+# Place environment file if one does not already exist
+RUN ./docker/django/copy_env_file.sh
 
 # Prepare folder for static files (create now as user for permissions)
 RUN mkdir -p static

--- a/docker/django/copy_env_file.sh
+++ b/docker/django/copy_env_file.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+echo "Copy environment (.env) file if one does not already exist"
+echo "=================================================="
+DEFAULTENVFILE=MPCAutofill/MPCAutofill/.env.dist
+ENVFILE=MPCAutofill/MPCAutofill/.env
+if [ ! -f "$ENVFILE" ]; then
+    cp $DEFAULTENVFILE $ENVFILE
+    echo "$ENVFILE copied with the following contents:"
+else
+    echo "$ENVFILE already exists (not copied) with the following contents:"
+fi
+cat $ENVFILE
+echo "=================================================="

--- a/docker/django/env.txt
+++ b/docker/django/env.txt
@@ -1,5 +1,0 @@
-DJANGO_SECRET_KEY=SehrGeheim123
-DJANGO_DEBUG=False
-DATABASE_ENGINE=django.db.backends.postgresql
-DATABASE_NAME=mpcautofill
-ELASTICSEARCH_HOST=elasticsearch


### PR DESCRIPTION
# Description

Current Docker setup copies `docker/django/env.txt` into `MPCAutofill/MPCAutofill/.env` regardless of if a file exists there already. This change makes it so that it checks for non-existence of the destination `.env` file before attempting to copy from what seems like the more robust `MPCAutofill/MPCAutofill/.env.dist` default environment file (instead of `docker/django/env.txt`).

# Checklist

- [x] I have installed `pre-commit` and run the hooks with `pre-commit run`.
- [x] I have updated any related tests for code I modified or added new tests where appropriate.
- [x] I have updated any relevant documentation or created new documentation where appropriate.
