### PR TITLE
Bulk card management

### DIFF
--- a/frontend/src/common/processing.test.ts
+++ b/frontend/src/common/processing.test.ts
@@ -70,7 +70,11 @@ test("empty prefix is processed correctly", () => {
 test("line that doesn't specify quantity is processed correctly", () => {
   expect(processLine("opt", dfcPairs)).toStrictEqual([
     1,
-    { query: { card_type: Card, query: "opt" }, selectedImage: undefined },
+    {
+      query: { card_type: Card, query: "opt" },
+      selectedImage: undefined,
+      selected: false,
+    },
     null,
   ]);
 });
@@ -81,6 +85,7 @@ test("non-dfc line is processed correctly", () => {
     {
       query: { card_type: Card, query: "lightning bolt" },
       selectedImage: undefined,
+      selected: false,
     },
     null,
   ]);
@@ -92,6 +97,7 @@ test("non-dfc cardback line is processed correctly", () => {
     {
       query: { card_type: Cardback, query: "black lotus" },
       selectedImage: undefined,
+      selected: false,
     },
     null,
   ]);
@@ -100,8 +106,16 @@ test("non-dfc cardback line is processed correctly", () => {
 test("manually specified front and back line is processed correctly", () => {
   expect(processLine("5 Opt | Char", dfcPairs)).toStrictEqual([
     5,
-    { query: { card_type: Card, query: "opt" }, selectedImage: undefined },
-    { query: { card_type: Card, query: "char" }, selectedImage: undefined },
+    {
+      query: { card_type: Card, query: "opt" },
+      selectedImage: undefined,
+      selected: false,
+    },
+    {
+      query: { card_type: Card, query: "char" },
+      selectedImage: undefined,
+      selected: false,
+    },
   ]);
 });
 
@@ -111,10 +125,12 @@ test("line that matches to dfc pair is processed correctly", () => {
     {
       query: { card_type: Card, query: "huntmaster of the fells" },
       selectedImage: undefined,
+      selected: false,
     },
     {
       query: { card_type: Card, query: "ravager of the fells" },
       selectedImage: undefined,
+      selected: false,
     },
   ]);
 });
@@ -127,8 +143,13 @@ test("line that matches to dfc pair but a back is also manually specified is pro
     {
       query: { card_type: Card, query: "huntmaster of the fells" },
       selectedImage: undefined,
+      selected: false,
     },
-    { query: { card_type: Token, query: "goblin" }, selectedImage: undefined },
+    {
+      query: { card_type: Token, query: "goblin" },
+      selectedImage: undefined,
+      selected: false,
+    },
   ]);
 });
 
@@ -143,10 +164,12 @@ test("a card name that's a subset of a DFC pair's front is not matched", () => {
       {
         query: { card_type: Card, query: "elesh norn" },
         selectedImage: undefined,
+        selected: false,
       },
       {
         query: { card_type: Card, query: "the argent etchings" },
         selectedImage: undefined,
+        selected: false,
       },
     ],
     [
@@ -154,6 +177,7 @@ test("a card name that's a subset of a DFC pair's front is not matched", () => {
       {
         query: { card_type: Card, query: "elesh norn grand cenobite" },
         selectedImage: undefined,
+        selected: false,
       },
       null,
     ],
@@ -163,7 +187,11 @@ test("a card name that's a subset of a DFC pair's front is not matched", () => {
 test("line that requests 0 of a card is processed correctly", () => {
   expect(processLine("0 opt", dfcPairs)).toStrictEqual([
     0,
-    { query: { card_type: Card, query: "opt" }, selectedImage: undefined },
+    {
+      query: { card_type: Card, query: "opt" },
+      selectedImage: undefined,
+      selected: false,
+    },
     null,
   ]);
 });
@@ -171,7 +199,11 @@ test("line that requests 0 of a card is processed correctly", () => {
 test("line that requests -1 of a card is processed correctly", () => {
   expect(processLine("-1 opt", dfcPairs)).toStrictEqual([
     1,
-    { query: { card_type: Card, query: "-1 opt" }, selectedImage: undefined },
+    {
+      query: { card_type: Card, query: "-1 opt" },
+      selectedImage: undefined,
+      selected: false,
+    },
     null,
   ]);
 });
@@ -185,7 +217,11 @@ test("multiple lines processed correctly", () => {
   ).toStrictEqual([
     [
       1,
-      { query: { card_type: Card, query: "char" }, selectedImage: undefined },
+      {
+        query: { card_type: Card, query: "char" },
+        selectedImage: undefined,
+        selected: false,
+      },
       null,
     ],
     [
@@ -193,10 +229,12 @@ test("multiple lines processed correctly", () => {
       {
         query: { card_type: Card, query: "delver of secrets" },
         selectedImage: undefined,
+        selected: false,
       },
       {
         query: { card_type: Card, query: "insectile aberration" },
         selectedImage: undefined,
+        selected: false,
       },
     ],
   ]);
@@ -205,7 +243,11 @@ test("multiple lines processed correctly", () => {
 test("a line specifying the selected image ID for the front is processed correctly", () => {
   expect(processLine("opt@xyz", dfcPairs)).toStrictEqual([
     1,
-    { query: { card_type: Card, query: "opt" }, selectedImage: "xyz" },
+    {
+      query: { card_type: Card, query: "opt" },
+      selectedImage: "xyz",
+      selected: false,
+    },
     null,
   ]);
 });
@@ -213,8 +255,16 @@ test("a line specifying the selected image ID for the front is processed correct
 test("a line specifying the selected image ID for both faces is processed correctly", () => {
   expect(processLine("2 opt@xyz | char@abcd", dfcPairs)).toStrictEqual([
     2,
-    { query: { card_type: Card, query: "opt" }, selectedImage: "xyz" },
-    { query: { card_type: Card, query: "char" }, selectedImage: "abcd" },
+    {
+      query: { card_type: Card, query: "opt" },
+      selectedImage: "xyz",
+      selected: false,
+    },
+    {
+      query: { card_type: Card, query: "char" },
+      selectedImage: "abcd",
+      selected: false,
+    },
   ]);
 });
 

--- a/frontend/src/common/processing.ts
+++ b/frontend/src/common/processing.ts
@@ -154,10 +154,14 @@ export function processLine(line: string, dfcPairs: DFCPairs): ProcessedLine {
   return [
     quantity,
     frontQuery != null
-      ? { query: frontQuery, selectedImage: frontSelectedImage }
+      ? {
+          query: frontQuery,
+          selectedImage: frontSelectedImage,
+          selected: false,
+        }
       : null,
     backQuery != null
-      ? { query: backQuery, selectedImage: backSelectedImage }
+      ? { query: backQuery, selectedImage: backSelectedImage, selected: false }
       : null,
   ];
 }
@@ -214,10 +218,12 @@ export function convertLinesIntoSlotProjectMembers(
           front: {
             query: frontMember?.query,
             selectedImage: frontMember?.selectedImage,
+            selected: false,
           },
           back: {
             query: backMember?.query,
             selectedImage: backMember?.selectedImage,
+            selected: false,
           },
         }),
       ];

--- a/frontend/src/common/test-constants.ts
+++ b/frontend/src/common/test-constants.ts
@@ -204,6 +204,7 @@ export const projectSelectedImage1: Project = {
       front: {
         query: { query: "my search query", card_type: Card },
         selectedImage: cardDocument1.identifier,
+        selected: false,
       },
       back: null,
     },
@@ -217,6 +218,7 @@ export const projectThreeMembersSelectedImage1: Project = {
       front: {
         query: { query: "my search query", card_type: Card },
         selectedImage: cardDocument1.identifier,
+        selected: false,
       },
       back: null,
     },
@@ -224,6 +226,7 @@ export const projectThreeMembersSelectedImage1: Project = {
       front: {
         query: { query: "my search query", card_type: Card },
         selectedImage: cardDocument1.identifier,
+        selected: false,
       },
       back: null,
     },
@@ -231,6 +234,7 @@ export const projectThreeMembersSelectedImage1: Project = {
       front: {
         query: { query: "my search query", card_type: Card },
         selectedImage: cardDocument1.identifier,
+        selected: false,
       },
       back: null,
     },
@@ -244,6 +248,7 @@ export const projectSelectedImage2: Project = {
       front: {
         query: { query: "my search query", card_type: Card },
         selectedImage: cardDocument2.identifier,
+        selected: false,
       },
       back: null,
     },

--- a/frontend/src/common/test-utils.tsx
+++ b/frontend/src/common/test-utils.tsx
@@ -236,6 +236,58 @@ export async function openCardSlotGridSelector(
   );
 }
 
+export async function selectSlot(slot: number, face: Faces) {
+  const cardElement = screen.getByTestId(`${face}-slot${slot - 1}`);
+  fireEvent.click(
+    within(cardElement).getByLabelText(`select-${face}${slot - 1}`)!.children[0]
+  );
+  await waitFor(() =>
+    expect(
+      within(cardElement).getByLabelText(`select-${face}${slot - 1}`)!
+        .children[0]
+    ).toHaveClass("bi-check-square")
+  );
+}
+
+export async function deselectSlot(slot: number, face: Faces) {
+  const cardElement = screen.getByTestId(`${face}-slot${slot - 1}`);
+  fireEvent.click(
+    within(cardElement).getByLabelText(`select-${face}${slot - 1}`)!.children[0]
+  );
+  await waitFor(() =>
+    expect(
+      within(cardElement).getByLabelText(`select-${face}${slot - 1}`)!
+        .children[0]
+    ).toHaveClass("bi-square")
+  );
+}
+
+export async function changeQueryForSelectedImages(query: string) {
+  screen.getByText("Modify").click();
+  await waitFor(() => screen.getByText("Change Query").click());
+  const textField = await waitFor(() =>
+    screen.getByLabelText("change-selected-image-queries-text")
+  );
+  fireEvent.change(textField, { target: { value: query } });
+  screen.getByLabelText("change-selected-image-queries-submit").click();
+}
+
+export async function changeImageForSelectedImages(cardName: string) {
+  screen.getByText("Modify").click();
+  await waitFor(() => screen.getByText("Change Version").click());
+  await waitFor(() => expect(screen.getByText("Option 1")));
+  await waitFor(() =>
+    within(screen.getByTestId("bulk-grid-selector"))
+      .getByAltText(cardName)
+      .click()
+  );
+}
+
+export async function deleteSelectedImages() {
+  screen.getByText("Modify").click();
+  await waitFor(() => screen.getByText("Delete Slots").click());
+}
+
 export async function openSearchSettingsModal() {
   screen.getByText("Search Settings", { exact: false }).click();
   await waitFor(() => expect(screen.getByText("Search Settings")));

--- a/frontend/src/common/types.ts
+++ b/frontend/src/common/types.ts
@@ -159,6 +159,7 @@ export interface SearchQuery {
 export interface ProjectMember {
   query: SearchQuery;
   selectedImage?: string;
+  selected: boolean;
 }
 
 export type SlotProjectMembers = {

--- a/frontend/src/features/card/__snapshots__/cardSlot.test.tsx.snap
+++ b/frontend/src/features/card/__snapshots__/cardSlot.test.tsx.snap
@@ -16,6 +16,7 @@ exports[`the html structure of a CardSlot with a single search result, image sel
         Slot 1
       </p>
       <button
+        aria-label="select-front0"
         class="card-select"
       >
         <i
@@ -96,6 +97,7 @@ exports[`the html structure of a CardSlot with a single search result, no image 
         Slot 1
       </p>
       <button
+        aria-label="select-front0"
         class="card-select"
       >
         <i
@@ -257,6 +259,7 @@ exports[`the html structure of a CardSlot with multiple search results, image se
         Slot 1
       </p>
       <button
+        aria-label="select-front0"
         class="card-select"
       >
         <i

--- a/frontend/src/features/card/__snapshots__/cardSlot.test.tsx.snap
+++ b/frontend/src/features/card/__snapshots__/cardSlot.test.tsx.snap
@@ -16,10 +16,10 @@ exports[`the html structure of a CardSlot with a single search result, image sel
         Slot 1
       </p>
       <button
-        class="padlock"
+        class="card-select"
       >
         <i
-          class="bi bi-unlock"
+          class="bi bi-square"
         />
       </button>
       <button
@@ -96,10 +96,91 @@ exports[`the html structure of a CardSlot with a single search result, no image 
         Slot 1
       </p>
       <button
-        class="padlock"
+        class="card-select"
       >
         <i
-          class="bi bi-unlock"
+          class="bi bi-square"
+        />
+      </button>
+      <button
+        class="remove"
+      >
+        <i
+          aria-label="remove-front0"
+          class="bi bi-x-circle"
+        />
+      </button>
+    </div>
+    <div>
+      <div
+        class="rounded-lg shadow-lg ratio ratio-7x5"
+        style="z-index: 0;"
+      >
+        <img
+          alt="Card 1"
+          class="card-img card-img-fade-in"
+          data-nimg="fill"
+          decoding="async"
+          loading="lazy"
+          src=""
+          style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent; z-index: 1; opacity: 1;"
+        />
+      </div>
+      <div
+        class="mb-0 text-center card-body"
+      >
+        <div
+          class="mpccard-name card-subtitle h6"
+        >
+          Card 1
+        </div>
+        <div
+          class="mpccard-spacing"
+        >
+          <p
+            class="mpccard-source card-text"
+          >
+            Source 1 [1200 DPI]
+          </p>
+        </div>
+      </div>
+    </div>
+    <div
+      class="padding-top card-footer"
+      style="padding-top: 50px;"
+    >
+      <p
+        class="mpccard-counter text-center align-middle"
+      >
+        1 / 
+        1
+      </p>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`the html structure of a CardSlot with a single search result, slot selected 1`] = `
+<div
+  data-testid="front-slot0"
+>
+  <div
+    class="mpccard mpccard-hover card"
+  >
+    <div
+      class="pb-0 text-center card-header"
+    >
+      <p
+        class="mpccard-slot"
+      >
+        Slot 1
+      </p>
+      <button
+        aria-label="select-front0"
+        class="card-select"
+      >
+        <i
+          class="bi bi-check-square"
         />
       </button>
       <button
@@ -176,10 +257,10 @@ exports[`the html structure of a CardSlot with multiple search results, image se
         Slot 1
       </p>
       <button
-        class="padlock"
+        class="card-select"
       >
         <i
-          class="bi bi-unlock"
+          class="bi bi-square"
         />
       </button>
       <button

--- a/frontend/src/features/card/cardSlot.test.tsx
+++ b/frontend/src/features/card/cardSlot.test.tsx
@@ -61,6 +61,39 @@ test("the html structure of a CardSlot with a single search result, no image sel
   expect(screen.getByTestId("front-slot0")).toMatchSnapshot();
 });
 
+test("the html structure of a CardSlot with a single search result, slot selected", async () => {
+  server.use(
+    cardDocumentsOneResult,
+    sourceDocumentsOneResult,
+    searchResultsOneResult
+  );
+  renderWithProviders(<App />, {
+    preloadedState: {
+      backend: localBackend,
+      project: {
+        members: [
+          {
+            front: {
+              query: { query: "my search query", card_type: Card },
+              selectedImage: null,
+            },
+            back: null,
+          },
+        ],
+        cardback: null,
+      },
+    },
+  });
+  await expectCardGridSlotState(1, Front, cardDocument1.name, 1, 1);
+  screen.getByLabelText("select-front0").click();
+  await waitFor(() =>
+    expect(screen.getByLabelText("select-front0").firstChild).toHaveClass(
+      "bi-check-square"
+    )
+  );
+  expect(screen.getByTestId("front-slot0")).toMatchSnapshot();
+});
+
 test("the html structure of a CardSlot with a single search result, image selected", async () => {
   server.use(
     cardDocumentsOneResult,

--- a/frontend/src/features/card/cardSlot.test.tsx
+++ b/frontend/src/features/card/cardSlot.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor } from "@testing-library/react";
+import { fireEvent, screen, waitFor } from "@testing-library/react";
 
 import App from "@/app/app";
 import { Back, Card, Front } from "@/common/constants";
@@ -413,4 +413,53 @@ test("CardSlot defaults to project cardback for backs with no search query", asy
 
   await expectCardGridSlotState(1, Back, cardDocument1.name, 1, 2);
   await expectCardbackSlotState(cardDocument1.name, 1, 2);
+});
+
+test.skip("double clicking the select button selects all slots for the same query", async () => {
+  server.use(
+    cardDocumentsOneResult,
+    sourceDocumentsOneResult,
+    searchResultsOneResult
+  );
+  renderWithProviders(<App />, {
+    preloadedState: {
+      backend: localBackend,
+      project: {
+        members: [
+          {
+            front: {
+              query: { query: "my search query", card_type: Card },
+              selectedImage: null,
+            },
+            back: null,
+          },
+          {
+            front: {
+              query: { query: "my search query", card_type: Card },
+              selectedImage: null,
+            },
+            back: null,
+          },
+        ],
+        cardback: null,
+      },
+    },
+  });
+  await expectCardGridSlotState(1, Front, cardDocument1.name, 1, 1);
+  await expectCardGridSlotState(2, Front, cardDocument1.name, 1, 1);
+  // fireEvent.doubleClick(screen.getByLabelText("select-front0"));
+  screen.getByLabelText("select-front0");
+  // const selectButton = screen.getByLabelText("select-front0");
+  // selectButton.click()
+  // selectButton.click()
+  await waitFor(() =>
+    expect(screen.getByLabelText("select-front0").firstChild).toHaveClass(
+      "bi-check-square"
+    )
+  );
+  await waitFor(() =>
+    expect(screen.getByLabelText("select-front1").firstChild).toHaveClass(
+      "bi-check-square"
+    )
+  );
 });

--- a/frontend/src/features/card/cardSlot.tsx
+++ b/frontend/src/features/card/cardSlot.tsx
@@ -17,6 +17,7 @@ import { wrapIndex } from "@/common/utils";
 import { MemoizedCard } from "@/features/card/card";
 import { GridSelector } from "@/features/card/gridSelector";
 import {
+  bulkSetMemberSelection,
   deleteSlot,
   setSelectedImage,
   toggleMemberSelection,
@@ -177,8 +178,15 @@ export function CardSlot({
     dispatch(deleteSlot({ slot }));
   };
 
-  const toggleSelectionForThisMember = () => {
-    dispatch(toggleMemberSelection({ slot, face }));
+  const toggleSelectionForThisMember = (
+    event: React.MouseEvent<HTMLButtonElement>
+  ) => {
+    if (event.detail == 2) {
+      // double-click
+      dispatch(bulkSetMemberSelection({ slot, face }));
+    } else {
+      dispatch(toggleMemberSelection({ slot, face }));
+    }
   };
 
   function setSelectedImageFromDelta(delta: number): void {

--- a/frontend/src/features/card/cardSlot.tsx
+++ b/frontend/src/features/card/cardSlot.tsx
@@ -17,7 +17,7 @@ import { wrapIndex } from "@/common/utils";
 import { MemoizedCard } from "@/features/card/card";
 import { GridSelector } from "@/features/card/gridSelector";
 import {
-  bulkSetMemberSelection,
+  bulkAlignMemberSelection,
   deleteSlot,
   setSelectedImage,
   toggleMemberSelection,
@@ -183,7 +183,7 @@ export function CardSlot({
   ) => {
     if (event.detail == 2) {
       // double-click
-      dispatch(bulkSetMemberSelection({ slot, face }));
+      dispatch(bulkAlignMemberSelection({ slot, face }));
     } else {
       dispatch(toggleMemberSelection({ slot, face }));
     }

--- a/frontend/src/features/card/cardSlot.tsx
+++ b/frontend/src/features/card/cardSlot.tsx
@@ -16,7 +16,11 @@ import { Faces, SearchQuery } from "@/common/types";
 import { wrapIndex } from "@/common/utils";
 import { MemoizedCard } from "@/features/card/card";
 import { GridSelector } from "@/features/card/gridSelector";
-import { deleteImage, setSelectedImage } from "@/features/project/projectSlice";
+import {
+  deleteSlot,
+  setSelectedImage,
+  toggleMemberSelection,
+} from "@/features/project/projectSlice";
 
 interface CardSlotProps {
   searchQuery: SearchQuery | undefined;
@@ -169,8 +173,12 @@ export function CardSlot({
       : undefined;
 
   // TODO: add a confirmation prompt here. yes/no/yes and don't ask again.
-  const deleteThisImage = () => {
-    dispatch(deleteImage({ slot }));
+  const deleteThisSlot = () => {
+    dispatch(deleteSlot({ slot }));
+  };
+
+  const toggleSelectionForThisMember = () => {
+    dispatch(toggleMemberSelection({ slot, face }));
   };
 
   function setSelectedImageFromDelta(delta: number): void {
@@ -193,16 +201,23 @@ export function CardSlot({
   }
 
   const cardHeaderTitle = `Slot ${slot + 1}`;
-  // TODO: the padlock should be replaced by a checkbox showing if the card is selected or not
   const cardHeaderButtons = (
     <>
-      <button className="padlock">
-        <i className="bi bi-unlock"></i>
+      <button
+        className="card-select"
+        onClick={toggleSelectionForThisMember}
+        aria-label={`select-${face}${slot}`}
+      >
+        <i
+          className={`bi bi${
+            projectMember?.selected ?? false ? "-check" : ""
+          }-square`}
+        ></i>
       </button>
       <button className="remove">
         <i
           className="bi bi-x-circle"
-          onClick={deleteThisImage}
+          onClick={deleteThisSlot}
           aria-label={`remove-${face}${slot}`}
         ></i>
       </button>

--- a/frontend/src/features/card/commonCardback.tsx
+++ b/frontend/src/features/card/commonCardback.tsx
@@ -15,7 +15,7 @@ import { MemoizedCard } from "@/features/card/card";
 import { MemoizedCardDetailedView } from "@/features/card/cardDetailedView";
 import { GridSelector } from "@/features/card/gridSelector";
 import {
-  bulkSetSelectedImage,
+  bulkReplaceSelectedImage,
   setSelectedCardback,
 } from "@/features/project/projectSlice";
 
@@ -42,7 +42,7 @@ export function CommonCardbackGridSelector({
   function setSelectedImageFromIdentifier(selectedImage: string): void {
     if (projectCardback != null) {
       dispatch(
-        bulkSetSelectedImage({
+        bulkReplaceSelectedImage({
           currentImage: projectCardback,
           selectedImage,
           face: Back,
@@ -120,7 +120,7 @@ export function CommonCardback({ selectedImage }: CommonCardbackProps) {
           wrapIndex(selectedImageIndex + delta, searchResults.length)
         ];
       dispatch(
-        bulkSetSelectedImage({
+        bulkReplaceSelectedImage({
           currentImage: selectedImage,
           selectedImage: newImage,
           face: Back,

--- a/frontend/src/features/import/importXML.tsx
+++ b/frontend/src/features/import/importXML.tsx
@@ -105,6 +105,7 @@ export function ImportXML() {
               selectedImage:
                 backCardElement.getElementsByTagName("id")[0].textContent ??
                 undefined,
+              selected: false,
             };
 
             lastNonNullSlot = Math.max(lastNonNullSlot, slot);
@@ -131,6 +132,7 @@ export function ImportXML() {
             selectedImage:
               frontCardElement.getElementsByTagName("id")[0].textContent ??
               undefined,
+            selected: false,
           };
 
           // apply the uploaded XML's cardback if the card doesn't have a matching back
@@ -138,6 +140,7 @@ export function ImportXML() {
             newMembers[slot].back = {
               query: { query: null, card_type: Cardback },
               selectedImage: cardback,
+              selected: false,
             };
           }
 

--- a/frontend/src/features/project/bulkManagement.test.tsx
+++ b/frontend/src/features/project/bulkManagement.test.tsx
@@ -1,0 +1,255 @@
+import { screen, waitFor } from "@testing-library/react";
+
+import App from "@/app/app";
+import { Front } from "@/common/constants";
+import {
+  cardDocument1,
+  cardDocument2,
+  cardDocument5,
+  localBackend,
+} from "@/common/test-constants";
+import {
+  changeImageForSelectedImages,
+  changeQueryForSelectedImages,
+  deleteSelectedImages,
+  deselectSlot,
+  expectCardGridSlotState,
+  expectCardSlotToNotExist,
+  importText,
+  renderWithProviders,
+  selectSlot,
+} from "@/common/test-utils";
+import {
+  cardbacksOneResult,
+  cardDocumentsOneResult,
+  cardDocumentsSixResults,
+  cardDocumentsThreeResults,
+  defaultHandlers,
+  searchResultsOneResult,
+  searchResultsSixResults,
+  searchResultsThreeResults,
+  sourceDocumentsOneResult,
+  sourceDocumentsThreeResults,
+} from "@/mocks/handlers";
+import { server } from "@/mocks/server";
+
+test("selecting a single card and changing its query", async () => {
+  server.use(
+    cardDocumentsSixResults,
+    cardbacksOneResult,
+    sourceDocumentsThreeResults,
+    searchResultsSixResults,
+    ...defaultHandlers
+  );
+  renderWithProviders(<App />, {
+    preloadedState: {
+      backend: localBackend,
+      project: {
+        members: [],
+        cardback: cardDocument5.identifier,
+      },
+    },
+  });
+
+  await importText("query 1");
+  await expectCardGridSlotState(1, Front, cardDocument1.name, 1, 1);
+
+  await selectSlot(1, Front);
+  await changeQueryForSelectedImages("query 2");
+  await expectCardGridSlotState(1, Front, cardDocument2.name, 1, 1);
+});
+
+test("selecting multiple cards and changing both of their queries", async () => {
+  server.use(
+    cardDocumentsSixResults,
+    cardbacksOneResult,
+    sourceDocumentsThreeResults,
+    searchResultsSixResults,
+    ...defaultHandlers
+  );
+  renderWithProviders(<App />, {
+    preloadedState: {
+      backend: localBackend,
+      project: {
+        members: [],
+        cardback: cardDocument5.identifier,
+      },
+    },
+  });
+
+  await importText("2x query 1");
+  await expectCardGridSlotState(1, Front, cardDocument1.name, 1, 1);
+  await expectCardGridSlotState(2, Front, cardDocument1.name, 1, 1);
+
+  await selectSlot(1, Front);
+  await selectSlot(2, Front);
+  await changeQueryForSelectedImages("query 2");
+  await expectCardGridSlotState(1, Front, cardDocument2.name, 1, 1);
+  await expectCardGridSlotState(2, Front, cardDocument2.name, 1, 1);
+});
+
+test("selecting a single card and changing its selected image", async () => {
+  server.use(
+    cardDocumentsThreeResults,
+    cardbacksOneResult,
+    sourceDocumentsOneResult,
+    searchResultsThreeResults,
+    ...defaultHandlers
+  );
+  renderWithProviders(<App />, {
+    preloadedState: {
+      backend: localBackend,
+      project: {
+        members: [],
+        cardback: cardDocument5.identifier,
+      },
+    },
+  });
+
+  await importText("my search query");
+  await expectCardGridSlotState(1, Front, cardDocument1.name, 1, 3);
+
+  await selectSlot(1, Front);
+  await changeImageForSelectedImages(cardDocument2.name);
+  await expectCardGridSlotState(1, Front, cardDocument2.name, 2, 3);
+});
+
+test("selecting multiple cards with the same query and changing both of their selected images", async () => {
+  server.use(
+    cardDocumentsThreeResults,
+    cardbacksOneResult,
+    sourceDocumentsOneResult,
+    searchResultsThreeResults,
+    ...defaultHandlers
+  );
+  renderWithProviders(<App />, {
+    preloadedState: {
+      backend: localBackend,
+      project: {
+        members: [],
+        cardback: cardDocument5.identifier,
+      },
+    },
+  });
+
+  await importText("2x my search query");
+  await expectCardGridSlotState(1, Front, cardDocument1.name, 1, 3);
+  await expectCardGridSlotState(2, Front, cardDocument1.name, 1, 3);
+
+  await selectSlot(1, Front);
+  await selectSlot(2, Front);
+  await changeImageForSelectedImages(cardDocument2.name);
+  await expectCardGridSlotState(1, Front, cardDocument2.name, 2, 3);
+  await expectCardGridSlotState(2, Front, cardDocument2.name, 2, 3);
+});
+
+test("cannot change the images of multiple selected images when they don't share the same query", async () => {
+  server.use(
+    cardDocumentsSixResults,
+    cardbacksOneResult,
+    sourceDocumentsThreeResults,
+    searchResultsSixResults,
+    ...defaultHandlers
+  );
+  renderWithProviders(<App />, {
+    preloadedState: {
+      backend: localBackend,
+      project: {
+        members: [],
+        cardback: cardDocument5.identifier,
+      },
+    },
+  });
+
+  await importText("query 1\nquery 2");
+  await expectCardGridSlotState(1, Front, cardDocument1.name, 1, 1);
+  await expectCardGridSlotState(2, Front, cardDocument2.name, 1, 1);
+
+  await selectSlot(1, Front);
+  await selectSlot(2, Front);
+
+  screen.getByText("Modify").click();
+  await waitFor(() =>
+    expect(screen.queryByText("Change Version")).not.toBeInTheDocument()
+  );
+});
+
+test("selecting a single card and deleting it", async () => {
+  server.use(
+    cardDocumentsOneResult,
+    cardbacksOneResult,
+    sourceDocumentsOneResult,
+    searchResultsOneResult,
+    ...defaultHandlers
+  );
+  renderWithProviders(<App />, {
+    preloadedState: {
+      backend: localBackend,
+      project: {
+        members: [],
+        cardback: cardDocument5.identifier,
+      },
+    },
+  });
+
+  await importText("my search query");
+  await expectCardGridSlotState(1, Front, cardDocument1.name, 1, 1);
+
+  await selectSlot(1, Front);
+  await deleteSelectedImages();
+  await expectCardSlotToNotExist(1);
+});
+
+test("selecting multiple cards and deleting them", async () => {
+  server.use(
+    cardDocumentsOneResult,
+    cardbacksOneResult,
+    sourceDocumentsOneResult,
+    searchResultsOneResult,
+    ...defaultHandlers
+  );
+  renderWithProviders(<App />, {
+    preloadedState: {
+      backend: localBackend,
+      project: {
+        members: [],
+        cardback: cardDocument5.identifier,
+      },
+    },
+  });
+
+  await importText("2x my search query");
+  await expectCardGridSlotState(1, Front, cardDocument1.name, 1, 1);
+  await expectCardGridSlotState(2, Front, cardDocument1.name, 1, 1);
+
+  await selectSlot(1, Front);
+  await selectSlot(2, Front);
+  await deleteSelectedImages();
+  await expectCardSlotToNotExist(1);
+  await expectCardSlotToNotExist(2);
+});
+
+test("selecting then clearing the selection", async () => {
+  server.use(
+    cardDocumentsOneResult,
+    cardbacksOneResult,
+    sourceDocumentsOneResult,
+    searchResultsOneResult,
+    ...defaultHandlers
+  );
+  renderWithProviders(<App />, {
+    preloadedState: {
+      backend: localBackend,
+      project: {
+        members: [],
+        cardback: cardDocument5.identifier,
+      },
+    },
+  });
+
+  await importText("my search query");
+  await expectCardGridSlotState(1, Front, cardDocument1.name, 1, 1);
+
+  await selectSlot(1, Front);
+  await deselectSlot(1, Front);
+});

--- a/frontend/src/features/project/bulkManagement.tsx
+++ b/frontend/src/features/project/bulkManagement.tsx
@@ -1,0 +1,154 @@
+/**
+ * This component exposes a bootstrap Alert to display the number of selected images
+ * and facilitate operating on the selected images in bulk - updating their queries
+ * or deleting them from the project.
+ */
+
+import React, { FormEvent, useState } from "react";
+import Alert from "react-bootstrap/Alert";
+import Button from "react-bootstrap/Button";
+import Dropdown from "react-bootstrap/Dropdown";
+import Form from "react-bootstrap/Form";
+import Modal from "react-bootstrap/Modal";
+import Stack from "react-bootstrap/Stack";
+import { useDispatch, useSelector } from "react-redux";
+
+import { useGetSampleCardsQuery } from "@/app/api";
+import { AppDispatch } from "@/app/store";
+import { Card } from "@/common/constants";
+import { Faces } from "@/common/types";
+import { selectBackendURL } from "@/features/backend/backendSlice";
+import {
+  bulkSetQuery,
+  selectSelectedProjectMembers,
+} from "@/features/project/projectSlice";
+
+interface MutateSelectedImageQueriesProps {
+  selectedProjectMembers: Array<[Faces, number]>;
+}
+
+function ChangeSelectedImageQueries({
+  selectedProjectMembers,
+}: MutateSelectedImageQueriesProps) {
+  const dispatch = useDispatch<AppDispatch>();
+
+  const [
+    showChangeSelectedImageQueriesModal,
+    setShowChangeSelectedImageQueriesModal,
+  ] = useState<boolean>(false);
+  const handleCloseChangeSelectedImageQueriesModal = () =>
+    setShowChangeSelectedImageQueriesModal(false);
+  const handleShowChangeSelectedImageQueriesModal = () =>
+    setShowChangeSelectedImageQueriesModal(true);
+  const [
+    changeSelectedImageQueriesModalValue,
+    setChangeSelectedImageQueriesModalValue,
+  ] = useState("");
+
+  const handleSubmitChangeSelectedImageQueriesModal = (
+    event: FormEvent<HTMLFormElement>
+  ) => {
+    event.preventDefault(); // to avoid reloading the page
+    dispatch(
+      bulkSetQuery({
+        query: changeSelectedImageQueriesModalValue,
+        slots: selectedProjectMembers,
+      })
+    );
+    handleCloseChangeSelectedImageQueriesModal();
+  };
+
+  const backendURL = useSelector(selectBackendURL);
+  const sampleCardsQuery = useGetSampleCardsQuery(undefined, {
+    skip: backendURL == null,
+  });
+  const placeholderCardName =
+    sampleCardsQuery.data != null &&
+    (sampleCardsQuery.data ?? {})[Card][0] != null
+      ? sampleCardsQuery.data[Card][0].name
+      : "";
+
+  return (
+    <>
+      <Dropdown.Item onClick={handleShowChangeSelectedImageQueriesModal}>
+        <i
+          className="bi bi-arrow-repeat"
+          style={{ paddingRight: 0.5 + "em" }}
+        />{" "}
+        Change Query
+      </Dropdown.Item>
+      <Modal
+        show={showChangeSelectedImageQueriesModal}
+        onHide={handleCloseChangeSelectedImageQueriesModal}
+        onExited={() => setChangeSelectedImageQueriesModalValue("")}
+      >
+        <Modal.Header closeButton>
+          <Modal.Title>Change Query</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          Type in a query to update the selected images with and hit{" "}
+          <b>Submit</b>.
+          <hr />
+          <Form
+            onSubmit={handleSubmitChangeSelectedImageQueriesModal}
+            id="changeSelectedImageQueriesForm"
+          >
+            <Form.Group className="mb-3">
+              <Form.Control
+                type="text"
+                placeholder={placeholderCardName}
+                onChange={(event) =>
+                  setChangeSelectedImageQueriesModalValue(event.target.value)
+                }
+                value={changeSelectedImageQueriesModalValue}
+                aria-label="change-selected-image-queries-text"
+              />
+            </Form.Group>
+          </Form>
+        </Modal.Body>
+        <Modal.Footer>
+          <Button
+            variant="secondary"
+            onClick={handleCloseChangeSelectedImageQueriesModal}
+          >
+            Close
+          </Button>
+          <Button
+            type="submit"
+            form="changeSelectedImageQueriesForm"
+            variant="primary"
+            aria-label="change-selected-image-queries-submit"
+          >
+            Submit
+          </Button>
+        </Modal.Footer>
+      </Modal>
+    </>
+  );
+}
+
+export function SelectedImagesStatus() {
+  const selectedProjectMembers = useSelector(selectSelectedProjectMembers);
+  return (
+    <>
+      <Alert
+        variant="primary"
+        style={{ display: selectedProjectMembers.length > 0 ? "" : "none" }}
+      >
+        <Stack direction="horizontal" gap={2}>
+          <b>{selectedProjectMembers.length}</b> image
+          {selectedProjectMembers.length != 1 && "s"} selected.
+          <Dropdown className="ms-auto">
+            <Dropdown.Toggle variant="secondary">Modify</Dropdown.Toggle>
+            <Dropdown.Menu>
+              <ChangeSelectedImageQueries
+                selectedProjectMembers={selectedProjectMembers}
+              />
+            </Dropdown.Menu>
+          </Dropdown>
+        </Stack>
+      </Alert>
+      {/*)*/}
+    </>
+  );
+}

--- a/frontend/src/features/project/bulkManagement.tsx
+++ b/frontend/src/features/project/bulkManagement.tsx
@@ -22,6 +22,7 @@ import { selectBackendURL } from "@/features/backend/backendSlice";
 import { GridSelector } from "@/features/card/gridSelector";
 import {
   bulkDeleteSlots,
+  bulkSetMemberSelection,
   bulkSetQuery,
   bulkSetSelectedImage,
   selectSelectedProjectMembers,
@@ -224,6 +225,27 @@ function DeleteSelectedImages({
   );
 }
 
+function ClearImageSelection({
+  selectedProjectMembers,
+}: MutateSelectedImageQueriesProps) {
+  const dispatch = useDispatch<AppDispatch>();
+
+  const onClick = () =>
+    dispatch(
+      bulkSetMemberSelection({
+        selectedStatus: false,
+        slots: selectedProjectMembers,
+      })
+    );
+
+  return (
+    <Dropdown.Item onClick={onClick}>
+      <i className="bi bi-circle" style={{ paddingRight: 0.5 + "em" }} /> Clear
+      Selection
+    </Dropdown.Item>
+  );
+}
+
 export function SelectedImagesStatus() {
   const selectedProjectMembers = useSelector(selectSelectedProjectMembers);
   return (
@@ -245,6 +267,9 @@ export function SelectedImagesStatus() {
                 selectedProjectMembers={selectedProjectMembers}
               />
               <DeleteSelectedImages
+                selectedProjectMembers={selectedProjectMembers}
+              />
+              <ClearImageSelection
                 selectedProjectMembers={selectedProjectMembers}
               />
             </Dropdown.Menu>

--- a/frontend/src/features/project/bulkManagement.tsx
+++ b/frontend/src/features/project/bulkManagement.tsx
@@ -21,6 +21,7 @@ import { Faces, SearchQuery } from "@/common/types";
 import { selectBackendURL } from "@/features/backend/backendSlice";
 import { GridSelector } from "@/features/card/gridSelector";
 import {
+  bulkDeleteSlots,
   bulkSetQuery,
   bulkSetSelectedImage,
   selectSelectedProjectMembers,
@@ -79,9 +80,9 @@ function ChangeSelectedImageSelectedImages({
     firstQuery != null &&
     firstQuery.query != null &&
     allSelectedProjectMembersHaveTheSameQuery
-      ? state.searchResults.searchResults[firstQuery.query][
+      ? (state.searchResults.searchResults[firstQuery.query] ?? {})[
           firstQuery.card_type
-        ]
+        ] ?? []
       : []
   );
 
@@ -207,6 +208,22 @@ function ChangeSelectedImageQueries({
   );
 }
 
+function DeleteSelectedImages({
+  selectedProjectMembers,
+}: MutateSelectedImageQueriesProps) {
+  const dispatch = useDispatch<AppDispatch>();
+
+  const slots = selectedProjectMembers.map(([face, slot]) => slot);
+  const onClick = () => dispatch(bulkDeleteSlots({ slots: slots }));
+
+  return (
+    <Dropdown.Item onClick={onClick}>
+      <i className="bi bi-x-circle" style={{ paddingRight: 0.5 + "em" }} />{" "}
+      Delete Slots
+    </Dropdown.Item>
+  );
+}
+
 export function SelectedImagesStatus() {
   const selectedProjectMembers = useSelector(selectSelectedProjectMembers);
   return (
@@ -225,6 +242,9 @@ export function SelectedImagesStatus() {
                 selectedProjectMembers={selectedProjectMembers}
               />
               <ChangeSelectedImageQueries
+                selectedProjectMembers={selectedProjectMembers}
+              />
+              <DeleteSelectedImages
                 selectedProjectMembers={selectedProjectMembers}
               />
             </Dropdown.Menu>

--- a/frontend/src/features/project/projectSlice.ts
+++ b/frontend/src/features/project/projectSlice.ts
@@ -303,9 +303,7 @@ export const selectProjectMembers = (
 ): Array<SlotProjectMembers> => state.project.members;
 
 // TODO: this is a bit disgusting
-export const selectSelectedProjectMembers = (
-  state: RootState
-): Array<[Faces, number]> =>
+export const selectSelectedSlots = (state: RootState): Array<[Faces, number]> =>
   state.project.members.flatMap((x: SlotProjectMembers, index: number) =>
     (x.front?.selected === true ? [[Front, index]] : []).concat(
       x.back?.selected === true ? [[Back, index]] : []

--- a/frontend/src/features/project/projectSlice.ts
+++ b/frontend/src/features/project/projectSlice.ts
@@ -24,6 +24,7 @@ const initialState: Project = {
       front: {
         query: { query: "island", card_type: Card },
         selectedImage: undefined,
+        selected: false,
       },
       back: null,
     },
@@ -31,6 +32,7 @@ const initialState: Project = {
       front: {
         query: { query: "grim monolith", card_type: Card },
         selectedImage: undefined,
+        selected: false,
       },
       back: null,
     },
@@ -38,6 +40,7 @@ const initialState: Project = {
       front: {
         query: { query: "past in flames", card_type: Card },
         selectedImage: undefined,
+        selected: false,
       },
       back: null,
     },
@@ -45,6 +48,7 @@ const initialState: Project = {
       front: {
         query: { query: "necropotence", card_type: Card },
         selectedImage: undefined,
+        selected: false,
       },
       back: null,
     },

--- a/frontend/src/features/project/projectSlice.ts
+++ b/frontend/src/features/project/projectSlice.ts
@@ -61,7 +61,7 @@ export const projectSlice = createSlice({
   initialState,
   reducers: {
     setSelectedImage: (
-      state: RootState,
+      state,
       action: PayloadAction<{
         face: Faces;
         slot: number;
@@ -76,6 +76,7 @@ export const projectSlice = createSlice({
             card_type: Card,
           },
           selectedImage: action.payload.selectedImage,
+          selected: false,
         };
       } else {
         state.members[action.payload.slot][action.payload.face]!.selectedImage =
@@ -83,7 +84,7 @@ export const projectSlice = createSlice({
       }
     },
     bulkSetSelectedImage: (
-      state: RootState,
+      state,
       action: PayloadAction<{
         face: Faces;
         currentImage: string;
@@ -113,6 +114,7 @@ export const projectSlice = createSlice({
               card_type: Card,
             },
             selectedImage: action.payload.selectedImage,
+            selected: false,
           };
         } else {
           state.members[slot][action.payload.face]!.selectedImage =
@@ -122,13 +124,13 @@ export const projectSlice = createSlice({
       }
     },
     setSelectedCardback: (
-      state: RootState,
+      state,
       action: PayloadAction<{ selectedImage: string }>
     ) => {
       state.cardback = action.payload.selectedImage;
     },
     addMembers: (
-      state: RootState,
+      state,
       action: PayloadAction<{ members: Array<SlotProjectMembers> }>
     ) => {
       /**
@@ -143,10 +145,21 @@ export const projectSlice = createSlice({
         ),
       ];
     },
-    deleteImage: (
-      state: RootState,
-      action: PayloadAction<{ slot: number }>
+    toggleMemberSelection: (
+      state,
+      action: PayloadAction<{
+        face: Faces;
+        slot: number;
+      }>
     ) => {
+      if (
+        (state.members[action.payload.slot] ?? {})[action.payload.face] != null
+      ) {
+        state.members[action.payload.slot][action.payload.face]!.selected =
+          !state.members[action.payload.slot][action.payload.face]!.selected;
+      }
+    },
+    deleteSlot: (state, action: PayloadAction<{ slot: number }>) => {
       // TODO: this breaks when you add a DFC card then delete the different card from the project.
       state.members.splice(action.payload.slot, 1);
     },
@@ -284,7 +297,8 @@ export const {
   bulkSetSelectedImage,
   setSelectedCardback,
   addMembers,
-  deleteImage,
+  toggleMemberSelection,
+  deleteSlot,
 } = projectSlice.actions;
 
 export default projectSlice.reducer;

--- a/frontend/src/features/project/projectSlice.ts
+++ b/frontend/src/features/project/projectSlice.ts
@@ -252,6 +252,18 @@ export const projectSlice = createSlice({
       // TODO: this breaks when you add a DFC card then delete the different card from the project.
       state.members.splice(action.payload.slot, 1);
     },
+    bulkDeleteSlots: (
+      state,
+      action: PayloadAction<{ slots: Array<number> }>
+    ) => {
+      action.payload.slots
+        .sort(function (a, b) {
+          return b - a;
+        })
+        .forEach(function (index) {
+          state.members.splice(index, 1);
+        });
+    },
 
     // switchToFront: state => {
     //   // Redux Toolkit allows us to write "mutating" logic in reducers. It
@@ -388,8 +400,6 @@ export const selectQueriesWithoutSearchResults = (
   return queriesToSearch;
 };
 
-// const getProjectCardCount = createSelector(selectProject, project => )
-
 // Action creators are generated for each case reducer function
 export const {
   setSelectedImage,
@@ -402,6 +412,7 @@ export const {
   toggleMemberSelection,
   bulkSetMemberSelection,
   deleteSlot,
+  bulkDeleteSlots,
 } = projectSlice.actions;
 
 export default projectSlice.reducer;

--- a/frontend/src/features/project/projectSlice.ts
+++ b/frontend/src/features/project/projectSlice.ts
@@ -215,6 +215,16 @@ export const selectProjectMembers = (
   state: RootState
 ): Array<SlotProjectMembers> => state.project.members;
 
+// TODO: this is a bit disgusting
+export const selectSelectedProjectMembers = (
+  state: RootState
+): Array<SlotProjectMembers> =>
+  state.project.members.flatMap((x: SlotProjectMembers) =>
+    (x.front?.selected === true ? [x.front] : []).concat(
+      x.back?.selected === true ? [x.back] : []
+    )
+  );
+
 // TODO: this is disgusting
 export const selectProjectMemberQueries = (state: RootState): Set<string> =>
   new Set(

--- a/frontend/src/features/project/projectSlice.ts
+++ b/frontend/src/features/project/projectSlice.ts
@@ -226,6 +226,25 @@ export const projectSlice = createSlice({
     bulkSetMemberSelection: (
       state,
       action: PayloadAction<{
+        selectedStatus: boolean;
+        slots: Array<[Faces, number]>;
+      }>
+    ) => {
+      for (const [face, slot] of action.payload.slots) {
+        if (state.members[slot][face] == null) {
+          state.members[slot][face] = {
+            query: { query: null, card_type: Card },
+            selectedImage: undefined,
+            selected: action.payload.selectedStatus,
+          };
+        } else {
+          state.members[slot][face]!.selected = action.payload.selectedStatus;
+        }
+      }
+    },
+    bulkAlignMemberSelection: (
+      state,
+      action: PayloadAction<{
         face: Faces;
         slot: number;
       }>
@@ -411,6 +430,7 @@ export const {
   addMembers,
   toggleMemberSelection,
   bulkSetMemberSelection,
+  bulkAlignMemberSelection,
   deleteSlot,
   bulkDeleteSlots,
 } = projectSlice.actions;

--- a/frontend/src/features/project/projectSlice.ts
+++ b/frontend/src/features/project/projectSlice.ts
@@ -92,7 +92,7 @@ export const projectSlice = createSlice({
           action.payload.selectedImage;
       }
     },
-    bulkSetSelectedImage: (
+    bulkReplaceSelectedImage: (
       state,
       action: PayloadAction<{
         face: Faces;
@@ -130,6 +130,27 @@ export const projectSlice = createSlice({
             action.payload.selectedImage;
         }
         // setSelectedImage(state, {face: action.payload.face, slot: slot, selectedImage: action.payload.selectedImage})
+      }
+    },
+    bulkSetSelectedImage: (
+      state,
+      action: PayloadAction<{
+        selectedImage: string;
+        slots: Array<[Faces, number]>;
+      }>
+    ) => {
+      for (const [face, slot] of action.payload.slots) {
+        if (state.members[slot][face] == null) {
+          state.members[slot][face] = {
+            query: { query: null, card_type: Card },
+            selectedImage: action.payload.selectedImage,
+            selected: false,
+          };
+        } else {
+          state.members[slot][face]!.selectedImage =
+            action.payload.selectedImage;
+          state.members[slot][face]!.selected = false;
+        }
       }
     },
     setQuery: (
@@ -372,6 +393,7 @@ export const selectQueriesWithoutSearchResults = (
 // Action creators are generated for each case reducer function
 export const {
   setSelectedImage,
+  bulkReplaceSelectedImage,
   bulkSetSelectedImage,
   setQuery,
   bulkSetQuery,

--- a/frontend/src/features/project/projectSlice.ts
+++ b/frontend/src/features/project/projectSlice.ts
@@ -30,6 +30,14 @@ const initialState: Project = {
     },
     {
       front: {
+        query: { query: "island", card_type: Card },
+        selectedImage: undefined,
+        selected: false,
+      },
+      back: null,
+    },
+    {
+      front: {
         query: { query: "grim monolith", card_type: Card },
         selectedImage: undefined,
         selected: false,
@@ -157,6 +165,31 @@ export const projectSlice = createSlice({
       ) {
         state.members[action.payload.slot][action.payload.face]!.selected =
           !state.members[action.payload.slot][action.payload.face]!.selected;
+      }
+    },
+    bulkSetMemberSelection: (
+      state,
+      action: PayloadAction<{
+        face: Faces;
+        slot: number;
+      }>
+    ) => {
+      const selectedMember = (state.members[action.payload.slot] ?? {})[
+        action.payload.face
+      ];
+      if (selectedMember != null) {
+        for (const [slot, projectMember] of state.members.entries()) {
+          if (
+            projectMember[action.payload.face] != null &&
+            projectMember[action.payload.face]!.query?.query ===
+              selectedMember.query.query &&
+            projectMember[action.payload.face]!.query?.card_type ===
+              selectedMember.query.card_type
+          ) {
+            projectMember[action.payload.face]!.selected =
+              selectedMember.selected;
+          }
+        }
       }
     },
     deleteSlot: (state, action: PayloadAction<{ slot: number }>) => {
@@ -298,6 +331,7 @@ export const {
   setSelectedCardback,
   addMembers,
   toggleMemberSelection,
+  bulkSetMemberSelection,
   deleteSlot,
 } = projectSlice.actions;
 

--- a/frontend/src/features/project/projectStatus.tsx
+++ b/frontend/src/features/project/projectStatus.tsx
@@ -3,8 +3,10 @@ import React from "react";
 import Alert from "react-bootstrap/Alert";
 import Button from "react-bootstrap/Button";
 import Col from "react-bootstrap/Col";
+import Dropdown from "react-bootstrap/Dropdown";
 import OverlayTrigger from "react-bootstrap/OverlayTrigger";
 import Row from "react-bootstrap/Row";
+import Stack from "react-bootstrap/Stack";
 import Tooltip from "react-bootstrap/Tooltip";
 import { useSelector } from "react-redux";
 import styled from "styled-components";
@@ -16,6 +18,7 @@ import {
   selectGeneratedXML,
   selectProjectFileSize,
   selectProjectSize,
+  selectSelectedProjectMembers,
 } from "@/features/project/projectSlice";
 
 // TODO: review the codebase for instances of this https://redux.js.org/usage/deriving-data-selectors#optimizing-selectors-with-memoization
@@ -23,6 +26,28 @@ import {
 const SizedIcon = styled.i`
   font-size 1.25rem
 `;
+
+function SelectedImagesStatus() {
+  const selectedProjectMembers = useSelector(selectSelectedProjectMembers);
+  return (
+    <>
+      {selectedProjectMembers.length > 0 && (
+        <Alert variant="primary">
+          <Stack direction="horizontal" gap={2}>
+            <b>
+              {selectedProjectMembers.length} image
+              {selectedProjectMembers.length != 1 && "s"} selected.
+            </b>
+            <Dropdown className="ms-auto">
+              <Dropdown.Toggle variant="secondary">Modify</Dropdown.Toggle>
+              <Dropdown.Menu></Dropdown.Menu>
+            </Dropdown>
+          </Stack>
+        </Alert>
+      )}
+    </>
+  );
+}
 
 export function ProjectStatus() {
   // const [show, setShow] = useState(false);
@@ -49,6 +74,7 @@ export function ProjectStatus() {
   return (
     <>
       <h2>Edit MPC Project</h2>
+      <SelectedImagesStatus />
       <Alert variant="secondary">
         Your project contains <b>{projectSize}</b> card
         {projectSize !== 1 && "s"}, belongs in the MPC bracket of up to{" "}

--- a/frontend/src/features/project/projectStatus.tsx
+++ b/frontend/src/features/project/projectStatus.tsx
@@ -3,22 +3,20 @@ import React from "react";
 import Alert from "react-bootstrap/Alert";
 import Button from "react-bootstrap/Button";
 import Col from "react-bootstrap/Col";
-import Dropdown from "react-bootstrap/Dropdown";
 import OverlayTrigger from "react-bootstrap/OverlayTrigger";
 import Row from "react-bootstrap/Row";
-import Stack from "react-bootstrap/Stack";
 import Tooltip from "react-bootstrap/Tooltip";
 import { useSelector } from "react-redux";
 import styled from "styled-components";
 
 import { ProjectMaxSize } from "@/common/constants";
 import { bracket, imageSizeToMBString } from "@/common/utils";
+import { SelectedImagesStatus } from "@/features/project/bulkManagement";
 import {
   selectGeneratedDecklist,
   selectGeneratedXML,
   selectProjectFileSize,
   selectProjectSize,
-  selectSelectedProjectMembers,
 } from "@/features/project/projectSlice";
 
 // TODO: review the codebase for instances of this https://redux.js.org/usage/deriving-data-selectors#optimizing-selectors-with-memoization
@@ -27,33 +25,7 @@ const SizedIcon = styled.i`
   font-size 1.25rem
 `;
 
-function SelectedImagesStatus() {
-  const selectedProjectMembers = useSelector(selectSelectedProjectMembers);
-  return (
-    <>
-      {selectedProjectMembers.length > 0 && (
-        <Alert variant="primary">
-          <Stack direction="horizontal" gap={2}>
-            <b>
-              {selectedProjectMembers.length} image
-              {selectedProjectMembers.length != 1 && "s"} selected.
-            </b>
-            <Dropdown className="ms-auto">
-              <Dropdown.Toggle variant="secondary">Modify</Dropdown.Toggle>
-              <Dropdown.Menu></Dropdown.Menu>
-            </Dropdown>
-          </Stack>
-        </Alert>
-      )}
-    </>
-  );
-}
-
 export function ProjectStatus() {
-  // const [show, setShow] = useState(false);
-  // const handleClose = () => setShow(false);
-  // const handleShow = () => setShow(true);
-
   const generatedXML = useSelector(selectGeneratedXML);
   const generatedDecklist = useSelector(selectGeneratedDecklist);
   const projectSize = useSelector(selectProjectSize);

--- a/frontend/src/styles/custom.css
+++ b/frontend/src/styles/custom.css
@@ -108,7 +108,7 @@
   height: 38px;
 }
 
-.padlock {
+.card-select {
   position: absolute;
   top: 10px;
   left: 5px;


### PR DESCRIPTION
# Description

* Added the ability to select individual card slots with a checkbox + select all card slots with the same query by double-clicking the checkbox
* Added a menu for operating on cards in bulk in the following ways:
    * Change the query for all selected cards
    * If all selected card slots have the same query, select a new image / version for those slots
    * Delete the selected slots

<img width="1184" alt="image" src="https://github.com/chilli-axe/mpc-autofill/assets/3079166/de98d6ae-d755-478f-bece-77422ab26ee5">

* This replaces the padlock functionality in the old GUI
* Still a bit messy visually, will aim to tidy up before merging
    * This is done but I can't be bothered to update the screenshot

# Checklist

- [x] I have installed `pre-commit` and run the hooks with `pre-commit run`.
- [x] I have updated any related tests for code I modified or added new tests where appropriate.
    - Tests to come
- [x] I have updated any relevant documentation or created new documentation where appropriate.
    - None required (for the moment)