### PR TITLE
Process multiple XML files in batch

### DIFF
--- a/autofill/autofill.py
+++ b/autofill/autofill.py
@@ -1,6 +1,7 @@
 import os
 
 import click
+import textwrap
 
 from src.constants import browsers
 from src.driver import AutofillDriver
@@ -29,6 +30,13 @@ os.system("")  # enables ansi escape characters in terminal
     is_flag=True,
 )
 @click.option(
+    "-a",
+    "--all",
+    default=False,
+    help="Create a saved project for each XML file found in the current folder.",
+    is_flag=True,
+)
+@click.option(
     "-u",
     "--username"
 )
@@ -36,19 +44,18 @@ os.system("")  # enables ansi escape characters in terminal
     "-p",
     "--password"
 )
-@click.option(
-    "-a",
-    "--all",
-    default=False,
-    help="Create a saved project for each XML file found in the current folder.",
-    is_flag=True,
-)
-def main(skipsetup: bool, browser: str, exportpdf: bool, username: str, password: str, all: bool) -> None:
+def main(skipsetup: bool, browser: str, exportpdf: bool, all: bool, username: str, password: str) -> None:
     try:
         if exportpdf:
             PdfExporter().execute()
         else:
-            AutofillDriver(driver_callable=browsers[browser], username=username, password=password, all_files=all).execute(skipsetup)
+            if all is True:
+                print(f"The XML files found in the current folder will be saved as {TEXT_BOLD}Saved Projects{TEXT_END} in your MPC account.")
+                if username is None:
+                    username = click.prompt("Enter your MPC username", type=str)
+                if password is None:
+                    password = click.prompt("Enter your MPC password", hide_input=True, type=str)
+            AutofillDriver(driver_callable=browsers[browser], process_all_files=all, username=username, password=password).execute(skipsetup)
     except Exception as e:
         print(f"An uncaught exception occurred: {TEXT_BOLD}{e}{TEXT_END}")
         input("Press Enter to exit.")

--- a/autofill/autofill.py
+++ b/autofill/autofill.py
@@ -36,12 +36,19 @@ os.system("")  # enables ansi escape characters in terminal
     "-p",
     "--password"
 )
-def main(skipsetup: bool, browser: str, exportpdf: bool, username: str, password: str) -> None:
+@click.option(
+    "-a",
+    "--all",
+    default=False,
+    help="Create a saved project for each XML file found in the current folder.",
+    is_flag=True,
+)
+def main(skipsetup: bool, browser: str, exportpdf: bool, username: str, password: str, all: bool) -> None:
     try:
         if exportpdf:
             PdfExporter().execute()
         else:
-            AutofillDriver(driver_callable=browsers[browser]).execute(skipsetup, username, password)
+            AutofillDriver(driver_callable=browsers[browser], username=username, password=password, all_files=all).execute(skipsetup)
     except Exception as e:
         print(f"An uncaught exception occurred: {TEXT_BOLD}{e}{TEXT_END}")
         input("Press Enter to exit.")

--- a/autofill/autofill.py
+++ b/autofill/autofill.py
@@ -28,12 +28,20 @@ os.system("")  # enables ansi escape characters in terminal
     help="Create a PDF export of the card images and do not create a project for MPC.",
     is_flag=True,
 )
-def main(skipsetup: bool, browser: str, exportpdf: bool) -> None:
+@click.option(
+    "-u",
+    "--username"
+)
+@click.option(
+    "-p",
+    "--password"
+)
+def main(skipsetup: bool, browser: str, exportpdf: bool, username: str, password: str) -> None:
     try:
         if exportpdf:
             PdfExporter().execute()
         else:
-            AutofillDriver(driver_callable=browsers[browser]).execute(skipsetup)
+            AutofillDriver(driver_callable=browsers[browser]).execute(skipsetup, username, password)
     except Exception as e:
         print(f"An uncaught exception occurred: {TEXT_BOLD}{e}{TEXT_END}")
         input("Press Enter to exit.")

--- a/autofill/autofill.py
+++ b/autofill/autofill.py
@@ -1,7 +1,6 @@
 import os
 
 import click
-import textwrap
 
 from src.constants import browsers
 from src.driver import AutofillDriver

--- a/autofill/readme.md
+++ b/autofill/readme.md
@@ -58,6 +58,10 @@ By default, the tool will configure a driver for Google Chrome. The three major 
 
 You can optionally export the downloaded images to a PDF which can be uploaded to a card printing site by using the `--exportpdfs` command line argument. Once the images are downloaded, press enter and you'll be presented with a few questions. If you plan to upload the PDFs to MakePlayingCards, select `yes` when asked about storing the separate faces in their own PDF. If you plan to use DriveThruCards, select `no` for that question, and then set the number of cards to include per exported file. If using DriveThruCards, be aware that they have a file size upload limit of 1gb, so depending on the file size of the selected images, your order may need to be set to a lower number, like 30 or 40 cards.
 
+### Process multiple XML files in batch
+
+You can optionally process multiple XML files generated on https://mpcfill.com in a single script execution. This can be useful if you want to prepare multiple decks, individually wrapped, with different back covers, for example. For this option to work, it is necessary to be authenticated on https://www.makeplayingcards.com to be able to save each deck as Saved Project. This is why the "-a" option will ask for credentials in order to automatically login and save the projects. Once the process is completed, the saved projects can be added in the cart and the order can be completed. You can specify the credentials on the command line with the option "-u" and "-p". If the credentials are not provided, a prompt will request the user to provide them.
+
 ## Developer Guide
 
 ### Running the Source Code

--- a/autofill/src/constants.py
+++ b/autofill/src/constants.py
@@ -81,7 +81,6 @@ class BaseTags(str, Enum):
 
 
 class DetailsTags(str, Enum):
-    name = "name"
     quantity = "quantity"
     bracket = "bracket"
     stock = "stock"

--- a/autofill/src/constants.py
+++ b/autofill/src/constants.py
@@ -81,6 +81,7 @@ class BaseTags(str, Enum):
 
 
 class DetailsTags(str, Enum):
+    name = "name"
     quantity = "quantity"
     bracket = "bracket"
     stock = "stock"

--- a/autofill/src/driver.py
+++ b/autofill/src/driver.py
@@ -42,6 +42,8 @@ class AutofillDriver:
     download_bar: enlighten.Counter = attr.ib(init=False, default=None)
     upload_bar: enlighten.Counter = attr.ib(init=False, default=None)
     file_path_to_pid_map: dict[str, str] = {}
+    username: str = None
+    password: str = None
 
     # region initialisation
     def initialise_driver(self) -> None:
@@ -437,12 +439,45 @@ class AutofillDriver:
         self.next_step()
         self.next_step()
 
+        if self.username is not None:
+
+            print("wait 3 more seconds")
+            time.sleep(3)
+
+            self.execute_javascript(f"document.getElementById('chk_appear').checked=true;")
+            self.execute_javascript("oFavCart.updateToProject();")
+
+            print("wait")
+            self.wait()
+            print("wait 3 more seconds")
+            time.sleep(3)
+            print("enter username")
+            txt_email = self.driver.find_element(By.ID, "txt_email")
+            txt_email.clear()
+            txt_email.send_keys(self.username)
+            print("enter password")
+            txt_password = self.driver.find_element(By.ID, "txt_password")
+            txt_password.clear()
+            txt_password.send_keys(self.password)
+            print("login")
+            
+            self.driver.find_element(By.ID, "btn_submit").click()
+
         self.set_state(States.finished)
 
     # region public
 
-    def execute(self, skip_setup: bool, all: bool) -> None:
+    def execute(self, skip_setup: bool, username: str, password: str) -> None:
         t = time.time()
+        self.username = username
+        self.password = password
+
+        link = self.driver.find_element(By.LINK_TEXT, "Sign in")
+        if link is not None:
+            print("link found")
+        else:
+            print("link NOT found")
+
         with ThreadPoolExecutor(max_workers=THREADS) as pool:
             self.order.fronts.download_images(pool, self.download_bar)
             self.order.backs.download_images(pool, self.download_bar)

--- a/autofill/src/driver.py
+++ b/autofill/src/driver.py
@@ -189,6 +189,10 @@ class AutofillDriver:
         except NoAlertPresentException:
             pass
 
+    def set_project_name(self, name: str) -> None:
+        if name is not None:
+            self.execute_javascript(f"document.getElementById('txt_temporaryname').value='{name}';")
+
     # endregion
 
     # region uploading
@@ -309,7 +313,7 @@ class AutofillDriver:
     # endregion
 
     # region define order
-
+    
     def define_order(self) -> None:
         self.assert_state(States.defining_order)
         # Select card stock
@@ -377,6 +381,9 @@ class AutofillDriver:
 
     def insert_fronts(self) -> None:
         self.assert_state(States.inserting_fronts)
+        
+        self.set_project_name(self.order.details.name)
+
         self.upload_and_insert_images(self.order.fronts)
 
         self.set_state(States.paging_to_backs)
@@ -434,7 +441,7 @@ class AutofillDriver:
 
     # region public
 
-    def execute(self, skip_setup: bool) -> None:
+    def execute(self, skip_setup: bool, all: bool) -> None:
         t = time.time()
         with ThreadPoolExecutor(max_workers=THREADS) as pool:
             self.order.fronts.download_images(pool, self.download_bar)

--- a/autofill/src/driver.py
+++ b/autofill/src/driver.py
@@ -39,7 +39,6 @@ class AutofillDriver:
     starting_url: str = attr.ib(init=False, default="https://www.makeplayingcards.com/design/custom-blank-card.html")
     order: CardOrder = attr.ib(default=None)
     orders: str = attr.ib(default=None)
-    order_index: int = attr.ib(default=0)
     state: str = attr.ib(init=False, default=States.initialising)
     action: Optional[str] = attr.ib(init=False, default=None)
     manager: enlighten.Manager = attr.ib(init=False, default=attr.Factory(enlighten.get_manager))

--- a/autofill/src/order.py
+++ b/autofill/src/order.py
@@ -208,7 +208,6 @@ class CardImageCollection:
 
 @attr.s
 class Details:
-    name: str = attr.ib(default=None)
     quantity: int = attr.ib(default=0)
     bracket: int = attr.ib(default=0)
     stock: str = attr.ib(default=constants.Cardstocks.S30.value)
@@ -242,7 +241,6 @@ class Details:
     @classmethod
     def from_element(cls, element: Element) -> "Details":
         details_dict = unpack_element(element, [x.value for x in constants.DetailsTags])
-        name = details_dict[constants.DetailsTags.name].text
         quantity = 0
         if (quantity_text := details_dict[constants.DetailsTags.quantity].text) is not None:
             quantity = int(quantity_text)
@@ -252,7 +250,7 @@ class Details:
         stock = details_dict[constants.DetailsTags.stock].text or constants.Cardstocks.S30
         foil: bool = details_dict[constants.DetailsTags.foil].text == "true"
 
-        details = cls(name=name, quantity=quantity, bracket=bracket, stock=stock, foil=foil)
+        details = cls(quantity=quantity, bracket=bracket, stock=stock, foil=foil)
         return details
 
     # endregion
@@ -300,8 +298,6 @@ class CardOrder:
     def from_element(cls, element: Element, name: Optional[str] = None) -> "CardOrder":
         root_dict = unpack_element(element, [x.value for x in constants.BaseTags])
         details = Details.from_element(root_dict[constants.BaseTags.details])
-        if details.name is None:
-            details.name = Path(name).stem
         fronts = CardImageCollection.from_element(
             element=root_dict[constants.BaseTags.fronts], num_slots=details.quantity, face=constants.Faces.front
         )

--- a/autofill/src/order.py
+++ b/autofill/src/order.py
@@ -360,4 +360,12 @@ class CardOrder:
             file_name = answers["xml_choice"]
         return cls.from_file_name(file_name)
 
+    @classmethod
+    def get_xml_files_in_folder(cls):
+        xml_glob = list(glob(os.path.join(CURRDIR, "*.xml")))
+        if len(xml_glob) <= 0:
+            input("No XML files found in this directory. Press enter to exit.")
+            sys.exit(0)
+        return xml_glob
+
     # endregion

--- a/autofill/src/order.py
+++ b/autofill/src/order.py
@@ -273,7 +273,7 @@ class CardOrder:
         print(
             f"Your order has a total of {TEXT_BOLD}{self.details.quantity}{TEXT_END} cards, in the MPC bracket of up "
             f"to {TEXT_BOLD}{self.details.bracket}{TEXT_END} cards.\n{TEXT_BOLD}{self.details.stock}{TEXT_END} "
-            f"cardstock ({TEXT_BOLD}{'foil' if self.details.foil else 'nonfoil'}{TEXT_END}).\n "
+            f"cardstock ({TEXT_BOLD}{'foil' if self.details.foil else 'nonfoil'}{TEXT_END}). "
         )
 
     # endregion
@@ -332,7 +332,6 @@ class CardOrder:
         except ParseError:
             input("Your XML file contains a syntax error so it can't be processed. Press Enter to exit.")
             sys.exit(0)
-        print(f"Parsing XML file {TEXT_BOLD}{file_name}{TEXT_END}...")
         order = cls.from_element(xml.getroot(), name=file_name)
         return order
 
@@ -366,6 +365,8 @@ class CardOrder:
         if len(xml_glob) <= 0:
             input("No XML files found in this directory. Press enter to exit.")
             sys.exit(0)
+        else:
+            print(f"{len(xml_glob)} order(s) found in current folder.")
         return xml_glob
 
     # endregion

--- a/autofill/src/order.py
+++ b/autofill/src/order.py
@@ -5,6 +5,7 @@ from glob import glob
 from queue import Queue
 from typing import Optional
 from xml.etree.ElementTree import Element, ParseError
+from pathlib import Path
 
 import attr
 import enlighten
@@ -207,6 +208,7 @@ class CardImageCollection:
 
 @attr.s
 class Details:
+    name: str = attr.ib(default=None)
     quantity: int = attr.ib(default=0)
     bracket: int = attr.ib(default=0)
     stock: str = attr.ib(default=constants.Cardstocks.S30.value)
@@ -240,6 +242,7 @@ class Details:
     @classmethod
     def from_element(cls, element: Element) -> "Details":
         details_dict = unpack_element(element, [x.value for x in constants.DetailsTags])
+        name = details_dict[constants.DetailsTags.name].text
         quantity = 0
         if (quantity_text := details_dict[constants.DetailsTags.quantity].text) is not None:
             quantity = int(quantity_text)
@@ -249,7 +252,7 @@ class Details:
         stock = details_dict[constants.DetailsTags.stock].text or constants.Cardstocks.S30
         foil: bool = details_dict[constants.DetailsTags.foil].text == "true"
 
-        details = cls(quantity=quantity, bracket=bracket, stock=stock, foil=foil)
+        details = cls(name=name, quantity=quantity, bracket=bracket, stock=stock, foil=foil)
         return details
 
     # endregion
@@ -297,6 +300,8 @@ class CardOrder:
     def from_element(cls, element: Element, name: Optional[str] = None) -> "CardOrder":
         root_dict = unpack_element(element, [x.value for x in constants.BaseTags])
         details = Details.from_element(root_dict[constants.BaseTags.details])
+        if details.name is None:
+            details.name = Path(name).stem
         fronts = CardImageCollection.from_element(
             element=root_dict[constants.BaseTags.fronts], num_slots=details.quantity, face=constants.Faces.front
         )


### PR DESCRIPTION
# Description

Three command lines options are added in this PR: `-a`, `-u` and `-p`.
The `-u` and `-p` are used to provide a username and password to the script and are only relevant if the `-a` option is set.
If the `-a` option is set and the credentials are missing, a prompt will ask the user to provide them.

Here is an example of what it looks like at this stage:
![image](https://user-images.githubusercontent.com/15271147/200379514-81c8e4da-72fb-4292-a630-4354fe000200.png)


When the `-a` option is set, the script will scan the folder for all the XML and process each file in a loop. Each order will be saved as a Saved Project on this page : https://www.makeplayingcards.com/design/dn_temporary_designes.aspx. Saved projects can be added in bulk in the cart, so it becomes easy for a user to prepare multiple decks and upload them in a single script execution.

At this stage, I didn't test how the `-a` will behave with the `--skipsetup` option.

## Unit tests

Seven tests are failing in the current state of the `master` branch. My PR do not fix any of those tests. I didn't not added any unit tests yet, but I am willing to provide them after someone do an initial review.

## Pre-commit

I ran the `pre-commit run` command in my own branch and no files seemed to have been checked. Is it normal?!?

Please see the output below:
![image](https://user-images.githubusercontent.com/15271147/200378877-9a842b92-e13a-46fe-a443-d8a6bd352b2d.png)


# Checklist

- [x] I have installed `pre-commit` and run the hooks with `pre-commit run`.
- [ ] I have updated any related tests for code I modified or added new tests where appropriate.
- [x] I have updated any relevant documentation or created new documentation where appropriate.
