### PR TITLE
Add refresh_patreon command to rotate access token

### DIFF
--- a/MPCAutofill/MPCAutofill/.env.dist
+++ b/MPCAutofill/MPCAutofill/.env.dist
@@ -39,6 +39,9 @@ REDDIT=https://www.reddit.com/r/mpcproxies/
 DISCORD=http://mprox.link/discord
 THEME=superhero
 
-# PATREON - Key from "Creator's Access Token"
-PATREON_KEY=
+# Patreon keys
+PATREON_ACCESS=
+PATREON_REFRESH=
+PATREON_CLIENT=
+PATREON_SECRET=
 PATREON_URL=

--- a/MPCAutofill/MPCAutofill/settings.py
+++ b/MPCAutofill/MPCAutofill/settings.py
@@ -106,7 +106,6 @@ WSGI_APPLICATION = "MPCAutofill.wsgi.application"
 
 # Database
 # https://docs.djangoproject.com/en/3.0/ref/settings/#databases
-
 DATABASES = {
     "default": {
         "ENGINE": env("DATABASE_ENGINE", default="django.db.backends.sqlite3"),
@@ -186,5 +185,8 @@ DEFAULT_CARDBACK_FOLDER_PATH = env("DEFAULT_CARDBACK_FOLDER_PATH", default="Chil
 DEFAULT_CARDBACK_IMAGE_NAME = env("DEFAULT_CARDBACK_IMAGE_NAME", default="Black Lotus")
 
 # PATREON
+PATREON_ACCESS = env("PATREON_ACCESS", default="")
+PATREON_REFRESH = env("PATREON_REFRESH", default="")
+PATREON_CLIENT = env("PATREON_CLIENT", default="")
+PATREON_SECRET = env("PATREON_SECRET", default="")
 PATREON_URL = env("PATREON_URL", default="")
-PATREON_KEY = env("PATREON_KEY", default="")

--- a/MPCAutofill/cardpicker/management/commands/refresh_patreon.py
+++ b/MPCAutofill/cardpicker/management/commands/refresh_patreon.py
@@ -1,0 +1,56 @@
+import os.path
+import platform
+from typing import Any
+
+import dotenv
+import requests
+
+from django.core.management.base import BaseCommand
+
+from MPCAutofill.settings import (
+    BASE_DIR,
+    PATREON_CLIENT,
+    PATREON_REFRESH,
+    PATREON_SECRET,
+)
+
+patreon_header = {
+    "User-Agent": f"Patreon-Python, version 0.5.1, platform {platform.platform()}",
+}
+
+
+class Command(BaseCommand):
+    help = "Refreshes the Patreon access token"
+
+    def handle(self, *args: Any, **kwargs: dict[str, Any]) -> None:
+        # TODO: Potentially more secure to store these keys in database?
+        # Make a request to refresh the Patreon access token
+        res = requests.post(
+            # https://docs.patreon.com/#step-7-keeping-up-to-date
+            url="https://www.patreon.com/api/oauth2/token",
+            params={
+                "grant_type": "refresh_token",
+                "refresh_token": PATREON_REFRESH,
+                "client_id": PATREON_CLIENT,
+                "client_secret": PATREON_SECRET,
+            },
+            headers=patreon_header,
+        ).json()
+
+        # Were the tokens received?
+        if "access_token" not in res or "refresh_token" not in res:
+            print(f"Response: {res}")
+            raise KeyError("Patreon response missing access_token or key_token!")
+
+        # Set access token
+        dotenv.set_key(
+            os.path.join(BASE_DIR, "MPCAutofill/.env"), "PATREON_ACCESS", res["access_token"], quote_mode="never"
+        )
+
+        # Set refresh token
+        dotenv.set_key(
+            os.path.join(BASE_DIR, "MPCAutofill/.env"), "PATREON_REFRESH", res["refresh_token"], quote_mode="never"
+        )
+
+        # Notify user
+        print("Patreon Access and Refresh tokens updated successfully!")

--- a/MPCAutofill/cardpicker/utils/patreon.py
+++ b/MPCAutofill/cardpicker/utils/patreon.py
@@ -4,11 +4,11 @@ from typing import TypedDict, Union
 
 import requests
 
-from MPCAutofill.settings import PATREON_KEY
+from MPCAutofill.settings import PATREON_ACCESS
 
 # Header must be included to access Patreon info
 patreon_header = {
-    "Authorization": f"Bearer {PATREON_KEY}",
+    "Authorization": f"Bearer {PATREON_ACCESS}",
     "User-Agent": f"Patreon-Python, version 0.5.1, platform {platform.platform()}",
 }
 

--- a/MPCAutofill/requirements.txt
+++ b/MPCAutofill/requirements.txt
@@ -2,6 +2,7 @@ attrs
 chardet
 click==8.0.4
 defusedxml
+python-dotenv
 Django~=4.0
 django-crispy-forms~=1.14
 django-elasticsearch-dsl~=7.2

--- a/refresh_patreon
+++ b/refresh_patreon
@@ -1,0 +1,4 @@
+# helper script to refresh patreon tokens
+
+cd ~/mpc-autofill/MPCAutofill
+~/mpc-autofill/MPCAutofill/env/bin/python ~/mpc-autofill/MPCAutofill/manage.py refresh_patreon


### PR DESCRIPTION
# Description

- Command refreshes the access and refresh tokens, then updates the .env accordingly
- Added script for use with crontab
- Updated .env to hold all relevant Patreon keys

# Checklist

- [x] I have installed `pre-commit` and run the hooks with `pre-commit run`.
- [x] I have updated any related tests for code I modified or added new tests where appropriate.
- [x] I have updated any relevant documentation or created new documentation where appropriate.
