### PR TITLE
Implement XML importer in new frontend

### DIFF
--- a/frontend/src/common/constants.ts
+++ b/frontend/src/common/constants.ts
@@ -1,4 +1,6 @@
 export const ProjectName = "MPC Autofill";
+export const MakePlayingCards = "MakePlayingCards.com";
+export const MakePlayingCardsURL = "https://www.makeplayingcards.com";
 
 import { CardType, Faces } from "@/common/types";
 

--- a/frontend/src/common/test-utils.tsx
+++ b/frontend/src/common/test-utils.tsx
@@ -179,6 +179,24 @@ export async function importCSV(fileContents: string) {
   fireEvent.drop(dropzone, createDtWithFiles([file]));
 }
 
+export async function openImportXMLModal() {
+  // open the modal and find the upload dropzone
+  screen.getByText("Add Cards", { exact: false }).click();
+  await waitFor(() => screen.getByText("XML", { exact: false }).click());
+  await waitFor(() => expect(screen.getByText("Add Cards — XML")));
+  return screen.getByLabelText("import-xml");
+}
+
+export async function importXML(fileContents: string) {
+  const dropzone = await openImportXMLModal();
+
+  const file = new File([fileContents], "test.xml", {
+    type: "text/xml;charset=utf-8",
+  });
+
+  fireEvent.drop(dropzone, createDtWithFiles([file]));
+}
+
 async function openGridSelector(
   cardSlotTestId: string,
   gridSelectorTestId: string,

--- a/frontend/src/common/test-utils.tsx
+++ b/frontend/src/common/test-utils.tsx
@@ -187,12 +187,18 @@ export async function openImportXMLModal() {
   return screen.getByLabelText("import-xml");
 }
 
-export async function importXML(fileContents: string) {
+export async function importXML(
+  fileContents: string,
+  useXMLCardback: boolean = false
+) {
   const dropzone = await openImportXMLModal();
 
   const file = new File([fileContents], "test.xml", {
     type: "text/xml;charset=utf-8",
   });
+  if (useXMLCardback) {
+    await waitFor(() => screen.getByText("Retain Selected Cardback").click());
+  }
 
   fireEvent.drop(dropzone, createDtWithFiles([file]));
 }

--- a/frontend/src/features/import/__snapshots__/importXML.test.tsx.snap
+++ b/frontend/src/features/import/__snapshots__/importXML.test.tsx.snap
@@ -1,0 +1,60 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`the html structure of XML importer 1`] = `
+<div
+  class="modal-dialog"
+  data-testid="import-xml"
+>
+  <div
+    class="modal-content"
+  >
+    <div
+      class="modal-header"
+    >
+      <div
+        class="modal-title h4"
+      >
+        Add Cards — XML
+      </div>
+      <button
+        aria-label="Close"
+        class="btn-close"
+        type="button"
+      />
+    </div>
+    <div
+      class="modal-body"
+    >
+      <div
+        class="container"
+      >
+        <div
+          aria-label="import-xml"
+          class="sc-dmqHEX lkItOe"
+          role="presentation"
+          tabindex="0"
+        >
+          <input
+            accept="text/xml,.xml"
+            multiple=""
+            style="display: none;"
+            tabindex="-1"
+            type="file"
+          />
+          Drag and drop a file here, or click to select a file.
+        </div>
+      </div>
+    </div>
+    <div
+      class="modal-footer"
+    >
+      <button
+        class="btn btn-secondary"
+        type="button"
+      >
+        Close
+      </button>
+    </div>
+  </div>
+</div>
+`;

--- a/frontend/src/features/import/__snapshots__/importXML.test.tsx.snap
+++ b/frontend/src/features/import/__snapshots__/importXML.test.tsx.snap
@@ -36,6 +36,30 @@ exports[`the html structure of XML importer 1`] = `
          desktop tool which auto-fills your order into MakePlayingCards expects a file in this format.
       </p>
       <div
+        class="btn toggle btn-md off btn-info"
+        role="button"
+        style="width: 100%; height: 38px;"
+      >
+        <div
+          class="toggle-group"
+        >
+          <span
+            class="btn toggle-on btn-md flex-centre btn-info"
+          >
+            Update Project with XML Cardback
+          </span>
+          <span
+            class="btn toggle-off btn-md flex-centre btn-info"
+          >
+            Retain Selected Cardback
+          </span>
+          <span
+            class="toggle-handle btn btn-md btn-default"
+          />
+        </div>
+      </div>
+      <hr />
+      <div
         class="container"
       >
         <div

--- a/frontend/src/features/import/__snapshots__/importXML.test.tsx.snap
+++ b/frontend/src/features/import/__snapshots__/importXML.test.tsx.snap
@@ -33,14 +33,16 @@ exports[`the html structure of XML importer 1`] = `
         MPC Autofill
          website can generate an XML file representing your project, and the 
         MPC Autofill
-         desktop tool which auto-fills your order into 
+         desktop tool which auto-fills your order into
+         
         <a
           href="https://www.makeplayingcards.com"
           target="_blank"
         >
           MakePlayingCards.com
         </a>
-         expects a file in this format.
+         
+        expects a file in this format.
       </p>
       <div
         class="btn toggle btn-md off btn-info"

--- a/frontend/src/features/import/__snapshots__/importXML.test.tsx.snap
+++ b/frontend/src/features/import/__snapshots__/importXML.test.tsx.snap
@@ -25,6 +25,16 @@ exports[`the html structure of XML importer 1`] = `
     <div
       class="modal-body"
     >
+      <p>
+        Upload an XML file of cards to add to the project.
+      </p>
+      <p>
+        The 
+        MPC Autofill
+         website can generate an XML file representing your project, and the 
+        MPC Autofill
+         desktop tool which auto-fills your order into MakePlayingCards expects a file in this format.
+      </p>
       <div
         class="container"
       >

--- a/frontend/src/features/import/__snapshots__/importXML.test.tsx.snap
+++ b/frontend/src/features/import/__snapshots__/importXML.test.tsx.snap
@@ -33,7 +33,14 @@ exports[`the html structure of XML importer 1`] = `
         MPC Autofill
          website can generate an XML file representing your project, and the 
         MPC Autofill
-         desktop tool which auto-fills your order into MakePlayingCards expects a file in this format.
+         desktop tool which auto-fills your order into 
+        <a
+          href="https://www.makeplayingcards.com"
+          target="_blank"
+        >
+          MakePlayingCards.com
+        </a>
+         expects a file in this format.
       </p>
       <div
         class="btn toggle btn-md off btn-info"

--- a/frontend/src/features/import/importCSV.tsx
+++ b/frontend/src/features/import/importCSV.tsx
@@ -13,14 +13,17 @@ import Button from "react-bootstrap/Button";
 import Dropdown from "react-bootstrap/Dropdown";
 import Modal from "react-bootstrap/Modal";
 import Table from "react-bootstrap/Table";
-import { useDispatch } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import styled from "styled-components";
 
 import { useGetDFCPairsQuery } from "@/app/api";
 import { AppDispatch } from "@/app/store";
 import { FaceSeparator, SelectedImageSeparator } from "@/common/constants";
-import { processLines } from "@/common/processing";
-import { addImages } from "@/features/project/projectSlice";
+import {
+  convertLinesIntoSlotProjectMembers,
+  processLines,
+} from "@/common/processing";
+import { addMembers, selectProjectSize } from "@/features/project/projectSlice";
 
 import { TextFileDropzone } from "../dropzone";
 
@@ -141,6 +144,8 @@ export function ImportCSV() {
   const handleCloseCSVModal = () => setShowCSVModal(false);
   const handleShowCSVModal = () => setShowCSVModal(true);
 
+  const projectSize = useSelector(selectProjectSize);
+
   const parseCSVFile = (fileContents: string | ArrayBuffer | null) => {
     if (typeof fileContents !== "string") {
       alert("invalid CSV file uploaded");
@@ -183,7 +188,14 @@ export function ImportCSV() {
       rows.map(formatCSVRowAsLine),
       dfcPairsQuery.data ?? {}
     );
-    dispatch(addImages({ lines: processedLines }));
+    dispatch(
+      addMembers({
+        members: convertLinesIntoSlotProjectMembers(
+          processedLines,
+          projectSize
+        ),
+      })
+    );
     handleCloseCSVModal();
   };
 

--- a/frontend/src/features/import/importText.tsx
+++ b/frontend/src/features/import/importText.tsx
@@ -9,7 +9,7 @@ import Button from "react-bootstrap/Button";
 import Dropdown from "react-bootstrap/Dropdown";
 import Form from "react-bootstrap/Form";
 import Modal from "react-bootstrap/Modal";
-import { useDispatch } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 
 import { useGetDFCPairsQuery, useGetSampleCardsQuery } from "@/app/api";
 import { AppDispatch } from "@/app/store";
@@ -22,12 +22,13 @@ import {
   Token,
 } from "@/common/constants";
 import {
+  convertLinesIntoSlotProjectMembers,
   processStringAsMultipleLines,
   stripTextInParentheses,
 } from "@/common/processing";
 import { CardDocument } from "@/common/types";
 
-import { addImages } from "../project/projectSlice";
+import { addMembers, selectProjectSize } from "../project/projectSlice";
 
 export function ImportText() {
   // TODO: add an accordion here for explaining how to search for each different card type with prefixes
@@ -40,6 +41,8 @@ export function ImportText() {
   const handleShowTextModal = () => setShowTextModal(true);
   const [textModalValue, setTextModalValue] = useState("");
   const [placeholderText, setPlaceholderText] = useState("");
+
+  const projectSize = useSelector(selectProjectSize);
 
   const formatPlaceholderText = (placeholders: {
     [cardType: string]: Array<CardDocument>;
@@ -81,7 +84,14 @@ export function ImportText() {
       textModalValue,
       dfcPairsQuery.data ?? {}
     );
-    dispatch(addImages({ lines: processedLines }));
+    dispatch(
+      addMembers({
+        members: convertLinesIntoSlotProjectMembers(
+          processedLines,
+          projectSize
+        ),
+      })
+    );
     handleCloseTextModal();
   };
 

--- a/frontend/src/features/import/importURL.tsx
+++ b/frontend/src/features/import/importURL.tsx
@@ -22,17 +22,20 @@ import {
 import { apiSlice } from "@/app/api";
 import { AppDispatch, RootState } from "@/app/store";
 import { ProjectName } from "@/common/constants";
-import { processStringAsMultipleLines } from "@/common/processing";
+import {
+  convertLinesIntoSlotProjectMembers,
+  processStringAsMultipleLines,
+} from "@/common/processing";
 import { Spinner } from "@/features/ui/spinner";
 
-import { addImages } from "../project/projectSlice";
+import { addMembers, selectProjectSize } from "../project/projectSlice";
 
 export function ImportURL() {
   const dfcPairsQuery = useGetDFCPairsQuery();
   const importSitesQuery = useGetImportSitesQuery();
   const backendInfoQuery = useGetBackendInfoQuery();
 
-  const backendURL = useSelector((state: RootState) => state.backend.url);
+  const projectSize = useSelector(selectProjectSize);
   const dispatch = useDispatch<AppDispatch>();
 
   // TODO: should probably set up type hints for all `useState` usages throughout the app
@@ -54,7 +57,14 @@ export function ImportURL() {
         query.data ?? "",
         dfcPairsQuery.data ?? {}
       );
-      dispatch(addImages({ lines: processedLines }));
+      dispatch(
+        addMembers({
+          members: convertLinesIntoSlotProjectMembers(
+            processedLines,
+            projectSize
+          ),
+        })
+      );
       handleCloseURLModal();
       setLoading(false);
     }

--- a/frontend/src/features/import/importXML.test.tsx
+++ b/frontend/src/features/import/importXML.test.tsx
@@ -407,3 +407,41 @@ test("importing a more complex XML into a non-empty project", async () => {
   await expectCardGridSlotState(4, Front, cardDocument1.name, 1, 4);
   await expectCardGridSlotState(4, Back, cardDocument3.name, 2, 2);
 });
+
+test("import an XML and retain its cardback", async () => {
+  server.use(
+    cardDocumentsThreeResults,
+    cardbacksTwoOtherResults,
+    sourceDocumentsOneResult,
+    searchResultsOneResult,
+    ...defaultHandlers
+  );
+  renderWithProviders(<App />, { preloadedState });
+
+  // import a card
+  await importXML(
+    `<order>
+      <details>
+        <quantity>1</quantity>
+        <bracket>18</bracket>
+      </details>
+      <fronts>
+        <card>
+          <id>${cardDocument1.identifier}</id>
+          <slots>0</slots>
+          <name>${cardDocument1.name}</name>
+          <query>my search query</query>
+        </card>
+      </fronts>
+      <cardback>${cardDocument3.identifier}</cardback>
+    </order>`,
+    true
+  );
+
+  // a card slot should have been created and it should retain the xml's cardback, not the project cardback
+  await expectCardSlotToExist(1);
+  await expectCardGridSlotState(1, Front, cardDocument1.name, 1, 1);
+  await expectCardGridSlotState(1, Back, cardDocument3.name, 2, 2);
+  // the project cardback should also have been updated
+  await expectCardbackSlotState(cardDocument3.name, 2, 2);
+});

--- a/frontend/src/features/import/importXML.test.tsx
+++ b/frontend/src/features/import/importXML.test.tsx
@@ -1,0 +1,409 @@
+import { screen } from "@testing-library/react";
+
+import App from "@/app/app";
+import { Back, Card, Front } from "@/common/constants";
+import {
+  cardDocument1,
+  cardDocument2,
+  cardDocument3,
+  cardDocument4,
+  cardDocument5,
+  cardDocument6,
+  localBackend,
+} from "@/common/test-constants";
+import {
+  expectCardbackSlotState,
+  expectCardGridSlotState,
+  expectCardSlotToExist,
+  importXML,
+  openImportXMLModal,
+  renderWithProviders,
+} from "@/common/test-utils";
+import {
+  cardbacksTwoOtherResults,
+  cardDocumentsSixResults,
+  cardDocumentsThreeResults,
+  defaultHandlers,
+  searchResultsFourResults,
+  searchResultsOneResult,
+  searchResultsSixResults,
+  searchResultsThreeResults,
+  sourceDocumentsOneResult,
+  sourceDocumentsThreeResults,
+} from "@/mocks/handlers";
+import { server } from "@/mocks/server";
+
+const preloadedState = {
+  backend: localBackend,
+  project: {
+    members: [],
+    cardback: cardDocument2.identifier,
+  },
+};
+
+//# region snapshot tests
+
+test("the html structure of XML importer", async () => {
+  renderWithProviders(<App />, { preloadedState });
+
+  await openImportXMLModal();
+
+  expect(screen.getByTestId("import-xml")).toMatchSnapshot();
+});
+
+//# endregion
+
+test("importing one card by XML into an empty project", async () => {
+  server.use(
+    cardDocumentsThreeResults,
+    cardbacksTwoOtherResults,
+    sourceDocumentsOneResult,
+    searchResultsOneResult,
+    ...defaultHandlers
+  );
+  renderWithProviders(<App />, { preloadedState });
+
+  // import a card
+  await importXML(
+    `<order>
+      <details>
+        <quantity>1</quantity>
+        <bracket>18</bracket>
+      </details>
+      <fronts>
+        <card>
+          <id>${cardDocument1.identifier}</id>
+          <slots>0</slots>
+          <name>${cardDocument1.name}</name>
+          <query>my search query</query>
+        </card>
+      </fronts>
+      <cardback>${cardDocument3.identifier}</cardback>
+    </order>`
+  );
+
+  // a card slot should have been created
+  await expectCardSlotToExist(1);
+  await expectCardGridSlotState(1, Front, cardDocument1.name, 1, 1);
+  await expectCardGridSlotState(1, Back, cardDocument2.name, 1, 2);
+  await expectCardbackSlotState(cardDocument3.name, 2, 2);
+});
+
+test("importing multiple instances of one card by XML into an empty project", async () => {
+  server.use(
+    cardDocumentsThreeResults,
+    cardbacksTwoOtherResults,
+    sourceDocumentsOneResult,
+    searchResultsOneResult,
+    ...defaultHandlers
+  );
+  renderWithProviders(<App />, { preloadedState });
+
+  // import two instances of a card
+  await importXML(
+    `<order>
+      <details>
+        <quantity>2</quantity>
+        <bracket>18</bracket>
+      </details>
+      <fronts>
+        <card>
+          <id>${cardDocument1.identifier}</id>
+          <slots>0,1</slots>
+          <name>${cardDocument1.name}</name>
+          <query>my search query</query>
+        </card>
+      </fronts>
+      <cardback>${cardDocument2.identifier}</cardback>
+    </order>`
+  );
+
+  // two card slots should have been created
+  await expectCardSlotToExist(1);
+  await expectCardGridSlotState(1, Front, cardDocument1.name, 1, 1);
+  await expectCardGridSlotState(1, Back, cardDocument2.name, 1, 2);
+  await expectCardSlotToExist(2);
+  await expectCardGridSlotState(2, Front, cardDocument1.name, 1, 1);
+  await expectCardGridSlotState(2, Back, cardDocument2.name, 1, 2);
+  await expectCardbackSlotState(cardDocument2.name, 1, 2);
+});
+
+test("importing one specific card version by XML into an empty project", async () => {
+  server.use(
+    cardDocumentsThreeResults,
+    cardbacksTwoOtherResults,
+    sourceDocumentsOneResult,
+    searchResultsThreeResults,
+    ...defaultHandlers
+  );
+  renderWithProviders(<App />, { preloadedState });
+
+  // import a card
+  await importXML(
+    `<order>
+      <details>
+        <quantity>1</quantity>
+        <bracket>18</bracket>
+      </details>
+      <fronts>
+        <card>
+          <id>${cardDocument3.identifier}</id>
+          <slots>0</slots>
+          <name>${cardDocument3.name}</name>
+          <query>my search query</query>
+        </card>
+      </fronts>
+      <cardback>${cardDocument2.identifier}</cardback>
+    </order>`
+  );
+
+  // a card slot should have been created
+  await expectCardSlotToExist(1);
+  await expectCardGridSlotState(1, Front, cardDocument3.name, 3, 3);
+  await expectCardGridSlotState(1, Back, cardDocument2.name, 1, 2);
+  await expectCardbackSlotState(cardDocument2.name, 1, 2);
+});
+
+test("importing one card of each type into an empty project", async () => {
+  server.use(
+    cardDocumentsSixResults,
+    cardbacksTwoOtherResults,
+    sourceDocumentsThreeResults,
+    searchResultsSixResults,
+    ...defaultHandlers
+  );
+  renderWithProviders(<App />, { preloadedState });
+
+  // import one card of each type
+  await importXML(
+    `<order>
+      <details>
+        <quantity>3</quantity>
+        <bracket>18</bracket>
+      </details>
+      <fronts>
+        <card>
+          <id>${cardDocument1.identifier}</id>
+          <slots>0</slots>
+          <name>${cardDocument1.name}</name>
+          <query>query 1</query>
+        </card>
+        <card>
+          <id>${cardDocument6.identifier}</id>
+          <slots>1</slots>
+          <name>${cardDocument6.name}</name>
+          <query>t:query 6</query>
+        </card>
+        <card>
+          <id>${cardDocument5.identifier}</id>
+          <slots>2</slots>
+          <name>${cardDocument5.name}</name>
+          <query>b:query 5</query>
+        </card>
+      </fronts>
+      <cardback>${cardDocument3.identifier}</cardback>
+    </order>`
+  );
+
+  // three card slots should have been created
+  await expectCardSlotToExist(1);
+  await expectCardGridSlotState(1, Front, cardDocument1.name, 1, 1);
+  await expectCardGridSlotState(1, Back, cardDocument2.name, 1, 2);
+  await expectCardSlotToExist(2);
+  await expectCardGridSlotState(2, Front, cardDocument6.name, 1, 1);
+  await expectCardGridSlotState(2, Back, cardDocument2.name, 1, 2);
+  await expectCardSlotToExist(3);
+  await expectCardGridSlotState(3, Front, cardDocument5.name, 1, 1);
+  await expectCardGridSlotState(3, Back, cardDocument2.name, 1, 2);
+  await expectCardbackSlotState(cardDocument2.name, 1, 2);
+});
+
+test("importing a more complex XML into an empty project", async () => {
+  server.use(
+    cardDocumentsSixResults,
+    cardbacksTwoOtherResults,
+    sourceDocumentsOneResult,
+    searchResultsFourResults,
+    ...defaultHandlers
+  );
+  renderWithProviders(<App />, { preloadedState });
+
+  // import a few cards
+  await importXML(
+    `<order>
+      <details>
+        <quantity>3</quantity>
+        <bracket>18</bracket>
+      </details>
+      <fronts>
+        <card>
+          <id>${cardDocument3.identifier}</id>
+          <slots>0,1</slots>
+          <name>${cardDocument3.name}</name>
+          <query>my search query</query>
+        </card>
+        <card>
+          <id>${cardDocument1.identifier}</id>
+          <slots>2</slots>
+          <name>${cardDocument1.name}</name>
+          <query>my search query</query>
+        </card>
+      </fronts>
+      <backs>
+        <card>
+          <id>${cardDocument4.identifier}</id>
+          <slots>0,1</slots>
+          <name>${cardDocument4.name}</name>
+          <query>my search query</query>
+        </card>
+      </backs>
+      <cardback>${cardDocument2.identifier}</cardback>
+    </order>`
+  );
+
+  // three card slots should have been created
+  await expectCardSlotToExist(1);
+  await expectCardGridSlotState(1, Front, cardDocument3.name, 3, 4);
+  await expectCardGridSlotState(1, Back, cardDocument4.name, 4, 4);
+  await expectCardSlotToExist(2);
+  await expectCardGridSlotState(2, Front, cardDocument3.name, 3, 4);
+  await expectCardGridSlotState(2, Back, cardDocument4.name, 4, 4);
+  await expectCardSlotToExist(3);
+  await expectCardGridSlotState(3, Front, cardDocument1.name, 1, 4);
+  await expectCardGridSlotState(3, Back, cardDocument2.name, 1, 2);
+  await expectCardbackSlotState(cardDocument2.name, 1, 2);
+});
+
+test("importing an XML with gaps into an empty project", async () => {
+  server.use(
+    cardDocumentsSixResults,
+    cardbacksTwoOtherResults,
+    sourceDocumentsOneResult,
+    searchResultsFourResults,
+    ...defaultHandlers
+  );
+  renderWithProviders(<App />, { preloadedState });
+
+  // import a few cards
+  await importXML(
+    `<order>
+      <details>
+        <quantity>4</quantity>
+        <bracket>18</bracket>
+      </details>
+      <fronts>
+        <card>
+          <id>${cardDocument3.identifier}</id>
+          <slots>0,1</slots>
+          <name>${cardDocument3.name}</name>
+          <query>my search query</query>
+        </card>
+        <card>
+          <id>${cardDocument1.identifier}</id>
+          <slots>3</slots>
+          <name>${cardDocument1.name}</name>
+          <query>my search query</query>
+        </card>
+      </fronts>
+      <backs>
+        <card>
+          <id>${cardDocument4.identifier}</id>
+          <slots>0,3</slots>
+          <name>${cardDocument4.name}</name>
+          <query>my search query</query>
+        </card>
+      </backs>
+      <cardback>${cardDocument2.identifier}</cardback>
+    </order>`
+  );
+
+  // four card slots should have been created, but only three will have images selected
+  await expectCardSlotToExist(1);
+  await expectCardGridSlotState(1, Front, cardDocument3.name, 3, 4);
+  await expectCardGridSlotState(1, Back, cardDocument4.name, 4, 4);
+  await expectCardSlotToExist(2);
+  await expectCardGridSlotState(2, Front, cardDocument3.name, 3, 4);
+  await expectCardGridSlotState(2, Back, cardDocument2.name, 1, 2);
+  await expectCardSlotToExist(4);
+  await expectCardSlotToExist(3);
+  await expectCardGridSlotState(4, Front, cardDocument1.name, 1, 4);
+  await expectCardGridSlotState(4, Back, cardDocument4.name, 4, 4);
+  await expectCardbackSlotState(cardDocument2.name, 1, 2);
+});
+
+test("importing a more complex XML into a non-empty project", async () => {
+  server.use(
+    cardDocumentsSixResults,
+    cardbacksTwoOtherResults,
+    sourceDocumentsOneResult,
+    searchResultsFourResults,
+    ...defaultHandlers
+  );
+  renderWithProviders(<App />, {
+    preloadedState: {
+      ...preloadedState,
+      project: {
+        members: [
+          {
+            front: {
+              query: { query: "my search query", card_type: Card },
+              selectedImage: cardDocument1.identifier,
+            },
+            back: null,
+          },
+        ],
+        cardback: cardDocument2.identifier,
+      },
+    },
+  });
+
+  // this slot should already exist from our preloaded state
+  await expectCardSlotToExist(1);
+  await expectCardGridSlotState(1, Front, cardDocument1.name, 1, 4);
+  await expectCardGridSlotState(1, Back, cardDocument2.name, 1, 2);
+  await expectCardbackSlotState(cardDocument2.name, 1, 2);
+
+  // import a few more cards
+  await importXML(
+    `<order>
+      <details>
+        <quantity>3</quantity>
+        <bracket>18</bracket>
+      </details>
+      <fronts>
+        <card>
+          <id>${cardDocument3.identifier}</id>
+          <slots>0,1</slots>
+          <name>${cardDocument3.name}</name>
+          <query>my search query</query>
+        </card>
+        <card>
+          <id>${cardDocument1.identifier}</id>
+          <slots>2</slots>
+          <name>${cardDocument1.name}</name>
+          <query>my search query</query>
+        </card>
+      </fronts>
+      <backs>
+        <card>
+          <id>${cardDocument4.identifier}</id>
+          <slots>0,1</slots>
+          <name>${cardDocument4.name}</name>
+          <query>my search query</query>
+        </card>
+      </backs>
+      <cardback>${cardDocument3.identifier}</cardback>
+    </order>`
+  );
+
+  // three card slots should have been created
+  await expectCardSlotToExist(2);
+  await expectCardGridSlotState(2, Front, cardDocument3.name, 3, 4);
+  await expectCardGridSlotState(2, Back, cardDocument4.name, 4, 4);
+  await expectCardSlotToExist(3);
+  await expectCardGridSlotState(3, Front, cardDocument3.name, 3, 4);
+  await expectCardGridSlotState(3, Back, cardDocument4.name, 4, 4);
+  await expectCardSlotToExist(4);
+  await expectCardGridSlotState(4, Front, cardDocument1.name, 1, 4);
+  await expectCardGridSlotState(4, Back, cardDocument3.name, 2, 2);
+});

--- a/frontend/src/features/import/importXML.test.tsx
+++ b/frontend/src/features/import/importXML.test.tsx
@@ -82,11 +82,11 @@ test("importing one card by XML into an empty project", async () => {
     </order>`
   );
 
-  // a card slot should have been created
+  // a card slot should have been created and it should retain the xml's cardback, not the project cardback
   await expectCardSlotToExist(1);
   await expectCardGridSlotState(1, Front, cardDocument1.name, 1, 1);
-  await expectCardGridSlotState(1, Back, cardDocument2.name, 1, 2);
-  await expectCardbackSlotState(cardDocument3.name, 2, 2);
+  await expectCardGridSlotState(1, Back, cardDocument3.name, 2, 2);
+  await expectCardbackSlotState(cardDocument2.name, 1, 2);
 });
 
 test("importing multiple instances of one card by XML into an empty project", async () => {
@@ -208,13 +208,13 @@ test("importing one card of each type into an empty project", async () => {
   // three card slots should have been created
   await expectCardSlotToExist(1);
   await expectCardGridSlotState(1, Front, cardDocument1.name, 1, 1);
-  await expectCardGridSlotState(1, Back, cardDocument2.name, 1, 2);
+  await expectCardGridSlotState(1, Back, cardDocument3.name, 2, 2);
   await expectCardSlotToExist(2);
   await expectCardGridSlotState(2, Front, cardDocument6.name, 1, 1);
-  await expectCardGridSlotState(2, Back, cardDocument2.name, 1, 2);
+  await expectCardGridSlotState(2, Back, cardDocument3.name, 2, 2);
   await expectCardSlotToExist(3);
   await expectCardGridSlotState(3, Front, cardDocument5.name, 1, 1);
-  await expectCardGridSlotState(3, Back, cardDocument2.name, 1, 2);
+  await expectCardGridSlotState(3, Back, cardDocument3.name, 2, 2);
   await expectCardbackSlotState(cardDocument2.name, 1, 2);
 });
 

--- a/frontend/src/features/import/importXML.tsx
+++ b/frontend/src/features/import/importXML.tsx
@@ -12,15 +12,23 @@ import React, { useState } from "react";
 import Button from "react-bootstrap/Button";
 import Dropdown from "react-bootstrap/Dropdown";
 import Modal from "react-bootstrap/Modal";
+// @ts-ignore: https://github.com/arnthor3/react-bootstrap-toggle/issues/21
+import Toggle from "react-bootstrap-toggle";
 import { useDispatch, useSelector } from "react-redux";
 
-import { Cardback, ProjectMaxSize, ProjectName } from "@/common/constants";
+import {
+  Cardback,
+  ProjectMaxSize,
+  ProjectName,
+  ToggleButtonHeight,
+} from "@/common/constants";
 import { processPrefix } from "@/common/processing";
 import { SlotProjectMembers } from "@/common/types";
 import {
   addMembers,
   selectProjectCardback,
   selectProjectSize,
+  setSelectedCardback,
 } from "@/features/project/projectSlice";
 
 import { TextFileDropzone } from "../dropzone";
@@ -32,12 +40,12 @@ export function ImportXML() {
   const handleShowXMLModal = () => setShowXMLModal(true);
   const projectCardback = useSelector(selectProjectCardback);
   const projectSize = useSelector(selectProjectSize);
+  const [useXMLCardback, setUseXMLCardback] = useState<boolean>(false);
 
   const parseXMLFile = (fileContents: string | ArrayBuffer | null) => {
     /**
-     * TODO - add settings to the XML importer modal for the following:
-     * 1. whether to set the project cardabck according to the imported file
-     * 2. do the same for the imported file's finish settings
+     * TODO - add controls for:
+     * * whether to set the project's finish settings according to the imported file
      */
 
     if (typeof fileContents !== "string") {
@@ -136,6 +144,9 @@ export function ImportXML() {
         });
     }
     dispatch(addMembers({ members: newMembers.slice(0, lastNonNullSlot + 1) }));
+    if (useXMLCardback && cardback != null) {
+      dispatch(setSelectedCardback({ selectedImage: cardback }));
+    }
     handleCloseXMLModal();
   };
 
@@ -160,6 +171,20 @@ export function ImportXML() {
             project, and the {ProjectName} desktop tool which auto-fills your
             order into MakePlayingCards expects a file in this format.
           </p>
+          <Toggle
+            onClick={() => setUseXMLCardback(!useXMLCardback)}
+            on="Update Project with XML Cardback"
+            onClassName="flex-centre"
+            off="Retain Selected Cardback"
+            offClassName="flex-centre"
+            onstyle="info"
+            offstyle="info"
+            width={100 + "%"}
+            size="md"
+            height={ToggleButtonHeight + "px"}
+            active={useXMLCardback}
+          />
+          <hr />
           <TextFileDropzone
             mimeTypes={{ "text/xml": [".xml"] }}
             fileUploadCallback={parseXMLFile}

--- a/frontend/src/features/import/importXML.tsx
+++ b/frontend/src/features/import/importXML.tsx
@@ -12,22 +12,131 @@ import React, { useState } from "react";
 import Button from "react-bootstrap/Button";
 import Dropdown from "react-bootstrap/Dropdown";
 import Modal from "react-bootstrap/Modal";
+import { useDispatch, useSelector } from "react-redux";
+
+import { Cardback, ProjectMaxSize } from "@/common/constants";
+import { processPrefix } from "@/common/processing";
+import { SlotProjectMembers } from "@/common/types";
+import {
+  addMembers,
+  selectProjectCardback,
+  selectProjectSize,
+} from "@/features/project/projectSlice";
 
 import { TextFileDropzone } from "../dropzone";
 
 export function ImportXML() {
+  const dispatch = useDispatch();
   const [showXMLModal, setShowXMLModal] = useState(false);
   const handleCloseXMLModal = () => setShowXMLModal(false);
   const handleShowXMLModal = () => setShowXMLModal(true);
+  const projectCardback = useSelector(selectProjectCardback);
+  const projectSize = useSelector(selectProjectSize);
 
-  const myCallback = (fileContents: string | ArrayBuffer | null) => {
+  const parseXMLFile = (fileContents: string | ArrayBuffer | null) => {
+    /**
+     * TODO - add settings to the XML importer modal for the following:
+     * 1. whether to set the project cardabck according to the imported file
+     * 2. do the same for the imported file's finish settings
+     */
+
     if (typeof fileContents !== "string") {
       alert("invalid CSV file uploaded");
       // TODO: error messaging to the user that they've uploaded an invalid file
       return;
     }
 
-    console.log("file received!");
+    // TODO: throw a user-visible error if the xml doc is malformed
+    const parser = new DOMParser();
+    const xmlDocument = parser.parseFromString(fileContents, "application/xml");
+    const rootElement = xmlDocument.getElementsByTagName("order")[0];
+
+    const frontsElement = rootElement.getElementsByTagName("fronts")[0];
+    const backsElement = rootElement.getElementsByTagName("backs")[0];
+
+    const frontCardElements = frontsElement.getElementsByTagName("card");
+    const backCardElements =
+      backsElement != null
+        ? backsElement.getElementsByTagName("card")
+        : undefined;
+
+    const cardback =
+      rootElement.getElementsByTagName("cardback")[0]?.textContent ??
+      projectCardback;
+
+    // `newMembers` is initialised with the maximum length it might need to contain all cards
+    // the project can hold, then is truncated later according to `lastNonNullSlot`
+    let lastNonNullSlot = 0;
+    const newMembers: Array<SlotProjectMembers> = Array.from(
+      { length: ProjectMaxSize - projectSize },
+      () => {
+        return { front: null, back: null };
+      }
+    );
+
+    // it's actually important that we iterate over the backs before the fronts
+    // this way, we can determine if each card needs to be given the project cardback or not
+    if (backCardElements != null) {
+      // TODO: avoid copy/pasting this stuff?
+      for (const backCardElement of backCardElements) {
+        const slotsText =
+          backCardElement.getElementsByTagName("slots")[0]?.textContent;
+        if (slotsText == null) {
+          continue;
+        }
+        const searchQuery = processPrefix(
+          backCardElement.getElementsByTagName("query")[0].textContent ?? ""
+        );
+        slotsText
+          .split(",")
+          .map((slotText) => parseInt(slotText))
+          .forEach((slot) => {
+            newMembers[slot].back = {
+              query: searchQuery,
+              selectedImage:
+                backCardElement.getElementsByTagName("id")[0].textContent ??
+                undefined,
+            };
+
+            lastNonNullSlot = Math.max(lastNonNullSlot, slot);
+          });
+      }
+    }
+
+    for (const frontCardElement of frontCardElements) {
+      const slotsText =
+        frontCardElement.getElementsByTagName("slots")[0].textContent;
+      if (slotsText == null) {
+        continue;
+      }
+      const searchQuery = processPrefix(
+        frontCardElement.getElementsByTagName("query")[0].textContent ?? ""
+      );
+
+      slotsText
+        .split(",")
+        .map((slotText) => parseInt(slotText))
+        .forEach((slot) => {
+          newMembers[slot].front = {
+            query: searchQuery,
+            selectedImage:
+              frontCardElement.getElementsByTagName("id")[0].textContent ??
+              undefined,
+          };
+
+          // apply the uploaded XML's cardback if the card doesn't have a matching back
+          if (newMembers[slot].back == null && cardback != null) {
+            newMembers[slot].back = {
+              query: { query: null, card_type: Cardback },
+              selectedImage: cardback,
+            };
+          }
+
+          lastNonNullSlot = Math.max(lastNonNullSlot, slot);
+        });
+    }
+    dispatch(addMembers({ members: newMembers.slice(0, lastNonNullSlot + 1) }));
+    handleCloseXMLModal();
   };
 
   return (
@@ -47,7 +156,7 @@ export function ImportXML() {
         <Modal.Body>
           <TextFileDropzone
             mimeTypes={{ "text/xml": [".xml"] }}
-            fileUploadCallback={myCallback}
+            fileUploadCallback={parseXMLFile}
             label="import-xml"
           />
         </Modal.Body>

--- a/frontend/src/features/import/importXML.tsx
+++ b/frontend/src/features/import/importXML.tsx
@@ -36,7 +36,11 @@ export function ImportXML() {
         <i className="bi bi-file-code" style={{ paddingRight: 0.5 + "em" }} />{" "}
         XML
       </Dropdown.Item>
-      <Modal show={showXMLModal} onHide={handleCloseXMLModal}>
+      <Modal
+        show={showXMLModal}
+        onHide={handleCloseXMLModal}
+        data-testid="import-xml"
+      >
         <Modal.Header closeButton>
           <Modal.Title>Add Cards — XML</Modal.Title>
         </Modal.Header>

--- a/frontend/src/features/import/importXML.tsx
+++ b/frontend/src/features/import/importXML.tsx
@@ -14,7 +14,7 @@ import Dropdown from "react-bootstrap/Dropdown";
 import Modal from "react-bootstrap/Modal";
 import { useDispatch, useSelector } from "react-redux";
 
-import { Cardback, ProjectMaxSize } from "@/common/constants";
+import { Cardback, ProjectMaxSize, ProjectName } from "@/common/constants";
 import { processPrefix } from "@/common/processing";
 import { SlotProjectMembers } from "@/common/types";
 import {
@@ -154,6 +154,12 @@ export function ImportXML() {
           <Modal.Title>Add Cards — XML</Modal.Title>
         </Modal.Header>
         <Modal.Body>
+          <p>Upload an XML file of cards to add to the project.</p>
+          <p>
+            The {ProjectName} website can generate an XML file representing your
+            project, and the {ProjectName} desktop tool which auto-fills your
+            order into MakePlayingCards expects a file in this format.
+          </p>
           <TextFileDropzone
             mimeTypes={{ "text/xml": [".xml"] }}
             fileUploadCallback={parseXMLFile}

--- a/frontend/src/features/import/importXML.tsx
+++ b/frontend/src/features/import/importXML.tsx
@@ -18,6 +18,8 @@ import { useDispatch, useSelector } from "react-redux";
 
 import {
   Cardback,
+  MakePlayingCards,
+  MakePlayingCardsURL,
   ProjectMaxSize,
   ProjectName,
   ToggleButtonHeight,
@@ -169,7 +171,11 @@ export function ImportXML() {
           <p>
             The {ProjectName} website can generate an XML file representing your
             project, and the {ProjectName} desktop tool which auto-fills your
-            order into MakePlayingCards expects a file in this format.
+            order into{" "}
+            <a href={MakePlayingCardsURL} target="_blank">
+              {MakePlayingCards}
+            </a>{" "}
+            expects a file in this format.
           </p>
           <Toggle
             onClick={() => setUseXMLCardback(!useXMLCardback)}

--- a/frontend/src/features/project/projectSlice.ts
+++ b/frontend/src/features/project/projectSlice.ts
@@ -124,40 +124,21 @@ export const projectSlice = createSlice({
     ) => {
       state.cardback = action.payload.selectedImage;
     },
-    addImages: (
+    addMembers: (
       state: RootState,
-      action: PayloadAction<{ lines: Array<ProcessedLine> }>
+      action: PayloadAction<{ members: Array<SlotProjectMembers> }>
     ) => {
       /**
-       * ProjectMaxSize (612 cards at time of writing) is enforced at this layer.
+       * ProjectMaxSize (612 cards at time of writing) is primarily enforced at this layer.
        */
 
-      let newMembers: Array<SlotProjectMembers> = [];
-      for (const [quantity, frontMember, backMember] of action.payload.lines) {
-        const cappedQuantity = Math.min(
-          quantity,
-          ProjectMaxSize - (state.members.length + newMembers.length)
-        );
-        if (frontMember != null || backMember != null) {
-          newMembers = [
-            ...newMembers,
-            ...Array(cappedQuantity).fill({
-              front: {
-                query: frontMember?.query,
-                selectedImage: frontMember?.selectedImage,
-              },
-              back: {
-                query: backMember?.query,
-                selectedImage: backMember?.selectedImage,
-              },
-            }),
-          ];
-          if (state.members.length + newMembers.length >= ProjectMaxSize) {
-            break;
-          }
-        }
-      }
-      state.members = [...state.members, ...newMembers];
+      state.members = [
+        ...state.members,
+        ...action.payload.members.slice(
+          0,
+          ProjectMaxSize - state.members.length
+        ),
+      ];
     },
     deleteImage: (
       state: RootState,
@@ -208,6 +189,9 @@ export const selectProjectMemberQueries = (state: RootState): Set<string> =>
 
 export const selectProjectSize = (state: RootState): number =>
   state.project.members.length;
+
+export const selectProjectCardback = (state: RootState): string | null =>
+  state.project.cardback;
 
 export const selectGeneratedXML = (state: RootState): string => {
   return generateXML(
@@ -296,7 +280,7 @@ export const {
   setSelectedImage,
   bulkSetSelectedImage,
   setSelectedCardback,
-  addImages,
+  addMembers,
   deleteImage,
 } = projectSlice.actions;
 

--- a/frontend/src/features/support/supportDeveloper.tsx
+++ b/frontend/src/features/support/supportDeveloper.tsx
@@ -2,7 +2,11 @@ import React from "react";
 import Button from "react-bootstrap/Button";
 import Modal from "react-bootstrap/Modal";
 
-import { ProjectName } from "@/common/constants";
+import {
+  MakePlayingCards,
+  MakePlayingCardsURL,
+  ProjectName,
+} from "@/common/constants";
 import { Coffee } from "@/features/ui/coffee";
 
 interface SupportDeveloperModalProps {
@@ -28,7 +32,10 @@ export function SupportDeveloperModal(props: SupportDeveloperModalProps) {
         <p>
           I&apos;m responsible for this website, the code that image repository
           servers run on, and the desktop tool that automates
-          MakePlayingCards.com.
+          <a href={MakePlayingCardsURL} target="_blank">
+            {MakePlayingCards}
+          </a>
+          .
         </p>
         <p>
           I started developing {ProjectName} in early 2020 while I was in uni to

--- a/frontend/src/pages/about.tsx
+++ b/frontend/src/pages/about.tsx
@@ -3,6 +3,7 @@ import styled from "styled-components";
 
 import { useGetBackendInfoQuery } from "@/app/api";
 import { ProjectName } from "@/common/constants";
+import { MakePlayingCards, MakePlayingCardsURL } from "@/common/constants";
 import Footer from "@/features/ui/footer";
 import Layout from "@/features/ui/layout";
 
@@ -73,8 +74,8 @@ export default function About() {
         <p>
           {ProjectName} does not condone or support the resale (or other
           commercial use) of cards printed with this website in any way. As per{" "}
-          <a href="https://www.makeplayingcards.com/" target="_blank">
-            MakePlayingCards.com
+          <a href={MakePlayingCardsURL} target="_blank">
+            {MakePlayingCards}
           </a>
           &apos;s user agreement, users acknowledge that they{" "}
           <i>
@@ -84,8 +85,8 @@ export default function About() {
         </p>
         <p>
           {ProjectName} is not affiliated with, produced by, or endorsed by{" "}
-          <a href="https://www.makeplayingcards.com/" target="_blank">
-            MakePlayingCards.com
+          <a href={MakePlayingCardsURL} target="_blank">
+            {MakePlayingCards}
           </a>{" "}
           or any other commercial entities.
         </p>

--- a/frontend/src/pages/contributions.tsx
+++ b/frontend/src/pages/contributions.tsx
@@ -6,7 +6,14 @@ import Table from "react-bootstrap/Table";
 import styled from "styled-components";
 
 import { useGetBackendInfoQuery, useGetContributionsQuery } from "@/app/api";
-import { Card, Cardback, ProjectName, Token } from "@/common/constants";
+import {
+  Card,
+  Cardback,
+  MakePlayingCards,
+  MakePlayingCardsURL,
+  ProjectName,
+  Token,
+} from "@/common/constants";
 import { SourceContribution } from "@/common/types";
 import Footer from "@/features/ui/footer";
 import Layout from "@/features/ui/layout";
@@ -109,8 +116,12 @@ function ContributionGuidelines() {
         <li>
           Limit your files to less than <b>30 MB</b> per image &mdash; this is
           the maximum that Google Scripts can return in one request and the
-          maximum that MakePlayingCards.com accepts, meaning the desktop client
-          won&apos;t work with images that exceed this limit.
+          maximum that{" "}
+          <a href={MakePlayingCardsURL} target="_blank">
+            {MakePlayingCards}
+          </a>{" "}
+          accepts, meaning the desktop client won&apos;t work with images that
+          exceed this limit.
         </li>
       </ul>
     </Alert>


### PR DESCRIPTION
# Description
* Does what it says on the tin
* This importer is a bit cooked - the XML format isn't really convenient for anyone or anything
    * The XML format should be deprecated in favour of a more machine-readable and human-readable format and eventually support for it should be removed. A problem for another day
* Pretty light on error handling here, I don't really have the energy to gold-plate this atm, will sort out later
* At least there's reasonable test coverage since this one is a bit complex
* Users are given the choice as to whether the project cardback should be updated according to the XML's cardback. Even if you don't choose this, the cards will bring along the XML's cardback

# Checklist
- [x] I have installed `pre-commit` and run the hooks with `pre-commit run`.
- [x] I have updated any related tests for code I modified or added new tests where appropriate.
- [x] I have updated any relevant documentation or created new documentation where appropriate.