### PR TITLE
Wakelock feature addition

### DIFF
--- a/autofill/autofill.py
+++ b/autofill/autofill.py
@@ -1,6 +1,7 @@
 import os
 
 import click
+from wakepy import set_keepawake, unset_keepawake
 
 from src.constants import browsers
 from src.driver import AutofillDriver
@@ -28,12 +29,22 @@ os.system("")  # enables ansi escape characters in terminal
     help="Create a PDF export of the card images and do not create a project for MPC.",
     is_flag=True,
 )
-def main(skipsetup: bool, browser: str, exportpdf: bool) -> None:
+@click.option(
+    "--preventsleep",
+    default=False,
+    help="Prevents the system from falling asleep during execution",
+    is_flag=True,
+)
+def main(skipsetup: bool, browser: str, exportpdf: bool, preventsleep: bool) -> None:
     try:
+        if preventsleep:
+            set_keepawake(keep_screen_awake=True)
         if exportpdf:
             PdfExporter().execute()
         else:
             AutofillDriver(driver_callable=browsers[browser]).execute(skipsetup)
+        if preventsleep:
+            unset_keepawake()
     except Exception as e:
         print(f"An uncaught exception occurred: {TEXT_BOLD}{e}{TEXT_END}")
         input("Press Enter to exit.")

--- a/autofill/autofill.py
+++ b/autofill/autofill.py
@@ -1,7 +1,8 @@
 import os
+from contextlib import nullcontext
 
 import click
-from wakepy import set_keepawake, unset_keepawake
+from wakepy import keepawake
 
 from src.constants import browsers
 from src.driver import AutofillDriver
@@ -30,22 +31,20 @@ os.system("")  # enables ansi escape characters in terminal
     is_flag=True,
 )
 @click.option(
-    "--preventsleep",
+    "--allowsleep",
     default=False,
-    help="Prevents the system from falling asleep during execution",
+    help="Allows the system to fall alseep during execution",
     is_flag=True,
 )
-def main(skipsetup: bool, browser: str, exportpdf: bool, preventsleep: bool) -> None:
+def main(skipsetup: bool, browser: str, exportpdf: bool, allowsleep: bool) -> None:
     try:
-        if preventsleep:
-            print("System sleep is being prevented during this execution")
-            set_keepawake(keep_screen_awake=True)
-        if exportpdf:
-            PdfExporter().execute()
-        else:
-            AutofillDriver(driver_callable=browsers[browser]).execute(skipsetup)
-        if preventsleep:
-            unset_keepawake()
+        with keepawake(keep_screen_awake=True) if not allowsleep else nullcontext():
+            if not allowsleep:
+                print("System sleep is being prevented during this execution")
+            if exportpdf:
+                PdfExporter().execute()
+            else:
+                AutofillDriver(driver_callable=browsers[browser]).execute(skipsetup)
     except Exception as e:
         print(f"An uncaught exception occurred: {TEXT_BOLD}{e}{TEXT_END}")
         input("Press Enter to exit.")

--- a/autofill/autofill.py
+++ b/autofill/autofill.py
@@ -38,6 +38,7 @@ os.system("")  # enables ansi escape characters in terminal
 def main(skipsetup: bool, browser: str, exportpdf: bool, preventsleep: bool) -> None:
     try:
         if preventsleep:
+            print("System sleep is being prevented during this execution")
             set_keepawake(keep_screen_awake=True)
         if exportpdf:
             PdfExporter().execute()

--- a/autofill/readme.md
+++ b/autofill/readme.md
@@ -58,6 +58,10 @@ By default, the tool will configure a driver for Google Chrome. The three major 
 
 You can optionally export the downloaded images to a PDF which can be uploaded to a card printing site by using the `--exportpdfs` command line argument. Once the images are downloaded, press enter and you'll be presented with a few questions. If you plan to upload the PDFs to MakePlayingCards, select `yes` when asked about storing the separate faces in their own PDF. If you plan to use DriveThruCards, select `no` for that question, and then set the number of cards to include per exported file. If using DriveThruCards, be aware that they have a file size upload limit of 1gb, so depending on the file size of the selected images, your order may need to be set to a lower number, like 30 or 40 cards.
 
+### Preventing Sleep
+
+By default the system can fall asleep during execution. System sleep during execution can be prevented by with the `--preventsleep` command line argument.
+
 ## Developer Guide
 
 ### Running the Source Code

--- a/autofill/readme.md
+++ b/autofill/readme.md
@@ -60,7 +60,7 @@ You can optionally export the downloaded images to a PDF which can be uploaded t
 
 ### Preventing Sleep
 
-By default the system can fall asleep during execution. System sleep during execution can be prevented by with the `--preventsleep` command line argument. This might require sudo/admin permissions on linux.
+By default the system is prevented from falling asleep during execution. This might require sudo/admin permissions on linux. System sleep during execution can be allowed with the `--allowsleep` command line argument.
 
 ## Developer Guide
 

--- a/autofill/readme.md
+++ b/autofill/readme.md
@@ -60,7 +60,7 @@ You can optionally export the downloaded images to a PDF which can be uploaded t
 
 ### Preventing Sleep
 
-By default the system can fall asleep during execution. System sleep during execution can be prevented by with the `--preventsleep` command line argument.
+By default the system can fall asleep during execution. System sleep during execution can be prevented by with the `--preventsleep` command line argument. This might require sudo/admin permissions on linux.
 
 ## Developer Guide
 

--- a/autofill/requirements.txt
+++ b/autofill/requirements.txt
@@ -15,3 +15,4 @@ requests
 sanitize-filename
 selenium~=4.8
 webdriver-manager==3.5.4
+wakepy==0.6.0


### PR DESCRIPTION
# Description

Implements the wakelock feature request through the use of wakepy. Utilized through the use of the --preventsleep command line argument.

Some Notes
1) Could only manually test for windows, worked as expected.
2) Might need admin privilege on linux according to the wakepy readme
3) Added the functionality to main, could be lower but would have to be duplicated.  
4) the unset_keepawake() seems to be unnecessary as normal sleep behavior resumes as soon as the execution end even if exiting mid execution, this is only known for windows though and so I put the function in.
5) I did not create any new tests/modify existing ones. Existing tests passed on one commit then stated failing on the next even though only documentation changed, all stating KeyError: 'card_faces' as the reason.
 
# Checklist

- [x] I have installed `pre-commit` and run the hooks with `pre-commit run`.
- [ ] I have updated any related tests for code I modified or added new tests where appropriate.
- [x] I have updated any relevant documentation or created new documentation where appropriate.
