### PR TITLE
Desktop tool image processing - downscale to 800 DPI

### DIFF
--- a/desktop-tool/autofill.py
+++ b/desktop-tool/autofill.py
@@ -6,7 +6,7 @@ from typing import Optional
 import click
 from wakepy import keepawake
 
-from src.constants import Browsers
+from src.constants import Browsers, ImageResizeMethods
 from src.driver import AutofillDriver
 from src.pdf_maker import PdfExporter
 from src.utils import TEXT_BOLD, TEXT_END
@@ -18,7 +18,9 @@ os.system("")  # enables ansi escape characters in terminal
 @click.command()
 @click.option(
     "--skipsetup",
-    prompt="Skip project setup to continue editing an existing MPC project?" if len(sys.argv) == 1 else False,
+    prompt="Skip project setup to continue editing an existing MPC project? (Press Enter if you're not sure.)"
+    if len(sys.argv) == 1
+    else False,
     default=False,
     help=(
         "If this flag is passed, the tool will prompt the user to navigate to an existing MPC project "
@@ -30,7 +32,9 @@ os.system("")  # enables ansi escape characters in terminal
 @click.option(
     "-b",
     "--browser",
-    prompt="Which web browser should the tool run on?" if len(sys.argv) == 1 else False,
+    prompt="Which web browser should the tool run on?  (Press Enter if you're not sure.)"
+    if len(sys.argv) == 1
+    else False,
     default=Browsers.chrome.name,
     type=click.Choice(sorted([browser.name for browser in Browsers]), case_sensitive=False),
     help="The web browser to run the tool on.",
@@ -54,6 +58,29 @@ os.system("")  # enables ansi escape characters in terminal
     "--allowsleep",
     default=False,
     help="Allows the system to fall asleep during execution.",
+    is_flag=True,
+)
+@click.option(
+    "--max-dpi",
+    default=800,
+    type=click.INT,
+    help="Images above this DPI will be downscaled to it before being uploaded to MPC. Defaults to 800 DPI.",
+)
+@click.option(
+    "--downscale-alg",
+    default=ImageResizeMethods.LANCZOS.name,
+    type=click.Choice(sorted([str(x.name) for x in ImageResizeMethods])),
+    help=(
+        "The algorithm used when downscaling images to the max DPI. "
+        "See the link below for a performance comparison of each option: "
+        "\nhttps://pillow.readthedocs.io/en/latest/handbook/concepts.html#filters-comparison-table"
+    ),
+)
+@click.option(
+    "--convert-to-jpeg",
+    default=True,
+    type=click.BOOL,
+    help="If this flag is set, non-JPEG images will be converted to JPEG before being uploaded to MPC.",
     is_flag=True,
 )
 def main(skipsetup: bool, browser: str, binary_location: Optional[str], exportpdf: bool, allowsleep: bool) -> None:

--- a/desktop-tool/requirements.txt
+++ b/desktop-tool/requirements.txt
@@ -7,6 +7,7 @@ enlighten~=1.11
 fpdf2~=2.7
 InquirerPy~=0.3
 numpy~=1.24
+pillow==9.5.0
 pre-commit
 pyinstaller~=5.10
 pytest~=7.3

--- a/desktop-tool/requirements.txt
+++ b/desktop-tool/requirements.txt
@@ -6,7 +6,6 @@ defusedxml~=0.7
 enlighten~=1.11
 fpdf2~=2.7
 InquirerPy~=0.3
-numpy~=1.24
 pillow==9.5.0
 pre-commit
 pyinstaller~=5.10

--- a/desktop-tool/src/constants.py
+++ b/desktop-tool/src/constants.py
@@ -111,13 +111,16 @@ class GoogleScriptsAPIs(str, Enum):
         return str(self.value)
 
 
-class ImageResizeMethods(str, Enum):
-    NEAREST = Image.Resampling.NEAREST
-    BOX = Image.Resampling.BOX
-    BILINEAR = Image.Resampling.BILINEAR
-    HAMMING = Image.Resampling.HAMMING
-    BICUBIC = Image.Resampling.BICUBIC
-    LANCZOS = Image.Resampling.LANCZOS
+class ImageResizeMethods(Enum):
+    NEAREST = Image.NEAREST
+    BOX = Image.BOX
+    BILINEAR = Image.BILINEAR
+    HAMMING = Image.HAMMING
+    BICUBIC = Image.BICUBIC
+    LANCZOS = Image.LANCZOS
+
+
+DPI_HEIGHT_RATIO = 300 / 1110  # TODO: share this between desktop tool and backend
 
 
 BRACKETS = [18, 36, 55, 72, 90, 108, 126, 144, 162, 180, 198, 216, 234, 396, 504, 612]

--- a/desktop-tool/src/constants.py
+++ b/desktop-tool/src/constants.py
@@ -41,6 +41,8 @@ import os
 from enum import Enum
 from functools import partial
 
+from PIL import Image
+
 import src.webdrivers as wd
 
 # Disable logging messages for webdriver_manager
@@ -107,6 +109,15 @@ class GoogleScriptsAPIs(str, Enum):
 
     def __str__(self) -> str:
         return str(self.value)
+
+
+class ImageResizeMethods(str, Enum):
+    NEAREST = Image.Resampling.NEAREST
+    BOX = Image.Resampling.BOX
+    BILINEAR = Image.Resampling.BILINEAR
+    HAMMING = Image.Resampling.HAMMING
+    BICUBIC = Image.Resampling.BICUBIC
+    LANCZOS = Image.Resampling.LANCZOS
 
 
 BRACKETS = [18, 36, 55, 72, 90, 108, 126, 144, 162, 180, 198, 216, 234, 396, 504, 612]

--- a/desktop-tool/src/constants.py
+++ b/desktop-tool/src/constants.py
@@ -102,10 +102,10 @@ class Browsers(Enum):
 
 
 class GoogleScriptsAPIs(str, Enum):
+    # POST
     image_name = "https://script.google.com/macros/s/AKfycbw90rkocSdppkEuyVdsTuZNslrhd5zNT3XMgfucNMM1JjhLl-Q/exec"
-    image_content = (
-        "https://script.google.com/macros/s/AKfycbzzCWc2x3tfQU1Zp45LB1P19FNZE-4njwzfKT5_Rx399h-5dELZWyvf/exec"
-    )
+    # GET
+    image_content = "https://script.google.com/macros/s/AKfycbw8laScKBfxda2Wb0g63gkYDBdy8NWNxINoC4xDOwnCQ3JMFdruam1MdmNmN4wI5k4/exec"
 
     def __str__(self) -> str:
         return str(self.value)

--- a/desktop-tool/src/driver.py
+++ b/desktop-tool/src/driver.py
@@ -18,11 +18,11 @@ from selenium.webdriver.support.expected_conditions import invisibility_of_eleme
 from selenium.webdriver.support.ui import Select, WebDriverWait
 
 from src.constants import THREADS, Browsers, States
+from src.exc import InvalidStateException
 from src.order import CardImage, CardImageCollection, CardOrder
 from src.utils import (
     TEXT_BOLD,
     TEXT_END,
-    InvalidStateException,
     alert_handler,
     log_hours_minutes_seconds_elapsed,
 )

--- a/desktop-tool/src/driver.py
+++ b/desktop-tool/src/driver.py
@@ -20,6 +20,7 @@ from selenium.webdriver.support.ui import Select, WebDriverWait
 from src.constants import THREADS, Browsers, States
 from src.exc import InvalidStateException
 from src.order import CardImage, CardImageCollection, CardOrder
+from src.processing import ImagePostProcessingConfig
 from src.utils import (
     TEXT_BOLD,
     TEXT_END,
@@ -442,11 +443,15 @@ class AutofillDriver:
 
     # region public
 
-    def execute(self, skip_setup: bool) -> None:
+    def execute(self, skip_setup: bool, post_processing_config: Optional[ImagePostProcessingConfig]) -> None:
         t = time.time()
         with ThreadPoolExecutor(max_workers=THREADS) as pool:
-            self.order.fronts.download_images(pool, self.download_bar)
-            self.order.backs.download_images(pool, self.download_bar)
+            self.order.fronts.download_images(
+                pool=pool, download_bar=self.download_bar, post_processing_config=post_processing_config
+            )
+            self.order.backs.download_images(
+                pool=pool, download_bar=self.download_bar, post_processing_config=post_processing_config
+            )
 
             if skip_setup:
                 self.set_state(States.defining_order, "Awaiting user input")

--- a/desktop-tool/src/exc.py
+++ b/desktop-tool/src/exc.py
@@ -1,0 +1,15 @@
+from src.utils import TEXT_BOLD, TEXT_END
+
+
+class InvalidStateException(Exception):
+    # TODO: recovery from invalid state?
+    def __init__(self, state: str, expected_state: str):
+        self.message = (
+            f"Expected the driver to be in the state {TEXT_BOLD}{expected_state}{TEXT_END} but the driver is in the "
+            f"state {TEXT_BOLD}{state}{TEXT_END}"
+        )
+        super().__init__(self.message)
+
+
+class ValidationException(Exception):
+    pass

--- a/desktop-tool/src/io.py
+++ b/desktop-tool/src/io.py
@@ -1,0 +1,116 @@
+import os
+import sys
+from typing import Any, Optional
+
+import numpy as np
+import ratelimit
+import requests
+
+import src.constants as constants
+
+# region network IO
+
+
+@ratelimit.sleep_and_retry  # type: ignore  # `ratelimit` does not implement decorator typing correctly
+@ratelimit.limits(calls=1, period=0.1)  # type: ignore  # `ratelimit` does not implement decorator typing correctly
+def rate_limit_post_api_call(url: str, data: dict[str, Any], timeout: Optional[int] = None) -> requests.Response:
+    with requests.post(url, data=data, timeout=timeout) as r_info:
+        return r_info
+
+
+def safe_post_api_call(
+    url: str, data: dict[str, Any], expected_keys: set[str], max_tries: int = 3, timeout: Optional[int] = None
+) -> Optional[dict[str, Any]]:
+    tries = 0
+    while True:
+        try:
+            r_info = rate_limit_post_api_call(url=url, data=data, timeout=timeout)
+            r_json = r_info.json()
+            # validate contents of response
+            if (
+                r_info.status_code != 500
+                and len(expected_keys - r_json.keys()) == 0
+                and not any([bool(r_json[x]) is False for x in expected_keys])
+            ):
+                return r_json
+        except (requests.exceptions.RequestException, TimeoutError):
+            pass
+
+        tries += 1
+        if tries >= max_tries:
+            return None
+
+
+def get_google_drive_file_name(drive_id: str) -> Optional[str]:
+    """
+    Retrieve the name for the Google Drive file identified by `drive_id`.
+    """
+
+    if not drive_id:
+        return None
+    response = safe_post_api_call(
+        url=constants.GoogleScriptsAPIs.image_name, data={"id": drive_id}, timeout=30, expected_keys={"name"}
+    )
+    return response["name"] if response is not None else None
+
+
+# endregion
+
+# region file IO
+
+
+CURRDIR: str = os.path.dirname(os.path.realpath(sys.executable)) if getattr(sys, "frozen", False) else os.getcwd()
+
+
+def image_directory() -> str:
+    cards_folder = os.path.join(CURRDIR, "cards")
+    if not os.path.exists(cards_folder):
+        os.mkdir(cards_folder)
+    return cards_folder
+
+
+def file_exists(file_path: Optional[str]) -> bool:
+    return file_path is not None and file_path != "" and os.path.isfile(file_path) and os.path.getsize(file_path) > 0
+
+
+def remove_directories(directory_list: list[str]) -> None:
+    for directory in directory_list:
+        try:
+            os.rmdir(directory)
+        except Exception:  # TODO: investigate which exceptions `os.rmdir` can raise and handle specifically them
+            pass
+
+
+def remove_files(file_list: list[str]) -> None:
+    for file in file_list:
+        try:
+            os.remove(file)
+        except Exception:  # TODO: investigate which exceptions `os.remove` can raise and handle specifically them
+            pass
+
+
+# endregion
+
+# region mixed network and file IO
+
+
+def download_google_drive_file(drive_id: str, file_path: str) -> bool:
+    """
+    Download the Google Drive file identified by `drive_id` to the specified `file_path`.
+    Returns whether the request was successful or not.
+    """
+
+    response = safe_post_api_call(
+        url=constants.GoogleScriptsAPIs.image_content, data={"id": drive_id}, timeout=5 * 60, expected_keys={"result"}
+    )
+    if response is not None:
+        file_contents = response["result"]
+        if len(file_contents) > 0:
+            # Download the image
+            with open(file_path, "wb") as f:
+                f.write(np.array(file_contents).astype(np.uint8))
+                return True
+    return False
+
+
+# endregion

--- a/desktop-tool/src/io.py
+++ b/desktop-tool/src/io.py
@@ -1,8 +1,8 @@
+import base64
 import os
 import sys
 from typing import Any, Optional
 
-import numpy as np
 import ratelimit
 import requests
 
@@ -14,9 +14,38 @@ from src.processing import ImagePostProcessingConfig, post_process_image
 
 @ratelimit.sleep_and_retry  # type: ignore  # `ratelimit` does not implement decorator typing correctly
 @ratelimit.limits(calls=1, period=0.1)  # type: ignore  # `ratelimit` does not implement decorator typing correctly
-def rate_limit_post_api_call(url: str, data: dict[str, Any], timeout: Optional[int] = None) -> requests.Response:
-    with requests.post(url, data=data, timeout=timeout) as r_info:
+def rate_limit_api_call(
+    url: str, method: str, data: dict[str, Any], params: dict[str, Any], timeout: Optional[int] = None
+) -> requests.Response:
+    with requests.request(url=url, method=method, data=data, params=params, timeout=timeout) as r_info:
         return r_info
+
+
+def rate_limit_get_api_call(url: str, params: dict[str, Any], timeout: Optional[int] = None) -> requests.Response:
+    return rate_limit_api_call(url=url, method="GET", data={}, params=params, timeout=timeout)
+
+
+def rate_limit_post_api_call(url: str, data: dict[str, Any], timeout: Optional[int] = None) -> requests.Response:
+    return rate_limit_api_call(url=url, method="POST", data=data, params={}, timeout=timeout)
+
+
+def safe_get_api_call(
+    url: str, params: dict[str, Any], max_tries: int = 3, timeout: Optional[int] = None
+) -> Optional[str]:
+    tries = 0
+    while True:
+        try:
+            r_info = rate_limit_get_api_call(url=url, params=params, timeout=timeout)
+            r_text = r_info.text
+            # validate contents of response
+            if r_info.status_code != 500 and len(r_text) > 0:
+                return r_text
+        except (requests.exceptions.RequestException, TimeoutError):
+            pass
+
+        tries += 1
+        if tries >= max_tries:
+            return None
 
 
 def safe_post_api_call(
@@ -103,20 +132,17 @@ def download_google_drive_file(
     Returns whether the request was successful or not.
     """
 
-    response = safe_post_api_call(
-        url=constants.GoogleScriptsAPIs.image_content, data={"id": drive_id}, timeout=5 * 60, expected_keys={"result"}
-    )
-    if response is not None:
-        file_contents = response["result"]
-        if len(file_contents) > 0:
-            if post_processing_config is not None:
-                processed_image = post_process_image(raw_image=file_contents, config=post_processing_config)
-                processed_image.save(file_path)
-            else:
-                # Save the bytes directly to disk - avoid reading in pillow in case any quality degradation occurs
-                with open(file_path, "wb") as f:
-                    f.write(np.array(file_contents).astype(np.uint8))
-            return True
+    response = safe_get_api_call(url=constants.GoogleScriptsAPIs.image_content, params={"id": drive_id}, timeout=5 * 60)
+    if response is not None and len(response) > 0:
+        file_bytes = base64.b64decode(response)
+        if post_processing_config is not None:
+            processed_image = post_process_image(raw_image=file_bytes, config=post_processing_config)
+            processed_image.save(file_path)
+        else:
+            # Save the bytes directly to disk - avoid reading in pillow in case any quality degradation occurs
+            with open(file_path, "wb") as f:
+                f.write(file_bytes)
+        return True
     return False
 
 

--- a/desktop-tool/src/order.py
+++ b/desktop-tool/src/order.py
@@ -12,19 +12,16 @@ import InquirerPy
 from defusedxml.ElementTree import parse as defused_parse
 from sanitize_filename import sanitize
 
-import src.constants as constants
-from src.utils import (
+from src import constants
+from src.exc import ValidationException
+from src.io import (
     CURRDIR,
-    TEXT_BOLD,
-    TEXT_END,
-    ValidationException,
     download_google_drive_file,
     file_exists,
     get_google_drive_file_name,
     image_directory,
-    text_to_list,
-    unpack_element,
 )
+from src.utils import TEXT_BOLD, TEXT_END, text_to_list, unpack_element
 
 
 @attr.s

--- a/desktop-tool/src/order.py
+++ b/desktop-tool/src/order.py
@@ -60,7 +60,6 @@ class CardImage:
         * If `self.drive_id` points to a valid file in the user's file system, use it as the file path
         * If a file with `self.name` exists in the `cards` directory, use the path to that file as the file path
         * Otherwise, use `self.name` with `self.drive_id` in parentheses in the `cards` directory as the file path.
-            * In this branch, if the file is to be converted to jpeg, we set the file extension to jpeg.
         """
 
         if file_exists(self.drive_id):

--- a/desktop-tool/src/processing.py
+++ b/desktop-tool/src/processing.py
@@ -1,0 +1,28 @@
+import io
+from dataclasses import dataclass
+
+import numpy as np
+from PIL import Image
+
+from src.constants import DPI_HEIGHT_RATIO, ImageResizeMethods
+
+
+@dataclass
+class ImagePostProcessingConfig:
+    max_dpi: int
+    downscale_alg: ImageResizeMethods
+    # jpeg: bool
+
+
+def post_process_image(raw_image: list[int], config: ImagePostProcessingConfig) -> Image:
+    # bit of a thick one-liner here - clip data to [0, 255], convert to bytes, convert to BytesIO, read into pillow img
+    img = Image.open(io.BytesIO(bytes(np.array(raw_image).astype(np.uint8))))
+
+    # downscale the image to `max_dpi`
+    img_dpi = DPI_HEIGHT_RATIO * img.height
+    if img_dpi > config.max_dpi:
+        new_height = round((config.max_dpi / img_dpi) * img.height)
+        new_width = round((config.max_dpi / img_dpi) * img.width)
+        img = img.resize((new_width, new_height), config.downscale_alg.value)
+
+    return img

--- a/desktop-tool/src/processing.py
+++ b/desktop-tool/src/processing.py
@@ -1,7 +1,6 @@
 import io
 from dataclasses import dataclass
 
-import numpy as np
 from PIL import Image
 
 from src.constants import DPI_HEIGHT_RATIO, ImageResizeMethods
@@ -14,12 +13,11 @@ class ImagePostProcessingConfig:
     # jpeg: bool
 
 
-def post_process_image(raw_image: list[int], config: ImagePostProcessingConfig) -> Image:
-    # bit of a thick one-liner here - clip data to [0, 255], convert to bytes, convert to BytesIO, read into pillow img
-    img = Image.open(io.BytesIO(bytes(np.array(raw_image).astype(np.uint8))))
+def post_process_image(raw_image: bytes, config: ImagePostProcessingConfig) -> Image:
+    img = Image.open(io.BytesIO(raw_image))
 
     # downscale the image to `max_dpi`
-    img_dpi = DPI_HEIGHT_RATIO * img.height
+    img_dpi = 10 * round(int(img.height) * DPI_HEIGHT_RATIO / 10)
     if img_dpi > config.max_dpi:
         new_height = round((config.max_dpi / img_dpi) * img.height)
         new_width = round((config.max_dpi / img_dpi) * img.width)

--- a/desktop-tool/src/utils.py
+++ b/desktop-tool/src/utils.py
@@ -1,105 +1,20 @@
-import os
-import sys
 import time
 from math import floor
-from typing import TYPE_CHECKING, Any, Callable, Optional, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Callable, TypeVar, cast
 from xml.etree import ElementTree
 from xml.etree.ElementTree import Element
 
-import numpy as np
-import ratelimit
-import requests
 from selenium.common.exceptions import NoAlertPresentException, NoSuchWindowException
 
-import src.constants as constants
-
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # necessary to avoid circular import
     from driver import AutofillDriver
 
 # https://mypy.readthedocs.io/en/stable/generics.html#declaring-decorators
 F = TypeVar("F", bound=Callable[..., Any])
 
 
-CURRDIR: str = os.path.dirname(os.path.realpath(sys.executable)) if getattr(sys, "frozen", False) else os.getcwd()
-
 TEXT_BOLD = "\033[1m"
 TEXT_END = "\033[0m"
-
-
-class InvalidStateException(Exception):
-    # TODO: recovery from invalid state?
-    def __init__(self, state: str, expected_state: str):
-        self.message = (
-            f"Expected the driver to be in the state {TEXT_BOLD}{expected_state}{TEXT_END} but the driver is in the "
-            f"state {TEXT_BOLD}{state}{TEXT_END}"
-        )
-        super().__init__(self.message)
-
-
-class ValidationException(Exception):
-    pass
-
-
-@ratelimit.sleep_and_retry  # type: ignore  # `ratelimit` does not implement decorator typing correctly
-@ratelimit.limits(calls=1, period=0.1)  # type: ignore  # `ratelimit` does not implement decorator typing correctly
-def rate_limit_post_api_call(url: str, data: dict[str, Any], timeout: Optional[int] = None) -> requests.Response:
-    with requests.post(url, data=data, timeout=timeout) as r_info:
-        return r_info
-
-
-def safe_post_api_call(
-    url: str, data: dict[str, Any], expected_keys: set[str], max_tries: int = 3, timeout: Optional[int] = None
-) -> Optional[dict[str, Any]]:
-    tries = 0
-    while True:
-        try:
-            r_info = rate_limit_post_api_call(url=url, data=data, timeout=timeout)
-            r_json = r_info.json()
-            # validate contents of response
-            if (
-                r_info.status_code != 500
-                and len(expected_keys - r_json.keys()) == 0
-                and not any([bool(r_json[x]) is False for x in expected_keys])
-            ):
-                return r_json
-        except (requests.exceptions.RequestException, TimeoutError):
-            pass
-
-        tries += 1
-        if tries >= max_tries:
-            return None
-
-
-def get_google_drive_file_name(drive_id: str) -> Optional[str]:
-    """
-    Retrieve the name for the Google Drive file identified by `drive_id`.
-    """
-
-    if not drive_id:
-        return None
-    response = safe_post_api_call(
-        url=constants.GoogleScriptsAPIs.image_name, data={"id": drive_id}, timeout=30, expected_keys={"name"}
-    )
-    return response["name"] if response is not None else None
-
-
-def download_google_drive_file(drive_id: str, file_path: str) -> bool:
-    """
-    Download the Google Drive file identified by `drive_id` to the specified `file_path`.
-    Returns whether the request was successful or not.
-    """
-
-    response = safe_post_api_call(
-        url=constants.GoogleScriptsAPIs.image_content, data={"id": drive_id}, timeout=5 * 60, expected_keys={"result"}
-    )
-    if response is not None:
-        file_contents = response["result"]
-        if len(file_contents) > 0:
-            # Download the image
-            with open(file_path, "wb") as f:
-                f.write(np.array(file_contents).astype(np.uint8))
-                return True
-    return False
 
 
 def text_to_list(input_text: str) -> list[int]:
@@ -119,17 +34,6 @@ def unpack_element(element: ElementTree.Element, tags: list[str]) -> dict[str, E
     """
 
     return {tag: Element(tag) for tag in tags} | {item.tag: item for item in element}
-
-
-def image_directory() -> str:
-    cards_folder = os.path.join(CURRDIR, "cards")
-    if not os.path.exists(cards_folder):
-        os.mkdir(cards_folder)
-    return cards_folder
-
-
-def file_exists(file_path: Optional[str]) -> bool:
-    return file_path is not None and file_path != "" and os.path.isfile(file_path) and os.path.getsize(file_path) > 0
 
 
 def alert_handler(func: F) -> F:
@@ -162,19 +66,3 @@ def log_hours_minutes_seconds_elapsed(t0: float) -> None:
     if hours > 0:
         print(f"{hours} hour{'s' if hours != 1 else ''}, ", end="")
     print(f"{mins} minute{'s' if mins != 1 else ''} and {secs} second{'s' if secs != 1 else ''}.")
-
-
-def remove_directories(directory_list: list[str]) -> None:
-    for directory in directory_list:
-        try:
-            os.rmdir(directory)
-        except Exception:
-            pass
-
-
-def remove_files(file_list: list[str]) -> None:
-    for file in file_list:
-        try:
-            os.remove(file)
-        except Exception:
-            pass

--- a/desktop-tool/tests/test_desktop_client.py
+++ b/desktop-tool/tests/test_desktop_client.py
@@ -24,7 +24,7 @@ from src.utils import text_to_list
 @pytest.fixture(autouse=True)
 def monkeypatch_current_working_directory(request, monkeypatch) -> None:
     monkeypatch.setattr(os, "getcwd", lambda: FILE_PATH)
-    monkeypatch.setattr(src.utils, "CURRDIR", FILE_PATH)
+    monkeypatch.setattr(src.io, "CURRDIR", FILE_PATH)
     monkeypatch.chdir(FILE_PATH)
 
 
@@ -840,10 +840,12 @@ def test_pdf_export_complete_separate_faces(monkeypatch, card_order_valid):
 # region test driver.py
 
 
-@pytest.mark.parametrize("browser", [constants.Browsers.chrome, constants.Browsers.edge])
+@pytest.mark.parametrize("browser", [constants.Browsers.chrome])
 def test_card_order_complete_run_single_cardback(browser, input_enter, card_order_valid):
     autofill_driver = AutofillDriver(order=card_order_valid, browser=browser, headless=True)
-    autofill_driver.execute(skip_setup=False)
+    autofill_driver.execute(
+        skip_setup=False, max_dpi=800, convert_to_jpeg=True, downscale_alg=constants.ImageResizeMethods.LANCZOS
+    )
     assert (
         len(
             WebDriverWait(autofill_driver.driver, 30).until(

--- a/desktop-tool/tests/test_desktop_client.py
+++ b/desktop-tool/tests/test_desktop_client.py
@@ -559,7 +559,7 @@ def test_download_google_drive_image_downscaled(
     )
     assert image_valid_google_drive.file_exists() is True
     assert image_valid_google_drive.errored is False
-    assert_file_size(image_valid_google_drive.file_path, 50701)
+    assert_file_size(image_valid_google_drive.file_path, 51123)
 
 
 def test_download_google_drive_image_no_post_processing(

--- a/desktop-tool/tests/test_desktop_client.py
+++ b/desktop-tool/tests/test_desktop_client.py
@@ -15,14 +15,10 @@ from selenium.webdriver.support.wait import WebDriverWait
 import src.constants as constants
 import src.utils
 from src.driver import AutofillDriver
+from src.io import get_google_drive_file_name, remove_directories, remove_files
 from src.order import CardImage, CardImageCollection, CardOrder, Details
 from src.pdf_maker import PdfExporter
-from src.utils import (
-    get_google_drive_file_name,
-    remove_directories,
-    remove_files,
-    text_to_list,
-)
+from src.utils import text_to_list
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
# Description
* Image upload times to MakePlayingCards is one of the primary complaints of mpc autofill users
* This PR attempts to improve upload times by downscaling images downloaded from google drive to 800 DPI
    * Image post-processing behaviour is fully customisable through the CLI
* In the future, we could also look at converting images to jpeg before uploading - this is a little fiddly so I've left it for now

# Checklist

- [x] I have installed `pre-commit` and run the hooks with `pre-commit run`.
- [x] I have updated any related tests for code I modified or added new tests where appropriate.
    - None required 
- [X] I have updated any relevant documentation or created new documentation where appropriate.