### PR TITLE
Use localStorage rather than cookies to store search settings

### DIFF
--- a/MPCAutofill/cardpicker/frontend/js/index.js
+++ b/MPCAutofill/cardpicker/frontend/js/index.js
@@ -1,4 +1,3 @@
-import Cookies from "js-cookie";
 import { base_on_load, handle_error } from "./base.js";
 import "bootstrap5-toggle/css/bootstrap5-toggle.min.css";
 import "bootstrap5-toggle";
@@ -20,8 +19,8 @@ function load_search_settings() {
     $("#" + all_drive_elems[i].id).bootstrapToggle();
   }
 
-  let settings = Cookies.get("search_settings");
-  if (settings !== undefined) {
+  let settings = window.localStorage.getItem("search_settings");
+  if (settings != null) {
     settings = JSON.parse(settings);
 
     const drives = settings.drives;
@@ -80,7 +79,7 @@ function save_search_settings() {
     settings.drives.push([drive_elements[i].id, drive_enabled]);
   }
 
-  Cookies.set("search_settings", JSON.stringify(settings), { expires: 365 });
+  window.localStorage.setItem("search_settings", JSON.stringify(settings));
 }
 
 export function toggle_checkboxes() {

--- a/MPCAutofill/cardpicker/templates/cardpicker/legal.html
+++ b/MPCAutofill/cardpicker/templates/cardpicker/legal.html
@@ -35,15 +35,16 @@
         <a href="https://scryfall.com/">Scryfall</a>, or Wizards of the Coast.
     </p>
     <h2>Privacy Policy</h2>
-    <b>Last updated: 21st June, 2021</b>
+    <b>Last updated: 11th April, 2023</b>
     <p>
         {{ SITE_NAME }} collects site usage data through Google Analytics via cookies. Understanding how users interact
         with the site allows me to continue to improve the site to the best of my ability. Users are presented with the
         option to opt-out of having their data collected by Google Analytics.
     </p>
     <p>
-        We also use cookies to remember your search settings &#8212 which drives you have enabled or disabled, their
-        ordering, and the search mode you selected (precise or fuzzy) &#8212 which is considered core site functionality.
+        We use local storage to remember your search settings &#8212 which drives you have enabled or disabled, their
+        ordering, and the search mode you selected (precise or fuzzy) &#8212 which is considered core site functionality
+        and cannot be disabled.
     </p>
     <p>{{ SITE_NAME }} will never share information collected by Google Analytics with third parties.</p>
     <p>


### PR DESCRIPTION
# Description
* The server doesn't need to read this cookie so there's no reason not to use localStorage instead.
* This prevents issues arising from the 4 kB cookie size limit when you have lots of sources.

# Checklist

- [x] I have installed `pre-commit` and run the hooks with `pre-commit run`.
- [x] I have updated any related tests for code I modified or added new tests where appropriate.
- [x] I have updated any relevant documentation or created new documentation where appropriate.
