### PR TITLE
User prompted when no arguments provided

### DIFF
--- a/desktop-tool/autofill.py
+++ b/desktop-tool/autofill.py
@@ -1,4 +1,5 @@
 import os
+import sys
 from contextlib import nullcontext
 
 import click
@@ -15,11 +16,16 @@ os.system("")  # enables ansi escape characters in terminal
 
 @click.command()
 @click.option(
-    "--skipsetup", default=False, help="Skip project setup to continue editing an existing MPC project.", is_flag=True
+    "--skipsetup",
+    prompt="Skip project setup to continue editing an existing MPC project?" if len(sys.argv) == 1 else False,
+    default=False,
+    help="Skip project setup to continue editing an existing MPC project.",
+    is_flag=True,
 )
 @click.option(
     "-b",
     "--browser",
+    prompt="Web browser to automate." if len(sys.argv) == 1 else False,
     default="chrome",
     type=click.Choice(sorted(browsers.keys()), case_sensitive=False),
     help="Web browser to automate.",

--- a/desktop-tool/readme.md
+++ b/desktop-tool/readme.md
@@ -42,7 +42,7 @@ Once the autofilling process completes, you can either complete and pay for your
 
 ### Editing Existing Projects
 
-By default, the tool will create the order as a new MPC project. The tool also supports continuing with saved MPC projects - run the program with the command line argument `--skipsetup` to use this functionality. You will be prompted to log into MPC, navigate to a saved project, and continue editing it before the program will continue.
+By default, the tool will create the order as a new MPC project. The tool also supports continuing with saved MPC projects - run the program with the command line argument `--skipsetup` to use this functionality or 'y' when prompted. You will be prompted to log into MPC, navigate to a saved project, and continue editing it before the program will continue.
 
 Some notes on how editing an existing project with `--skipsetup` works:
 
@@ -52,7 +52,7 @@ Some notes on how editing an existing project with `--skipsetup` works:
 
 ### Specifying a Browser
 
-By default, the tool will configure a driver for Google Chrome. The three major Chromium-based browsers are supported (Chrome, Edge, and Brave), and you can specify which browser should be used to configure the driver with the `--browser` command line argument.
+By default, the tool will configure a driver for Google Chrome. The three major Chromium-based browsers are supported (Chrome, Edge, and Brave), and you can specify which browser should be used to configure the driver with the `--browser` command line argument or you can enter the browser to use when prompted.
 
 ### Exporting to PDF
 


### PR DESCRIPTION
# Description
Issue #109 Configure desktop client CLI to prompt user for options
When no additional cli arguments are provided will prompt the user if they want to continue an existing project and what browser to use.

# Checklist

- [x] I have installed `pre-commit` and run the hooks with `pre-commit run`.
- [ ] I have updated any related tests for code I modified or added new tests where appropriate.
- [x] I have updated any relevant documentation or created new documentation where appropriate.

# Notes 

Tried to find a way to only have the prompt happen when running via double click. Couldn't find a method that worked reliably.
Used the amount of command line arguments instead to determine when to prompt, as a result can prompt when running via command line. 
Defaults are kept allowing users to just 'enter' through to keep default behavior with no typing.
Only prompts for skip setup and browser, can easily make others into prompts if needed.
Can only ensure desired behavior for windows need another to ensure desired behavior on other OSs
 