### PR TITLE
Bugfix: `generator didn't yield`

### DIFF
--- a/autofill/src/driver.py
+++ b/autofill/src/driver.py
@@ -96,12 +96,14 @@ class AutofillDriver:
         Context manager for switching to `frame`.
         """
 
+        in_frame = True
         try:
             self.driver.switch_to.frame(frame)
         except (sl_exc.NoSuchFrameException, sl_exc.NoSuchElementException):
-            return
+            in_frame = False
         yield
-        self.driver.switch_to.default_content()
+        if in_frame:
+            self.driver.switch_to.default_content()
 
     @alert_handler
     def wait(self) -> None:


### PR DESCRIPTION
# Description

* Fixes issue #123
* I set up a context manager incorrectly such that in some code paths, the generator returned rather than yielding, causing the exception `generator didn't yield`. the fix here is to track whether a frame was moved into in the context manager, then only move out of the frame if it was moved into, but always yielding.
* Honestly surprised that mypy didn't pick this up
* Still unsure why this broke for many people all at once

# Checklist

- [x] I have installed `pre-commit` and run the hooks with `pre-commit run`.
- [x] I have updated any related tests for code I modified or added new tests where appropriate.
    - Cannot reliably recreate the issue
- [x] I have updated any relevant documentation or created new documentation where appropriate.
    - None required