### PR TITLE
Implement CSV importer in new frontend

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,6 +16,7 @@
         "bootswatch": "^5.2.3",
         "file-saver": "^2.0.5",
         "js-cookie": "^3.0.1",
+        "lil-csv": "^1.4.5",
         "next": "^13.3.0",
         "nextjs-google-analytics": "^2.3.3",
         "ping.js": "^0.3.0",
@@ -7087,6 +7088,11 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/lil-csv": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/lil-csv/-/lil-csv-1.4.5.tgz",
+      "integrity": "sha512-4/vdLe2d2WcRzSxTjDGTdbXtVEhz29IQ9gWadS6QRRpKVdiSlP7aZBteyNP+jzyaco8KaEHthliVY2zhtigULg=="
     },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
@@ -15757,6 +15763,11 @@
         "prelude-ls": "^1.2.1",
         "type-check": "~0.4.0"
       }
+    },
+    "lil-csv": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/lil-csv/-/lil-csv-1.4.5.tgz",
+      "integrity": "sha512-4/vdLe2d2WcRzSxTjDGTdbXtVEhz29IQ9gWadS6QRRpKVdiSlP7aZBteyNP+jzyaco8KaEHthliVY2zhtigULg=="
     },
     "lines-and-columns": {
       "version": "1.2.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,6 +19,7 @@
     "bootswatch": "^5.2.3",
     "file-saver": "^2.0.5",
     "js-cookie": "^3.0.1",
+    "lil-csv": "^1.4.5",
     "next": "^13.3.0",
     "nextjs-google-analytics": "^2.3.3",
     "ping.js": "^0.3.0",

--- a/frontend/src/common/constants.ts
+++ b/frontend/src/common/constants.ts
@@ -6,6 +6,7 @@ export const Card: CardType = "CARD";
 export const Cardback: CardType = "CARDBACK";
 export const Token: CardType = "TOKEN";
 
+export const SelectedImageSeparator = "@";
 export const CardTypeSeparator = ":";
 
 export const CardTypePrefixes: { [prefix: string]: CardType } = {

--- a/frontend/src/common/processing.test.ts
+++ b/frontend/src/common/processing.test.ts
@@ -70,7 +70,7 @@ test("empty prefix is processed correctly", () => {
 test("line that doesn't specify quantity is processed correctly", () => {
   expect(processLine("opt", dfcPairs)).toStrictEqual([
     1,
-    { card_type: Card, query: "opt" },
+    { query: { card_type: Card, query: "opt" }, selectedImage: undefined },
     null,
   ]);
 });
@@ -78,7 +78,10 @@ test("line that doesn't specify quantity is processed correctly", () => {
 test("non-dfc line is processed correctly", () => {
   expect(processLine("3x Lightning Bolt", dfcPairs)).toStrictEqual([
     3,
-    { card_type: Card, query: "lightning bolt" },
+    {
+      query: { card_type: Card, query: "lightning bolt" },
+      selectedImage: undefined,
+    },
     null,
   ]);
 });
@@ -86,7 +89,10 @@ test("non-dfc line is processed correctly", () => {
 test("non-dfc cardback line is processed correctly", () => {
   expect(processLine("3x b:Black Lotus", dfcPairs)).toStrictEqual([
     3,
-    { card_type: Cardback, query: "black lotus" },
+    {
+      query: { card_type: Cardback, query: "black lotus" },
+      selectedImage: undefined,
+    },
     null,
   ]);
 });
@@ -94,16 +100,22 @@ test("non-dfc cardback line is processed correctly", () => {
 test("manually specified front and back line is processed correctly", () => {
   expect(processLine("5 Opt | Char", dfcPairs)).toStrictEqual([
     5,
-    { card_type: Card, query: "opt" },
-    { card_type: Card, query: "char" },
+    { query: { card_type: Card, query: "opt" }, selectedImage: undefined },
+    { query: { card_type: Card, query: "char" }, selectedImage: undefined },
   ]);
 });
 
 test("line that matches to dfc pair is processed correctly", () => {
   expect(processLine("2 Huntmaster of the Fells", dfcPairs)).toStrictEqual([
     2,
-    { card_type: Card, query: "huntmaster of the fells" },
-    { card_type: Card, query: "ravager of the fells" },
+    {
+      query: { card_type: Card, query: "huntmaster of the fells" },
+      selectedImage: undefined,
+    },
+    {
+      query: { card_type: Card, query: "ravager of the fells" },
+      selectedImage: undefined,
+    },
   ]);
 });
 
@@ -112,8 +124,11 @@ test("line that matches to dfc pair but a back is also manually specified is pro
     processLine("2 Huntmaster of the Fells | t:Goblin", dfcPairs)
   ).toStrictEqual([
     2,
-    { card_type: Card, query: "huntmaster of the fells" },
-    { card_type: Token, query: "goblin" },
+    {
+      query: { card_type: Card, query: "huntmaster of the fells" },
+      selectedImage: undefined,
+    },
+    { query: { card_type: Token, query: "goblin" }, selectedImage: undefined },
   ]);
 });
 
@@ -125,17 +140,30 @@ test("a card name that's a subset of a DFC pair's front is not matched", () => {
   ).toStrictEqual([
     [
       1,
-      { card_type: Card, query: "elesh norn" },
-      { card_type: Card, query: "the argent etchings" },
+      {
+        query: { card_type: Card, query: "elesh norn" },
+        selectedImage: undefined,
+      },
+      {
+        query: { card_type: Card, query: "the argent etchings" },
+        selectedImage: undefined,
+      },
     ],
-    [1, { card_type: Card, query: "elesh norn grand cenobite" }, null],
+    [
+      1,
+      {
+        query: { card_type: Card, query: "elesh norn grand cenobite" },
+        selectedImage: undefined,
+      },
+      null,
+    ],
   ]);
 });
 
 test("line that requests 0 of a card is processed correctly", () => {
   expect(processLine("0 opt", dfcPairs)).toStrictEqual([
     0,
-    { card_type: Card, query: "opt" },
+    { query: { card_type: Card, query: "opt" }, selectedImage: undefined },
     null,
   ]);
 });
@@ -143,7 +171,7 @@ test("line that requests 0 of a card is processed correctly", () => {
 test("line that requests -1 of a card is processed correctly", () => {
   expect(processLine("-1 opt", dfcPairs)).toStrictEqual([
     1,
-    { card_type: Card, query: "-1 opt" },
+    { query: { card_type: Card, query: "-1 opt" }, selectedImage: undefined },
     null,
   ]);
 });
@@ -152,11 +180,21 @@ test("multiple lines processed correctly", () => {
   expect(
     processLines("char\n0 lightning bolt\n2x delver of secrets", dfcPairs)
   ).toStrictEqual([
-    [1, { card_type: Card, query: "char" }, null],
+    [
+      1,
+      { query: { card_type: Card, query: "char" }, selectedImage: undefined },
+      null,
+    ],
     [
       2,
-      { card_type: Card, query: "delver of secrets" },
-      { card_type: Card, query: "insectile aberration" },
+      {
+        query: { card_type: Card, query: "delver of secrets" },
+        selectedImage: undefined,
+      },
+      {
+        query: { card_type: Card, query: "insectile aberration" },
+        selectedImage: undefined,
+      },
     ],
   ]);
 });

--- a/frontend/src/common/processing.test.ts
+++ b/frontend/src/common/processing.test.ts
@@ -3,9 +3,9 @@ import each from "jest-each";
 import { Card, Cardback, Token } from "@/common/constants";
 import {
   processLine,
-  processLines,
   processPrefix,
   processQuery,
+  processStringAsMultipleLines,
   sanitiseWhitespace,
   standardiseURL,
   stripTextInParentheses,
@@ -134,7 +134,7 @@ test("line that matches to dfc pair but a back is also manually specified is pro
 
 test("a card name that's a subset of a DFC pair's front is not matched", () => {
   expect(
-    processLines("1 elesh norn\n1 elesh norn, grand cenobite", {
+    processStringAsMultipleLines("1 elesh norn\n1 elesh norn, grand cenobite", {
       "elesh norn": "the argent etchings",
     })
   ).toStrictEqual([
@@ -178,7 +178,10 @@ test("line that requests -1 of a card is processed correctly", () => {
 
 test("multiple lines processed correctly", () => {
   expect(
-    processLines("char\n0 lightning bolt\n2x delver of secrets", dfcPairs)
+    processStringAsMultipleLines(
+      "char\n0 lightning bolt\n2x delver of secrets",
+      dfcPairs
+    )
   ).toStrictEqual([
     [
       1,

--- a/frontend/src/common/processing.test.ts
+++ b/frontend/src/common/processing.test.ts
@@ -199,6 +199,22 @@ test("multiple lines processed correctly", () => {
   ]);
 });
 
+test("a line specifying the selected image ID for the front is processed correctly", () => {
+  expect(processLine("opt@xyz", dfcPairs)).toStrictEqual([
+    1,
+    { query: { card_type: Card, query: "opt" }, selectedImage: "xyz" },
+    null,
+  ]);
+});
+
+test("a line specifying the selected image ID for both faces is processed correctly", () => {
+  expect(processLine("2 opt@xyz | char@abcd", dfcPairs)).toStrictEqual([
+    2,
+    { query: { card_type: Card, query: "opt" }, selectedImage: "xyz" },
+    { query: { card_type: Card, query: "char" }, selectedImage: "abcd" },
+  ]);
+});
+
 describe("URLs are sanitised correctly", () => {
   each([
     "http://127.0.0.1:8000",

--- a/frontend/src/common/processing.ts
+++ b/frontend/src/common/processing.ts
@@ -161,7 +161,7 @@ export function processLine(line: string, dfcPairs: DFCPairs): ProcessedLine {
 }
 
 export function processLines(
-  lines: string,
+  lines: Array<string>,
   dfcPairs: DFCPairs
 ): Array<ProcessedLine> {
   /**
@@ -170,7 +170,7 @@ export function processLines(
 
   const queries: Array<[number, ProjectMember | null, ProjectMember | null]> =
     [];
-  lines.split(/\r?\n|\r|\n/g).forEach((line: string) => {
+  lines.forEach((line: string) => {
     if (line != null && line.trim().length > 0) {
       const [quantity, frontMember, backMember] = processLine(line, dfcPairs);
       if (quantity > 0 && (frontMember != null || backMember != null)) {
@@ -179,6 +179,13 @@ export function processLines(
     }
   });
   return queries;
+}
+
+export function processStringAsMultipleLines(
+  lines: string,
+  dfcPairs: DFCPairs
+): Array<ProcessedLine> {
+  return processLines(lines.split(/\r?\n|\r|\n/g), dfcPairs);
 }
 
 export function standardiseURL(url: string): string {

--- a/frontend/src/common/processing.ts
+++ b/frontend/src/common/processing.ts
@@ -8,7 +8,12 @@ import {
   CardTypeSeparator,
   FaceSeparator,
 } from "@/common/constants";
-import { DFCPairs, ProcessedLine, SearchQuery } from "@/common/types";
+import {
+  DFCPairs,
+  ProcessedLine,
+  ProjectMember,
+  SearchQuery,
+} from "@/common/types";
 
 export function sanitiseWhitespace(text: string): string {
   /**
@@ -102,7 +107,11 @@ export function processLine(line: string, dfcPairs: DFCPairs): ProcessedLine {
     // TODO: is it problematic to assume that all DFC pairs are the `Card` type?
     backQuery = { query: dfcPairs[frontQuery.query], card_type: Card };
   }
-  return [quantity, frontQuery, backQuery];
+  return [
+    quantity,
+    frontQuery != null ? { query: frontQuery, selectedImage: undefined } : null,
+    backQuery != null ? { query: backQuery, selectedImage: undefined } : null,
+  ];
 }
 
 export function processLines(
@@ -113,18 +122,13 @@ export function processLines(
    * Process each line in `lines`, ignoring any lines which don't contain relevant information.
    */
 
-  const queries: Array<[number, SearchQuery | null, SearchQuery | null]> = [];
+  const queries: Array<[number, ProjectMember | null, ProjectMember | null]> =
+    [];
   lines.split(/\r?\n|\r|\n/g).forEach((line: string) => {
     if (line != null && line.trim().length > 0) {
-      const [quantity, frontSearchQuery, backSearchQuery] = processLine(
-        line,
-        dfcPairs
-      );
-      if (
-        quantity > 0 &&
-        (frontSearchQuery != null || backSearchQuery != null)
-      ) {
-        queries.push([quantity, frontSearchQuery, backSearchQuery]);
+      const [quantity, frontMember, backMember] = processLine(line, dfcPairs);
+      if (quantity > 0 && (frontMember != null || backMember != null)) {
+        queries.push([quantity, frontMember, backMember]);
       }
     }
   });

--- a/frontend/src/common/processing.ts
+++ b/frontend/src/common/processing.ts
@@ -7,6 +7,7 @@ import {
   CardTypePrefixes,
   CardTypeSeparator,
   FaceSeparator,
+  SelectedImageSeparator,
 } from "@/common/constants";
 import {
   DFCPairs,
@@ -54,7 +55,8 @@ export function processQuery(query: string): string {
 
 export function processPrefix(query: string): SearchQuery {
   /**
-   * Identify the prefix of a query. For example, `query`="t:goblin" would yield ["goblin", TOKEN].
+   * Identify the prefix of a query. For example, `query`="t:goblin" would yield
+   *   {query: "goblin", card_type: TOKEN}.
    */
 
   for (const [prefix, cardType] of Object.entries(CardTypePrefixes)) {
@@ -74,43 +76,87 @@ export function processPrefix(query: string): SearchQuery {
   return { query: processQuery(query), card_type: CardTypePrefixes[""] };
 }
 
-export function processLine(line: string, dfcPairs: DFCPairs): ProcessedLine {
+function unpackLine(
+  line: string
+): [number, [string, string | null] | null, [string, string | null] | null] {
   /**
-   * Process `line` to identify the search query and the number of instances requested for each face.
-   * If no back query is specified, attempt to match the front query to a DFC pair.
-   * For example, `line`="3x t:goblin" would yield [["goblin", TOKEN, 3], null].
-   * Another example is `line`="3x forest | b:elf" would yield [3, ["forest", CARD], ["elf", TOKEN]].
+   * Unpack `line` into its constituents.
+   *
+   * Inputs to this function are unpacked according to the below schema. For example, consider `4x opt@1234 | char@xyz`:
+   *      4x                opt        @        1234         |      char       @        xyz
+   * └─ quantity ──┘ └─ front query ──┘ └─ front image ID ──┘ └─ back query ──┘ └─ back image ID ──┘
+   *
+   * If quantity is not specified, we assume a quantity of 1.
+   * Specifying a back query is optional.
+   * Specifying an image ID (for each face) is optional.
+   *
+   * (sorry for jamming this much stuff into one regex 🗿)
    */
 
   const trimmedLine = line.replace(/\s+/g, " ").trim();
-  const re = /^([0-9]*)?[xX]?\s?(.*)$/; // note that "x" after the quantity is ignored - e.g. 3x and 3 are treated the same
+  const re = new RegExp(
+    `^(?:([0-9]*)?[xX]?\\s?(.*?)(?:${SelectedImageSeparator}([A-z0-9_\\-]*))?)?(?:(?:\\s*)${
+      "\\" + FaceSeparator
+    }(?:\\s*)(.+?)(?:${SelectedImageSeparator}([A-z0-9_\\-]*))?)?$`,
+    "gm"
+  );
   const results = re.exec(trimmedLine);
   if (results == null) {
     return [0, null, null];
   }
-  const quantity = parseInt(results[1] ?? "1");
+  return [
+    parseInt(results[1] ?? "1"),
+    [results[2], results[3]],
+    [results[4], results[5]],
+  ];
+}
+
+export function processLine(line: string, dfcPairs: DFCPairs): ProcessedLine {
+  /**
+   * Process `line` to identify the search query and the number of instances requested for each face.
+   * If no back query is specified, attempt to match the front query to a DFC pair.
+   * For example, `line`="3x t:goblin" would yield:
+   *   [3, {query: {query: "goblin", card_type: TOKEN, selectedImage: null}}, null].
+   * Another example is `line`="3x forest | b:elf" would yield:
+   *   [
+   *     3,
+   *     {query: {query: "forest", card_type: CARD}, selectedImage: null},
+   *     {query: {query: "elf", card_type: TOKEN}, selectedImage: null},
+   *   ].
+   */
+
+  const [quantity, frontRawQuery, backRawQuery] = unpackLine(line);
 
   let frontQuery: SearchQuery | null = null;
-  let backQuery: SearchQuery | null = null;
-  const [frontRawQuery, backRawQuery] = results[2].split(FaceSeparator);
-  if (frontRawQuery != null && frontRawQuery.length > 0) {
-    frontQuery = processPrefix(frontRawQuery);
+  let frontSelectedImage: string | undefined = undefined;
+  if (frontRawQuery != null && (frontRawQuery[0] ?? "").length > 0) {
+    frontQuery = processPrefix(frontRawQuery[0]);
+    frontSelectedImage = frontRawQuery[1] ?? undefined;
   }
-  if (backRawQuery != null && backRawQuery.length > 0) {
-    backQuery = processPrefix(backRawQuery);
+
+  let backQuery: SearchQuery | null = null;
+  let backSelectedImage: string | undefined = undefined;
+  if (backRawQuery != null && (backRawQuery[0] ?? "").length > 0) {
+    backQuery = processPrefix(backRawQuery[0]);
+    backSelectedImage = backRawQuery[1] ?? undefined;
   } else if (
     frontQuery != null &&
-    frontQuery.query != null &&
+    frontQuery?.query != null &&
     frontQuery.query in dfcPairs
   ) {
     // attempt to match to DFC pair
     // TODO: is it problematic to assume that all DFC pairs are the `Card` type?
     backQuery = { query: dfcPairs[frontQuery.query], card_type: Card };
   }
+
   return [
     quantity,
-    frontQuery != null ? { query: frontQuery, selectedImage: undefined } : null,
-    backQuery != null ? { query: backQuery, selectedImage: undefined } : null,
+    frontQuery != null
+      ? { query: frontQuery, selectedImage: frontSelectedImage }
+      : null,
+    backQuery != null
+      ? { query: backQuery, selectedImage: backSelectedImage }
+      : null,
   ];
 }
 

--- a/frontend/src/common/test-utils.tsx
+++ b/frontend/src/common/test-utils.tsx
@@ -137,6 +137,14 @@ export async function importText(text: string) {
   screen.getByLabelText("import-text-submit").click();
 }
 
+export async function openImportCSVModal() {
+  // open the modal and find the upload dropzone
+  screen.getByText("Add Cards", { exact: false }).click();
+  await waitFor(() => screen.getByText("CSV", { exact: false }).click());
+  await waitFor(() => expect(screen.getByText("Add Cards — CSV")));
+  return screen.getByLabelText("import-csv");
+}
+
 async function openGridSelector(
   cardSlotTestId: string,
   gridSelectorTestId: string,

--- a/frontend/src/common/test-utils.tsx
+++ b/frontend/src/common/test-utils.tsx
@@ -121,6 +121,32 @@ export async function expectCardbackSlotState(
 
 //# endregion
 
+//# region react-dropzone
+
+function createDtWithFiles(files: File[] = []) {
+  /**
+   * Copy/pasted from react-dropzone test source code.
+   *
+   * createDtWithFiles creates a mock data transfer object that can be used for drop events
+   * @param {File[]} files
+   */
+
+  return {
+    dataTransfer: {
+      files,
+      items: files.map((file) => ({
+        kind: "file",
+        size: file.size,
+        type: file.type,
+        getAsFile: () => file,
+      })),
+      types: ["Files"],
+    },
+  };
+}
+
+//# endregion
+
 //# region UI interactions
 
 export async function openImportTextModal() {
@@ -143,6 +169,14 @@ export async function openImportCSVModal() {
   await waitFor(() => screen.getByText("CSV", { exact: false }).click());
   await waitFor(() => expect(screen.getByText("Add Cards — CSV")));
   return screen.getByLabelText("import-csv");
+}
+
+export async function importCSV(fileContents: string) {
+  const dropzone = await openImportCSVModal();
+
+  const file = new File([fileContents], "test.csv", { type: "text/csv" });
+
+  fireEvent.drop(dropzone, createDtWithFiles([file]));
 }
 
 async function openGridSelector(

--- a/frontend/src/common/types.ts
+++ b/frontend/src/common/types.ts
@@ -180,4 +180,8 @@ export interface ViewSettingsState {
   facetBySource: boolean;
 }
 
-export type ProcessedLine = [number, SearchQuery | null, SearchQuery | null];
+export type ProcessedLine = [
+  number,
+  ProjectMember | null,
+  ProjectMember | null
+];

--- a/frontend/src/features/dropzone.tsx
+++ b/frontend/src/features/dropzone.tsx
@@ -68,8 +68,11 @@ export function TextFileDropzone({
     useDropzone({ onDrop, accept: mimeTypes, maxFiles: 1 });
 
   return (
-    <div className="container" aria-label={label ?? "dropzone"}>
-      <Container {...getRootProps({ isFocused, isDragAccept, isDragReject })}>
+    <div className="container">
+      <Container
+        {...getRootProps({ isFocused, isDragAccept, isDragReject })}
+        aria-label={label ?? "dropzone"}
+      >
         <input {...getInputProps()} />
         Drag and drop a file here, or click to select a file.
       </Container>

--- a/frontend/src/features/dropzone.tsx
+++ b/frontend/src/features/dropzone.tsx
@@ -37,33 +37,38 @@ const Container = styled.div`
 
 interface StyledDropzoneProps {
   mimeTypes: { [mimeType: string]: Array<string> };
-  callback: {
-    (fileContent: string): void;
+  fileUploadCallback: {
+    (fileContent: string | ArrayBuffer | null): void;
   };
   label: string;
 }
 
-export function TextFileDropzone(props: StyledDropzoneProps) {
-  const onDrop = useCallback((acceptedFiles: Array<File>) => {
-    acceptedFiles.forEach((file: File) => {
-      // TODO: handle errors correctly
-      const reader = new FileReader();
-      reader.onabort = () => console.log("file reading was aborted");
-      reader.onerror = () => console.log("file reading has failed");
-      reader.onload = () => {
-        // @ts-ignore  // TODO
-        const fileContents: string = reader.result;
-        props.callback(fileContents);
-      };
-      reader.readAsText(file);
-    });
-  }, []);
+export function TextFileDropzone({
+  mimeTypes,
+  fileUploadCallback,
+  label,
+}: StyledDropzoneProps) {
+  const onDrop = useCallback(
+    (acceptedFiles: Array<File>) => {
+      acceptedFiles.forEach((file: File) => {
+        // TODO: handle errors correctly
+        const reader = new FileReader();
+        reader.onabort = () => console.log("file reading was aborted");
+        reader.onerror = () => console.log("file reading has failed");
+        reader.onload = () => {
+          fileUploadCallback(reader.result);
+        };
+        reader.readAsText(file);
+      });
+    },
+    [fileUploadCallback]
+  );
 
   const { getRootProps, getInputProps, isFocused, isDragAccept, isDragReject } =
-    useDropzone({ onDrop, accept: props.mimeTypes, maxFiles: 1 });
+    useDropzone({ onDrop, accept: mimeTypes, maxFiles: 1 });
 
   return (
-    <div className="container" aria-label={props.label ?? "dropzone"}>
+    <div className="container" aria-label={label ?? "dropzone"}>
       <Container {...getRootProps({ isFocused, isDragAccept, isDragReject })}>
         <input {...getInputProps()} />
         Drag and drop a file here, or click to select a file.

--- a/frontend/src/features/dropzone.tsx
+++ b/frontend/src/features/dropzone.tsx
@@ -40,6 +40,7 @@ interface StyledDropzoneProps {
   callback: {
     (fileContent: string): void;
   };
+  label: string;
 }
 
 export function TextFileDropzone(props: StyledDropzoneProps) {
@@ -62,7 +63,7 @@ export function TextFileDropzone(props: StyledDropzoneProps) {
     useDropzone({ onDrop, accept: props.mimeTypes, maxFiles: 1 });
 
   return (
-    <div className="container">
+    <div className="container" aria-label={props.label ?? "dropzone"}>
       <Container {...getRootProps({ isFocused, isDragAccept, isDragReject })}>
         <input {...getInputProps()} />
         Drag and drop a file here, or click to select a file.

--- a/frontend/src/features/import/__snapshots__/importCSV.test.tsx.snap
+++ b/frontend/src/features/import/__snapshots__/importCSV.test.tsx.snap
@@ -254,10 +254,10 @@ exports[`the html structure of CSV importer 1`] = `
       </table>
       <hr />
       <div
-        aria-label="import-csv"
         class="container"
       >
         <div
+          aria-label="import-csv"
           class="sc-dmqHEX lkItOe"
           role="presentation"
           tabindex="0"

--- a/frontend/src/features/import/__snapshots__/importCSV.test.tsx.snap
+++ b/frontend/src/features/import/__snapshots__/importCSV.test.tsx.snap
@@ -1,0 +1,288 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`the html structure of CSV importer 1`] = `
+<div
+  class="modal-dialog"
+  data-testid="import-csv"
+>
+  <div
+    class="modal-content"
+  >
+    <div
+      class="modal-header"
+    >
+      <div
+        class="modal-title h4"
+      >
+        Add Cards — CSV
+      </div>
+      <button
+        aria-label="Close"
+        class="btn-close"
+        type="button"
+      />
+    </div>
+    <div
+      class="modal-body"
+    >
+      <p>
+        Upload a CSV file of cards to add to the project. The file must
+         
+        <b>
+          exactly
+        </b>
+         match the following format:
+      </p>
+      <table
+        class="sc-hLseeU emfKgg table table-bordered"
+      >
+        <thead>
+          <th
+            class="sc-eDDNvR kubbQn"
+          >
+            Quantity
+          </th>
+          <th
+            class="sc-eDDNvR kubbQn"
+          >
+            Front
+          </th>
+          <th
+            class="sc-eDDNvR kubbQn"
+          >
+            Front ID
+          </th>
+          <th
+            class="sc-eDDNvR kubbQn"
+          >
+            Back
+          </th>
+          <th
+            class="sc-eDDNvR kubbQn"
+          >
+            Back ID
+          </th>
+        </thead>
+        <tbody>
+          <tr>
+            <td
+              class="sc-jTrPJq hlHZbj"
+            />
+            <td
+              class="sc-jTrPJq hlHZbj"
+            />
+            <td
+              class="sc-jTrPJq hlHZbj"
+            />
+            <td
+              class="sc-jTrPJq hlHZbj"
+            />
+            <td
+              class="sc-jTrPJq hlHZbj"
+            />
+          </tr>
+          <tr>
+            <td
+              class="sc-jTrPJq hlHZbj"
+            />
+            <td
+              class="sc-jTrPJq hlHZbj"
+            />
+            <td
+              class="sc-jTrPJq hlHZbj"
+            />
+            <td
+              class="sc-jTrPJq hlHZbj"
+            />
+            <td
+              class="sc-jTrPJq hlHZbj"
+            />
+          </tr>
+          <tr>
+            <td
+              class="sc-jTrPJq hlHZbj"
+            />
+            <td
+              class="sc-jTrPJq hlHZbj"
+            />
+            <td
+              class="sc-jTrPJq hlHZbj"
+            />
+            <td
+              class="sc-jTrPJq hlHZbj"
+            />
+            <td
+              class="sc-jTrPJq hlHZbj"
+            />
+          </tr>
+        </tbody>
+      </table>
+      Where the columns follow these rules:
+      <ul>
+        <li>
+          <b>
+            Quantity
+          </b>
+          : The quantity to include of this row. Must be greater than 0. 
+          <b>
+            Cannot be blank.
+          </b>
+        </li>
+        <li>
+          <b>
+            Front
+          </b>
+          : Search query for card front. 
+          <b>
+            Cannot be blank.
+          </b>
+        </li>
+        <li>
+          <b>
+            Front ID
+          </b>
+          : If this image is in the front search results, it will be pre-selected. Can be blank.
+        </li>
+        <li>
+          <b>
+            Front
+          </b>
+          : Search query for card back. Can be blank.
+        </li>
+        <li>
+          <b>
+            Front ID
+          </b>
+          : If this image is in the back search results, it will be pre-selected. Can be blank.
+        </li>
+      </ul>
+      For example:
+      <table
+        class="sc-hLseeU emfKgg table table-bordered"
+      >
+        <thead>
+          <th
+            class="sc-eDDNvR kubbQn"
+          >
+            Quantity
+          </th>
+          <th
+            class="sc-eDDNvR kubbQn"
+          >
+            Front
+          </th>
+          <th
+            class="sc-eDDNvR kubbQn"
+          >
+            Front ID
+          </th>
+          <th
+            class="sc-eDDNvR kubbQn"
+          >
+            Back
+          </th>
+          <th
+            class="sc-eDDNvR kubbQn"
+          >
+            Back ID
+          </th>
+        </thead>
+        <tbody>
+          <tr>
+            <td
+              class="sc-jTrPJq hlHZbj"
+            >
+              <code>
+                2
+              </code>
+            </td>
+            <td
+              class="sc-jTrPJq hlHZbj"
+            >
+              <code>
+                island
+              </code>
+            </td>
+            <td
+              class="sc-jTrPJq hlHZbj"
+            >
+              <code>
+                1HsvTYs1...
+              </code>
+            </td>
+            <td
+              class="sc-jTrPJq hlHZbj"
+            >
+              <code>
+                forest
+              </code>
+            </td>
+            <td
+              class="sc-jTrPJq hlHZbj"
+            />
+          </tr>
+          <tr>
+            <td
+              class="sc-jTrPJq hlHZbj"
+            >
+              <code>
+                3
+              </code>
+            </td>
+            <td
+              class="sc-jTrPJq hlHZbj"
+            >
+              <code>
+                t:goblin
+              </code>
+            </td>
+            <td
+              class="sc-jTrPJq hlHZbj"
+            />
+            <td
+              class="sc-jTrPJq hlHZbj"
+            />
+            <td
+              class="sc-jTrPJq hlHZbj"
+            >
+              <code>
+                1JtXL6Ca...
+              </code>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <hr />
+      <div
+        aria-label="import-csv"
+        class="container"
+      >
+        <div
+          class="sc-dmqHEX lkItOe"
+          role="presentation"
+          tabindex="0"
+        >
+          <input
+            accept="text/csv,.csv"
+            multiple=""
+            style="display: none;"
+            tabindex="-1"
+            type="file"
+          />
+          Drag and drop a file here, or click to select a file.
+        </div>
+      </div>
+    </div>
+    <div
+      class="modal-footer"
+    >
+      <button
+        class="btn btn-secondary"
+        type="button"
+      >
+        Close
+      </button>
+    </div>
+  </div>
+</div>
+`;

--- a/frontend/src/features/import/__snapshots__/importText.test.tsx.snap
+++ b/frontend/src/features/import/__snapshots__/importText.test.tsx.snap
@@ -50,6 +50,20 @@ exports[`the html structure of text importer 1`] = `
         .
       </p>
       <p>
+        You may optionally specify the image ID to select with
+         
+        <code>
+          @
+        </code>
+         — for example,
+         
+        <code>
+          brainstorm
+          @
+          1c4M-sK9gd0Xju0NXCPtqeTW_DQTldVU5
+        </code>
+      </p>
+      <p>
         If you don't specify a back query and your front query is a double-faced card, we will automatically query the back for you.
       </p>
       <div

--- a/frontend/src/features/import/importCSV.test.tsx
+++ b/frontend/src/features/import/importCSV.test.tsx
@@ -1,8 +1,28 @@
 import { screen } from "@testing-library/react";
 
 import App from "@/app/app";
-import { cardDocument2, localBackend } from "@/common/test-constants";
-import { openImportCSVModal, renderWithProviders } from "@/common/test-utils";
+import { Back, Front } from "@/common/constants";
+import {
+  cardDocument1,
+  cardDocument2,
+  localBackend,
+} from "@/common/test-constants";
+import {
+  expectCardbackSlotState,
+  expectCardGridSlotState,
+  expectCardSlotToExist,
+  importCSV,
+  openImportCSVModal,
+  renderWithProviders,
+} from "@/common/test-utils";
+import {
+  cardbacksTwoOtherResults,
+  cardDocumentsThreeResults,
+  defaultHandlers,
+  searchResultsOneResult,
+  sourceDocumentsOneResult,
+} from "@/mocks/handlers";
+import { server } from "@/mocks/server";
 
 const preloadedState = {
   backend: localBackend,
@@ -23,3 +43,23 @@ test("the html structure of CSV importer", async () => {
 });
 
 //# endregion
+
+test("importing one card by CSV into an empty project", async () => {
+  server.use(
+    cardDocumentsThreeResults,
+    cardbacksTwoOtherResults,
+    sourceDocumentsOneResult,
+    searchResultsOneResult,
+    ...defaultHandlers
+  );
+  renderWithProviders(<App />, { preloadedState });
+
+  // import a card
+  await importCSV("Quantity,Front\n,my search query");
+
+  // a card slot should have been created
+  await expectCardSlotToExist(1);
+  await expectCardGridSlotState(1, Front, cardDocument1.name, 1, 1);
+  await expectCardGridSlotState(1, Back, cardDocument2.name, 1, 2);
+  await expectCardbackSlotState(cardDocument2.name, 1, 2);
+});

--- a/frontend/src/features/import/importCSV.test.tsx
+++ b/frontend/src/features/import/importCSV.test.tsx
@@ -1,0 +1,25 @@
+import { screen } from "@testing-library/react";
+
+import App from "@/app/app";
+import { cardDocument2, localBackend } from "@/common/test-constants";
+import { openImportCSVModal, renderWithProviders } from "@/common/test-utils";
+
+const preloadedState = {
+  backend: localBackend,
+  project: {
+    members: [],
+    cardback: cardDocument2.identifier,
+  },
+};
+
+//# region snapshot tests
+
+test("the html structure of CSV importer", async () => {
+  renderWithProviders(<App />, { preloadedState });
+
+  await openImportCSVModal();
+
+  expect(screen.getByTestId("import-csv")).toMatchSnapshot();
+});
+
+//# endregion

--- a/frontend/src/features/import/importCSV.tsx
+++ b/frontend/src/features/import/importCSV.tsx
@@ -39,6 +39,7 @@ const FormattedColumnData = styled.td`
   text-align: center;
 `;
 
+// TODO: typescript enums don't allow for reverse lookup :(
 enum CSVHeaders {
   quantity = "Quantity",
   frontQuery = "Front",
@@ -48,6 +49,7 @@ enum CSVHeaders {
 }
 
 function CSVFormat() {
+  // TODO: some strings are defined in a few places in this file. consolidate them
   return (
     <>
       <BorderedTable bordered={true}>
@@ -138,7 +140,12 @@ export function ImportCSV() {
   const handleCloseCSVModal = () => setShowCSVModal(false);
   const handleShowCSVModal = () => setShowCSVModal(true);
 
-  const parseCSVFile = (fileContents: string) => {
+  const parseCSVFile = (fileContents: string | ArrayBuffer | null) => {
+    if (typeof fileContents !== "string") {
+      alert("invalid CSV file uploaded");
+      // TODO: error messaging to the user that they've uploaded an invalid file
+      return;
+    }
     const quantityProperty = "quantity";
     const frontQueryProperty = "frontQuery";
     const frontSelectedImageProperty = "frontSelectedImage";
@@ -207,7 +214,7 @@ export function ImportCSV() {
           <hr />
           <TextFileDropzone
             mimeTypes={{ "text/csv": [".csv"] }}
-            callback={parseCSVFile}
+            fileUploadCallback={parseCSVFile}
             label="import-csv"
           />
         </Modal.Body>

--- a/frontend/src/features/import/importCSV.tsx
+++ b/frontend/src/features/import/importCSV.tsx
@@ -188,7 +188,11 @@ export function ImportCSV() {
         />{" "}
         CSV
       </Dropdown.Item>
-      <Modal show={showCSVModal} onHide={handleCloseCSVModal}>
+      <Modal
+        show={showCSVModal}
+        onHide={handleCloseCSVModal}
+        data-testid="import-csv"
+      >
         <Modal.Header closeButton>
           <Modal.Title>Add Cards — CSV</Modal.Title>
         </Modal.Header>
@@ -204,6 +208,7 @@ export function ImportCSV() {
           <TextFileDropzone
             mimeTypes={{ "text/csv": [".csv"] }}
             callback={parseCSVFile}
+            label="import-csv"
           />
         </Modal.Body>
         <Modal.Footer>

--- a/frontend/src/features/import/importText.tsx
+++ b/frontend/src/features/import/importText.tsx
@@ -18,6 +18,7 @@ import {
   Cardback,
   FaceSeparator,
   ReversedCardTypePrefixes,
+  SelectedImageSeparator,
   Token,
 } from "@/common/constants";
 import { processLines, stripTextInParentheses } from "@/common/processing";
@@ -108,6 +109,14 @@ export function ImportText() {
               4x goblin {FaceSeparator} {ReversedCardTypePrefixes[Token]}elf
             </code>
             .
+          </p>
+          <p>
+            You may optionally specify the image ID to select with{" "}
+            <code>{SelectedImageSeparator}</code> — for example,{" "}
+            <code>
+              brainstorm{SelectedImageSeparator}
+              1c4M-sK9gd0Xju0NXCPtqeTW_DQTldVU5
+            </code>
           </p>
           <p>
             If you don&apos;t specify a back query and your front query is a

--- a/frontend/src/features/import/importText.tsx
+++ b/frontend/src/features/import/importText.tsx
@@ -21,7 +21,10 @@ import {
   SelectedImageSeparator,
   Token,
 } from "@/common/constants";
-import { processLines, stripTextInParentheses } from "@/common/processing";
+import {
+  processStringAsMultipleLines,
+  stripTextInParentheses,
+} from "@/common/processing";
 import { CardDocument } from "@/common/types";
 
 import { addImages } from "../project/projectSlice";
@@ -74,7 +77,7 @@ export function ImportText() {
      * Parse the contents of the modal and add the resultant queries in the desired numbers of instances to the project.
      */
 
-    const processedLines = processLines(
+    const processedLines = processStringAsMultipleLines(
       textModalValue,
       dfcPairsQuery.data ?? {}
     );

--- a/frontend/src/features/import/importURL.tsx
+++ b/frontend/src/features/import/importURL.tsx
@@ -22,7 +22,7 @@ import {
 import { apiSlice } from "@/app/api";
 import { AppDispatch, RootState } from "@/app/store";
 import { ProjectName } from "@/common/constants";
-import { processLines } from "@/common/processing";
+import { processStringAsMultipleLines } from "@/common/processing";
 
 import { addImages } from "../project/projectSlice";
 
@@ -49,7 +49,7 @@ export function ImportURL() {
     if (trimmedURL.length > 0) {
       setLoading(true);
       const query = await triggerFn(URLModalValue);
-      const processedLines = processLines(
+      const processedLines = processStringAsMultipleLines(
         query.data ?? "",
         dfcPairsQuery.data ?? {}
       );

--- a/frontend/src/features/import/importXML.tsx
+++ b/frontend/src/features/import/importXML.tsx
@@ -38,6 +38,7 @@ export function ImportXML() {
           <TextFileDropzone
             mimeTypes={{ "text/xml": [".xml"] }}
             callback={myCallback}
+            label="import-xml"
           />
         </Modal.Body>
         <Modal.Footer>

--- a/frontend/src/features/import/importXML.tsx
+++ b/frontend/src/features/import/importXML.tsx
@@ -20,7 +20,13 @@ export function ImportXML() {
   const handleCloseXMLModal = () => setShowXMLModal(false);
   const handleShowXMLModal = () => setShowXMLModal(true);
 
-  const myCallback = (fileContents: string) => {
+  const myCallback = (fileContents: string | ArrayBuffer | null) => {
+    if (typeof fileContents !== "string") {
+      alert("invalid CSV file uploaded");
+      // TODO: error messaging to the user that they've uploaded an invalid file
+      return;
+    }
+
     console.log("file received!");
   };
 
@@ -37,7 +43,7 @@ export function ImportXML() {
         <Modal.Body>
           <TextFileDropzone
             mimeTypes={{ "text/xml": [".xml"] }}
-            callback={myCallback}
+            fileUploadCallback={myCallback}
             label="import-xml"
           />
         </Modal.Body>

--- a/frontend/src/features/project/projectSlice.ts
+++ b/frontend/src/features/project/projectSlice.ts
@@ -133,20 +133,28 @@ export const projectSlice = createSlice({
        */
 
       let newMembers: Array<SlotProjectMembers> = [];
-      for (const [quantity, frontQuery, backQuery] of action.payload.lines) {
+      for (const [quantity, frontMember, backMember] of action.payload.lines) {
         const cappedQuantity = Math.min(
           quantity,
           ProjectMaxSize - (state.members.length + newMembers.length)
         );
-        newMembers = [
-          ...newMembers,
-          ...Array(cappedQuantity).fill({
-            front: { query: frontQuery, selectedImage: null },
-            back: { query: backQuery, selectedImage: null },
-          }),
-        ];
-        if (state.members.length + newMembers.length >= ProjectMaxSize) {
-          break;
+        if (frontMember != null || backMember != null) {
+          newMembers = [
+            ...newMembers,
+            ...Array(cappedQuantity).fill({
+              front: {
+                query: frontMember?.query,
+                selectedImage: frontMember?.selectedImage,
+              },
+              back: {
+                query: backMember?.query,
+                selectedImage: backMember?.selectedImage,
+              },
+            }),
+          ];
+          if (state.members.length + newMembers.length >= ProjectMaxSize) {
+            break;
+          }
         }
       }
       state.members = [...state.members, ...newMembers];

--- a/frontend/src/features/project/projectSlice.ts
+++ b/frontend/src/features/project/projectSlice.ts
@@ -11,7 +11,6 @@ import {
   Faces,
   ProcessedLine,
   Project,
-  ProjectMember,
   SearchQuery,
   SlotProjectMembers,
 } from "@/common/types";
@@ -54,37 +53,17 @@ const initialState: Project = {
   cardback: null,
 };
 
-interface SetSelectedImageAction {
-  face: Faces;
-  slot: number;
-  selectedImage?: string;
-}
-
-interface BulkSetSelectedImageAction {
-  face: Faces;
-  currentImage: string;
-  selectedImage: string;
-}
-
-interface SetSelectedCardbackAction {
-  selectedImage: string;
-}
-
-interface AddImagesAction {
-  lines: Array<ProcessedLine>;
-}
-
-interface DeleteImageAction {
-  slot: number;
-}
-
 export const projectSlice = createSlice({
   name: "project",
   initialState,
   reducers: {
     setSelectedImage: (
       state: RootState,
-      action: PayloadAction<SetSelectedImageAction>
+      action: PayloadAction<{
+        face: Faces;
+        slot: number;
+        selectedImage?: string;
+      }>
     ) => {
       // TODO: this is a bit awkward
       if (state.members[action.payload.slot][action.payload.face] == null) {
@@ -102,7 +81,11 @@ export const projectSlice = createSlice({
     },
     bulkSetSelectedImage: (
       state: RootState,
-      action: PayloadAction<BulkSetSelectedImageAction>
+      action: PayloadAction<{
+        face: Faces;
+        currentImage: string;
+        selectedImage: string;
+      }>
     ) => {
       // identify all cards in the specified face which have selected the old image
       // set all those images to the new image
@@ -137,11 +120,14 @@ export const projectSlice = createSlice({
     },
     setSelectedCardback: (
       state: RootState,
-      action: PayloadAction<SetSelectedCardbackAction>
+      action: PayloadAction<{ selectedImage: string }>
     ) => {
       state.cardback = action.payload.selectedImage;
     },
-    addImages: (state: RootState, action: PayloadAction<AddImagesAction>) => {
+    addImages: (
+      state: RootState,
+      action: PayloadAction<{ lines: Array<ProcessedLine> }>
+    ) => {
       /**
        * ProjectMaxSize (612 cards at time of writing) is enforced at this layer.
        */
@@ -167,7 +153,7 @@ export const projectSlice = createSlice({
     },
     deleteImage: (
       state: RootState,
-      action: PayloadAction<DeleteImageAction>
+      action: PayloadAction<{ slot: number }>
     ) => {
       // TODO: this breaks when you add a DFC card then delete the different card from the project.
       state.members.splice(action.payload.slot, 1);


### PR DESCRIPTION
# Description
* Does what it says on the tin
* This first crack at CSV upload just gets it working and has very bare automated testing - will continue to flesh this out
* As part of this work, I also extended the text importer to allow specifying the version to select, using `@` as the separator
* Using `lil-csv` at the moment, but might switch off it later because it doesn't have Typescript support. I figured this was such a simple use case that it wasn't worth adding a heavy library for

# Checklist

- [x] I have installed `pre-commit` and run the hooks with `pre-commit run`.
- [x] I have updated any related tests for code I modified or added new tests where appropriate.
- [x] I have updated any relevant documentation or created new documentation where appropriate.
