### PR TITLE
Rework frontend image download

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,6 +12,7 @@
         "@hello-pangea/dnd": "^16.2.0",
         "@popperjs/core": "^2.11.6",
         "@types/ua-parser-js": "^0.7.36",
+        "@types/workerpool": "^6.4.0",
         "base64-js": "^1.5.1",
         "bootstrap": "^5.2.3",
         "bootstrap-icons": "^1.10.3",
@@ -29,8 +30,10 @@
         "react-dropzone": "^14.2.3",
         "react-redux": "^8.0.5",
         "styled-components": "^5.3.9",
+        "threads": "^1.7.0",
         "typescript": "^4.9.4",
         "ua-parser-js": "^1.0.35",
+        "workerpool": "^6.4.0",
         "xml-formatter": "^3.3.2"
       },
       "devDependencies": {
@@ -1994,8 +1997,7 @@
     "node_modules/@types/node": {
       "version": "18.16.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.0.tgz",
-      "integrity": "sha512-BsAaKhB+7X+H4GnSjGhJG9Qi8Tw+inU9nJDwmD5CgOmBLEI6ArdhikpLX7DjbjDRDTbqZzU2LSQNZg8WGPiSZQ==",
-      "dev": true
+      "integrity": "sha512-BsAaKhB+7X+H4GnSjGhJG9Qi8Tw+inU9nJDwmD5CgOmBLEI6ArdhikpLX7DjbjDRDTbqZzU2LSQNZg8WGPiSZQ=="
     },
     "node_modules/@types/prettier": {
       "version": "2.7.2",
@@ -2110,6 +2112,14 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/warning/-/warning-3.0.0.tgz",
       "integrity": "sha512-t/Tvs5qR47OLOr+4E9ckN8AmP2Tf16gWq+/qA4iUGS/OOyHVO8wv2vjJuX8SNOUTJyWb+2t7wJm6cXILFnOROA=="
+    },
+    "node_modules/@types/workerpool": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@types/workerpool/-/workerpool-6.4.0.tgz",
+      "integrity": "sha512-SIF2/169pDsLKeM8GQGHkOFifGalDbZgiBSaLUnnlVSRsAOenkAvQ6h4uhV2W+PZZczS+8LQxACwNkSykdT91A==",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/yargs": {
       "version": "17.0.23",
@@ -3235,7 +3245,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -4701,6 +4710,15 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true
     },
+    "node_modules/esm": {
+      "version": "3.2.25",
+      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
+      "optional": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/espree": {
       "version": "9.5.1",
       "resolved": "https://registry.npmjs.org/espree/-/espree-9.5.1.tgz",
@@ -5910,6 +5928,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-observable": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-observable/-/is-observable-2.1.0.tgz",
+      "integrity": "sha512-DailKdLb0WU+xX8K5w7VsJhapwHLZ9jjmazqCJq4X12CTgqq73TKnbRcnSLuXYPOoLQgV5IrD7ePiX/h1vnkBw==",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-path-inside": {
@@ -7837,6 +7866,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/observable-fns": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/observable-fns/-/observable-fns-0.6.1.tgz",
+      "integrity": "sha512-9gRK4+sRWzeN6AOewNBTLXir7Zl/i3GB6Yl26gK4flxz8BXVpD3kt8amREmWNb0mxYOGDotvE5a4N+PtGGKdkg=="
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -9699,6 +9733,23 @@
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
     },
+    "node_modules/threads": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/threads/-/threads-1.7.0.tgz",
+      "integrity": "sha512-Mx5NBSHX3sQYR6iI9VYbgHKBLisyB+xROCBGjjWm1O9wb9vfLxdaGtmT/KCjUqMsSNW6nERzCW3T6H43LqjDZQ==",
+      "dependencies": {
+        "callsites": "^3.1.0",
+        "debug": "^4.2.0",
+        "is-observable": "^2.1.0",
+        "observable-fns": "^0.6.1"
+      },
+      "funding": {
+        "url": "https://github.com/andywer/threads.js?sponsor=1"
+      },
+      "optionalDependencies": {
+        "tiny-worker": ">= 2"
+      }
+    },
     "node_modules/through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -9719,6 +9770,15 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.1.tgz",
       "integrity": "sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw=="
+    },
+    "node_modules/tiny-worker": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tiny-worker/-/tiny-worker-2.3.0.tgz",
+      "integrity": "sha512-pJ70wq5EAqTAEl9IkGzA+fN0836rycEuz2Cn6yeZ6FRzlVS5IDOkFHpIoEsksPRQV34GDqXm65+OlnZqUSyK2g==",
+      "optional": true,
+      "dependencies": {
+        "esm": "^3.2.25"
+      }
     },
     "node_modules/tmp": {
       "version": "0.0.33",
@@ -10408,6 +10468,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/workerpool": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.4.0.tgz",
+      "integrity": "sha512-i3KR1mQMNwY2wx20ozq2EjISGtQWDIfV56We+yGJ5yDs8jTwQiLLaqHlkBHITlCuJnYlVRmXegxFxZg7gqI++A=="
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
@@ -12045,8 +12110,7 @@
     "@types/node": {
       "version": "18.16.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.0.tgz",
-      "integrity": "sha512-BsAaKhB+7X+H4GnSjGhJG9Qi8Tw+inU9nJDwmD5CgOmBLEI6ArdhikpLX7DjbjDRDTbqZzU2LSQNZg8WGPiSZQ==",
-      "dev": true
+      "integrity": "sha512-BsAaKhB+7X+H4GnSjGhJG9Qi8Tw+inU9nJDwmD5CgOmBLEI6ArdhikpLX7DjbjDRDTbqZzU2LSQNZg8WGPiSZQ=="
     },
     "@types/prettier": {
       "version": "2.7.2",
@@ -12161,6 +12225,14 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/warning/-/warning-3.0.0.tgz",
       "integrity": "sha512-t/Tvs5qR47OLOr+4E9ckN8AmP2Tf16gWq+/qA4iUGS/OOyHVO8wv2vjJuX8SNOUTJyWb+2t7wJm6cXILFnOROA=="
+    },
+    "@types/workerpool": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@types/workerpool/-/workerpool-6.4.0.tgz",
+      "integrity": "sha512-SIF2/169pDsLKeM8GQGHkOFifGalDbZgiBSaLUnnlVSRsAOenkAvQ6h4uhV2W+PZZczS+8LQxACwNkSykdT91A==",
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/yargs": {
       "version": "17.0.23",
@@ -12980,8 +13052,7 @@
     "callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "dev": true
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
     },
     "camelcase": {
       "version": "5.3.1",
@@ -14046,6 +14117,12 @@
       "integrity": "sha512-HPpKPUBQcAsZOsHAFwTtIKcYlCje62XB7SEAcxjtmW6TD1WVpkS6i6/hOVtTZIl4zGj/mBqpFVGvaDneik+VoQ==",
       "dev": true
     },
+    "esm": {
+      "version": "3.2.25",
+      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
+      "optional": true
+    },
     "espree": {
       "version": "9.5.1",
       "resolved": "https://registry.npmjs.org/espree/-/espree-9.5.1.tgz",
@@ -14905,6 +14982,11 @@
       "requires": {
         "has-tostringtag": "^1.0.0"
       }
+    },
+    "is-observable": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-observable/-/is-observable-2.1.0.tgz",
+      "integrity": "sha512-DailKdLb0WU+xX8K5w7VsJhapwHLZ9jjmazqCJq4X12CTgqq73TKnbRcnSLuXYPOoLQgV5IrD7ePiX/h1vnkBw=="
     },
     "is-path-inside": {
       "version": "3.0.3",
@@ -16331,6 +16413,11 @@
         "es-abstract": "^1.20.4"
       }
     },
+    "observable-fns": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/observable-fns/-/observable-fns-0.6.1.tgz",
+      "integrity": "sha512-9gRK4+sRWzeN6AOewNBTLXir7Zl/i3GB6Yl26gK4flxz8BXVpD3kt8amREmWNb0mxYOGDotvE5a4N+PtGGKdkg=="
+    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -17611,6 +17698,18 @@
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
     },
+    "threads": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/threads/-/threads-1.7.0.tgz",
+      "integrity": "sha512-Mx5NBSHX3sQYR6iI9VYbgHKBLisyB+xROCBGjjWm1O9wb9vfLxdaGtmT/KCjUqMsSNW6nERzCW3T6H43LqjDZQ==",
+      "requires": {
+        "callsites": "^3.1.0",
+        "debug": "^4.2.0",
+        "is-observable": "^2.1.0",
+        "observable-fns": "^0.6.1",
+        "tiny-worker": ">= 2"
+      }
+    },
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -17631,6 +17730,15 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.1.tgz",
       "integrity": "sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw=="
+    },
+    "tiny-worker": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tiny-worker/-/tiny-worker-2.3.0.tgz",
+      "integrity": "sha512-pJ70wq5EAqTAEl9IkGzA+fN0836rycEuz2Cn6yeZ6FRzlVS5IDOkFHpIoEsksPRQV34GDqXm65+OlnZqUSyK2g==",
+      "optional": true,
+      "requires": {
+        "esm": "^3.2.25"
+      }
     },
     "tmp": {
       "version": "0.0.33",
@@ -18131,6 +18239,11 @@
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
       "dev": true
+    },
+    "workerpool": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.4.0.tgz",
+      "integrity": "sha512-i3KR1mQMNwY2wx20ozq2EjISGtQWDIfV56We+yGJ5yDs8jTwQiLLaqHlkBHITlCuJnYlVRmXegxFxZg7gqI++A=="
     },
     "wrap-ansi": {
       "version": "7.0.0",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,7 +12,6 @@
         "@hello-pangea/dnd": "^16.2.0",
         "@popperjs/core": "^2.11.6",
         "@types/ua-parser-js": "^0.7.36",
-        "@types/workerpool": "^6.4.0",
         "base64-js": "^1.5.1",
         "bootstrap": "^5.2.3",
         "bootstrap-icons": "^1.10.3",
@@ -33,7 +32,6 @@
         "threads": "^1.7.0",
         "typescript": "^4.9.4",
         "ua-parser-js": "^1.0.35",
-        "workerpool": "^6.4.0",
         "xml-formatter": "^3.3.2"
       },
       "devDependencies": {
@@ -1997,7 +1995,8 @@
     "node_modules/@types/node": {
       "version": "18.16.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.0.tgz",
-      "integrity": "sha512-BsAaKhB+7X+H4GnSjGhJG9Qi8Tw+inU9nJDwmD5CgOmBLEI6ArdhikpLX7DjbjDRDTbqZzU2LSQNZg8WGPiSZQ=="
+      "integrity": "sha512-BsAaKhB+7X+H4GnSjGhJG9Qi8Tw+inU9nJDwmD5CgOmBLEI6ArdhikpLX7DjbjDRDTbqZzU2LSQNZg8WGPiSZQ==",
+      "dev": true
     },
     "node_modules/@types/prettier": {
       "version": "2.7.2",
@@ -2112,14 +2111,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/warning/-/warning-3.0.0.tgz",
       "integrity": "sha512-t/Tvs5qR47OLOr+4E9ckN8AmP2Tf16gWq+/qA4iUGS/OOyHVO8wv2vjJuX8SNOUTJyWb+2t7wJm6cXILFnOROA=="
-    },
-    "node_modules/@types/workerpool": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@types/workerpool/-/workerpool-6.4.0.tgz",
-      "integrity": "sha512-SIF2/169pDsLKeM8GQGHkOFifGalDbZgiBSaLUnnlVSRsAOenkAvQ6h4uhV2W+PZZczS+8LQxACwNkSykdT91A==",
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@types/yargs": {
       "version": "17.0.23",
@@ -10469,11 +10460,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/workerpool": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.4.0.tgz",
-      "integrity": "sha512-i3KR1mQMNwY2wx20ozq2EjISGtQWDIfV56We+yGJ5yDs8jTwQiLLaqHlkBHITlCuJnYlVRmXegxFxZg7gqI++A=="
-    },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
@@ -12110,7 +12096,8 @@
     "@types/node": {
       "version": "18.16.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.0.tgz",
-      "integrity": "sha512-BsAaKhB+7X+H4GnSjGhJG9Qi8Tw+inU9nJDwmD5CgOmBLEI6ArdhikpLX7DjbjDRDTbqZzU2LSQNZg8WGPiSZQ=="
+      "integrity": "sha512-BsAaKhB+7X+H4GnSjGhJG9Qi8Tw+inU9nJDwmD5CgOmBLEI6ArdhikpLX7DjbjDRDTbqZzU2LSQNZg8WGPiSZQ==",
+      "dev": true
     },
     "@types/prettier": {
       "version": "2.7.2",
@@ -12225,14 +12212,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/warning/-/warning-3.0.0.tgz",
       "integrity": "sha512-t/Tvs5qR47OLOr+4E9ckN8AmP2Tf16gWq+/qA4iUGS/OOyHVO8wv2vjJuX8SNOUTJyWb+2t7wJm6cXILFnOROA=="
-    },
-    "@types/workerpool": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@types/workerpool/-/workerpool-6.4.0.tgz",
-      "integrity": "sha512-SIF2/169pDsLKeM8GQGHkOFifGalDbZgiBSaLUnnlVSRsAOenkAvQ6h4uhV2W+PZZczS+8LQxACwNkSykdT91A==",
-      "requires": {
-        "@types/node": "*"
-      }
     },
     "@types/yargs": {
       "version": "17.0.23",
@@ -18239,11 +18218,6 @@
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
       "dev": true
-    },
-    "workerpool": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.4.0.tgz",
-      "integrity": "sha512-i3KR1mQMNwY2wx20ozq2EjISGtQWDIfV56We+yGJ5yDs8jTwQiLLaqHlkBHITlCuJnYlVRmXegxFxZg7gqI++A=="
     },
     "wrap-ansi": {
       "version": "7.0.0",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,6 +12,7 @@
         "@hello-pangea/dnd": "^16.2.0",
         "@popperjs/core": "^2.11.6",
         "@types/ua-parser-js": "^0.7.36",
+        "base64-js": "^1.5.1",
         "bootstrap": "^5.2.3",
         "bootstrap-icons": "^1.10.3",
         "bootswatch": "^5.2.3",
@@ -3024,7 +3025,6 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -12844,8 +12844,7 @@
     "base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
     },
     "big.js": {
       "version": "5.2.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,6 @@
     "@hello-pangea/dnd": "^16.2.0",
     "@popperjs/core": "^2.11.6",
     "@types/ua-parser-js": "^0.7.36",
-    "@types/workerpool": "^6.4.0",
     "base64-js": "^1.5.1",
     "bootstrap": "^5.2.3",
     "bootstrap-icons": "^1.10.3",
@@ -36,7 +35,6 @@
     "threads": "^1.7.0",
     "typescript": "^4.9.4",
     "ua-parser-js": "^1.0.35",
-    "workerpool": "^6.4.0",
     "xml-formatter": "^3.3.2"
   },
   "devDependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
     "@hello-pangea/dnd": "^16.2.0",
     "@popperjs/core": "^2.11.6",
     "@types/ua-parser-js": "^0.7.36",
+    "base64-js": "^1.5.1",
     "bootstrap": "^5.2.3",
     "bootstrap-icons": "^1.10.3",
     "bootswatch": "^5.2.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
     "@hello-pangea/dnd": "^16.2.0",
     "@popperjs/core": "^2.11.6",
     "@types/ua-parser-js": "^0.7.36",
+    "@types/workerpool": "^6.4.0",
     "base64-js": "^1.5.1",
     "bootstrap": "^5.2.3",
     "bootstrap-icons": "^1.10.3",
@@ -32,8 +33,10 @@
     "react-dropzone": "^14.2.3",
     "react-redux": "^8.0.5",
     "styled-components": "^5.3.9",
+    "threads": "^1.7.0",
     "typescript": "^4.9.4",
     "ua-parser-js": "^1.0.35",
+    "workerpool": "^6.4.0",
     "xml-formatter": "^3.3.2"
   },
   "devDependencies": {

--- a/frontend/src/app/api.ts
+++ b/frontend/src/app/api.ts
@@ -133,6 +133,15 @@ export const apiSlice = createApi({
       transformResponse: (response: { info: BackendInfo }, meta, arg) =>
         response.info,
     }),
+    getGoogleDriveImage: builder.query<string, string>({
+      query: (identifier: string) => ({
+        url: "https://script.google.com/macros/s/AKfycbw8laScKBfxda2Wb0g63gkYDBdy8NWNxINoC4xDOwnCQ3JMFdruam1MdmNmN4wI5k4/exec",
+        method: "GET",
+        params: { id: identifier },
+        responseHandler: "text",
+      }),
+      keepUnusedDataFor: 1,
+    }),
   }),
 });
 

--- a/frontend/src/app/api.ts
+++ b/frontend/src/app/api.ts
@@ -10,7 +10,7 @@ import {
 } from "@reduxjs/toolkit/query/react";
 
 import { RootState } from "@/app/store";
-import { QueryTags } from "@/common/constants";
+import { GoogleDriveImageAPIURL, QueryTags } from "@/common/constants";
 import {
   BackendInfo,
   CardDocument,
@@ -135,7 +135,7 @@ export const apiSlice = createApi({
     }),
     getGoogleDriveImage: builder.query<string, string>({
       query: (identifier: string) => ({
-        url: "https://script.google.com/macros/s/AKfycbw8laScKBfxda2Wb0g63gkYDBdy8NWNxINoC4xDOwnCQ3JMFdruam1MdmNmN4wI5k4/exec",
+        url: GoogleDriveImageAPIURL,
         method: "GET",
         params: { id: identifier },
         responseHandler: "text",

--- a/frontend/src/app/app.tsx
+++ b/frontend/src/app/app.tsx
@@ -15,6 +15,7 @@ import { NavbarHeight } from "@/common/constants";
 import { selectBackendURL } from "@/features/backend/backendSlice";
 import { CardGrid } from "@/features/card/cardGrid";
 import { CommonCardback } from "@/features/card/commonCardback";
+import { Export } from "@/features/export/export";
 import { Import } from "@/features/import/import";
 import { ProjectStatus } from "@/features/project/projectStatus";
 import { fetchSourceDocuments } from "@/features/search/sourceDocumentsSlice";
@@ -61,14 +62,14 @@ function App() {
           >
             <ProjectStatus />
             <Row className="g-0">
-              <ViewSettings />
+              <SearchSettings />
             </Row>
             <Row className="g-0 py-3">
               <Col lg={6} md={12} sm={12} xs={12}>
-                <SearchSettings />
+                <Import />
               </Col>
               <Col lg={6} md={12} sm={12} xs={12}>
-                <Import />
+                <Export />
               </Col>
             </Row>
             <Col className="g-0" lg={{ span: 8, offset: 2 }} md={12}>

--- a/frontend/src/common/constants.ts
+++ b/frontend/src/common/constants.ts
@@ -54,3 +54,6 @@ export const ProjectMaxSize: number = Brackets[Brackets.length - 1];
 export enum QueryTags {
   BackendSpecific = "backendSpecific",
 }
+
+export const GoogleDriveImageAPIURL =
+  "https://script.google.com/macros/s/AKfycbw8laScKBfxda2Wb0g63gkYDBdy8NWNxINoC4xDOwnCQ3JMFdruam1MdmNmN4wI5k4/exec";

--- a/frontend/src/common/processing.ts
+++ b/frontend/src/common/processing.ts
@@ -2,6 +2,8 @@
  * This module contains functions which sanitise and transform user inputs for cards to query into useful formats.
  */
 
+import { toByteArray } from "base64-js";
+
 import {
   Card,
   CardTypePrefixes,
@@ -250,4 +252,8 @@ export function standardiseURL(url: string): string {
 export function formatURL(backendURL: string, routeURL: string): string {
   // TODO: implement this properly
   return backendURL + routeURL;
+}
+
+export function base64StringToBlob(base64: string): Blob {
+  return new Blob([toByteArray(base64)]);
 }

--- a/frontend/src/common/test-utils.tsx
+++ b/frontend/src/common/test-utils.tsx
@@ -310,12 +310,20 @@ export async function openSearchSettingsModal() {
   return screen.getByTestId("search-settings");
 }
 
-async function downloadFile(id: string) {
+function getDownloadMenu() {
+  return within(screen.getByTestId("right-panel")).getByText("Download", {
+    exact: false,
+  });
+}
+
+async function downloadFile(label: string) {
   // @ts-ignore
   jest.spyOn(global, "Blob").mockImplementation(function (content, options) {
     return { content, options };
   });
-  await waitFor(() => screen.getByTestId(`download-${id}`).click());
+  const downloadMenu = getDownloadMenu();
+  downloadMenu.click();
+  await waitFor(() => screen.getByText(label, { exact: false }).click());
   expect(FileSaver.saveAs).toHaveBeenCalledTimes(1);
 
   // @ts-ignore
@@ -324,11 +332,11 @@ async function downloadFile(id: string) {
 }
 
 export async function downloadXML() {
-  return await downloadFile("xml");
+  return await downloadFile("XML");
 }
 
 export async function downloadDecklist() {
-  return await downloadFile("decklist");
+  return await downloadFile("Decklist");
 }
 
 //# endregion

--- a/frontend/src/common/test-utils.tsx
+++ b/frontend/src/common/test-utils.tsx
@@ -316,14 +316,14 @@ function getDownloadMenu() {
   });
 }
 
-async function downloadFile(label: string) {
+async function downloadFile(testId: string) {
   // @ts-ignore
   jest.spyOn(global, "Blob").mockImplementation(function (content, options) {
     return { content, options };
   });
   const downloadMenu = getDownloadMenu();
   downloadMenu.click();
-  await waitFor(() => screen.getByText(label, { exact: false }).click());
+  await waitFor(() => screen.getByTestId(testId).click());
   expect(FileSaver.saveAs).toHaveBeenCalledTimes(1);
 
   // @ts-ignore
@@ -332,11 +332,11 @@ async function downloadFile(label: string) {
 }
 
 export async function downloadXML() {
-  return await downloadFile("XML");
+  return await downloadFile("export-xml-button");
 }
 
 export async function downloadDecklist() {
-  return await downloadFile("Decklist");
+  return await downloadFile("export-decklist-button");
 }
 
 //# endregion

--- a/frontend/src/features/card/cardDetailedView.tsx
+++ b/frontend/src/features/card/cardDetailedView.tsx
@@ -12,13 +12,17 @@ import Row from "react-bootstrap/Row";
 import Table from "react-bootstrap/Table";
 import { useSelector } from "react-redux";
 
+import { apiSlice } from "@/app/api";
 import { RootState } from "@/app/store";
+import { base64StringToBlob } from "@/common/processing";
 import { CardDocument } from "@/common/types";
 import { imageSizeToMBString } from "@/common/utils";
 import {
   MemoizedCardImage,
   MemoizedCardProportionWrapper,
 } from "@/features/card/card";
+import DisableSSR from "@/features/ui/disableSSR";
+import { Spinner } from "@/features/ui/spinner";
 
 interface CardDetailedViewProps {
   imageIdentifier: string;
@@ -45,126 +49,144 @@ export function CardDetailedView({
     (state: RootState) => state.sourceDocuments.sourceDocuments
   );
 
+  const [triggerFn, getGoogleDriveImageQuery] =
+    apiSlice.endpoints.getGoogleDriveImage.useLazyQuery();
+
+  const downloadImage = async () => {
+    const response = await triggerFn(maybeCardDocument.identifier);
+    const data = response.data;
+    if (data != null) {
+      saveAs(
+        base64StringToBlob(data),
+        `${maybeCardDocument.name} (${maybeCardDocument.identifier}).${maybeCardDocument.extension}`
+      );
+    }
+  };
+
   return (
-    <div>
-      {maybeCardDocument != null && (
-        <Modal
-          show={show}
-          onHide={handleClose}
-          size={"xl"}
-          data-testid="detailed-view"
-        >
-          <Modal.Header closeButton>
-            <Modal.Title>Card Details</Modal.Title>
-          </Modal.Header>
-          <Modal.Body>
-            <Row>
-              <div
-                className="col-lg-5 mb-3 mb-lg-0"
-                style={{ position: "relative" }}
-              >
-                <MemoizedCardProportionWrapper small={false}>
-                  <MemoizedCardImage
-                    cardDocument={maybeCardDocument}
-                    hidden={false}
-                    small={false}
-                  />
-                </MemoizedCardProportionWrapper>
-              </div>
-              <div className="col-lg-7">
-                <h4>{maybeCardDocument.name}</h4>
-                <Table hover>
-                  <tbody>
-                    <tr>
-                      <td>
-                        <b>Source Name</b>
-                      </td>
-                      <td>
-                        {maybeSourceDocuments != null &&
-                        maybeSourceDocuments[maybeCardDocument.source_id]
-                          .external_link != null ? (
-                          <a
-                            href={
-                              maybeSourceDocuments[maybeCardDocument.source_id]
-                                .external_link
-                            }
-                            target="_blank"
-                          >
-                            {maybeCardDocument.source_name}
-                          </a>
-                        ) : (
-                          <a>{maybeCardDocument.source_name}</a>
-                        )}
-                      </td>
-                    </tr>
-                    <tr>
-                      <td>
-                        <b>Source Type</b>
-                      </td>
-                      <td>{maybeCardDocument.source_type}</td>
-                    </tr>
-                    <tr>
-                      <td>
-                        <b>Class</b>
-                      </td>
-                      <td>
-                        {maybeCardDocument.card_type.charAt(0).toUpperCase() +
-                          maybeCardDocument.card_type.slice(1).toLowerCase()}
-                      </td>
-                    </tr>
-                    <tr>
-                      <td>
-                        <b>Identifier</b>
-                      </td>
-                      <td>
-                        <code>{maybeCardDocument.identifier}</code>
-                      </td>
-                    </tr>
-                    <tr>
-                      <td>
-                        <b>Resolution</b>
-                      </td>
-                      <td>{maybeCardDocument.dpi} DPI</td>
-                    </tr>
-                    <tr>
-                      <td>
-                        <b>Date Created</b>
-                      </td>
-                      <td>{maybeCardDocument.date}</td>
-                    </tr>
-                    <tr>
-                      <td>
-                        <b>File Size</b>
-                      </td>
-                      <td>{imageSizeToMBString(maybeCardDocument.size, 2)}</td>
-                    </tr>
-                  </tbody>
-                </Table>
-                <div className="d-grid gap-0">
-                  <Button
-                    variant="primary"
-                    onClick={() =>
-                      // TODO: setting the filename like this doesn't work for google drive links :(
-                      saveAs(
-                        maybeCardDocument.download_link,
-                        `${maybeCardDocument.name} (${maybeCardDocument.identifier}).${maybeCardDocument.extension}`
-                      )
-                    }
-                  >
-                    Download Image
-                  </Button>
+    <DisableSSR>
+      <div>
+        {maybeCardDocument != null && (
+          <Modal
+            show={show}
+            onHide={handleClose}
+            size={"xl"}
+            data-testid="detailed-view"
+          >
+            <Modal.Header closeButton>
+              <Modal.Title>Card Details</Modal.Title>
+            </Modal.Header>
+            <Modal.Body>
+              <Row>
+                <div
+                  className="col-lg-5 mb-3 mb-lg-0"
+                  style={{ position: "relative" }}
+                >
+                  <MemoizedCardProportionWrapper small={false}>
+                    <MemoizedCardImage
+                      cardDocument={maybeCardDocument}
+                      hidden={false}
+                      small={false}
+                    />
+                  </MemoizedCardProportionWrapper>
                 </div>
-              </div>
-            </Row>
-          </Modal.Body>
-          <Modal.Footer>
-            <Button variant="secondary" onClick={handleClose}>
-              Close
-            </Button>
-          </Modal.Footer>
-        </Modal>
-      )}
-    </div>
+                <div className="col-lg-7">
+                  <h4>{maybeCardDocument.name}</h4>
+                  <Table hover>
+                    <tbody>
+                      <tr>
+                        <td>
+                          <b>Source Name</b>
+                        </td>
+                        <td>
+                          {maybeSourceDocuments != null &&
+                          maybeSourceDocuments[maybeCardDocument.source_id]
+                            .external_link != null ? (
+                            <a
+                              href={
+                                maybeSourceDocuments[
+                                  maybeCardDocument.source_id
+                                ].external_link
+                              }
+                              target="_blank"
+                            >
+                              {maybeCardDocument.source_name}
+                            </a>
+                          ) : (
+                            <a>{maybeCardDocument.source_name}</a>
+                          )}
+                        </td>
+                      </tr>
+                      <tr>
+                        <td>
+                          <b>Source Type</b>
+                        </td>
+                        <td>{maybeCardDocument.source_type}</td>
+                      </tr>
+                      <tr>
+                        <td>
+                          <b>Class</b>
+                        </td>
+                        <td>
+                          {maybeCardDocument.card_type.charAt(0).toUpperCase() +
+                            maybeCardDocument.card_type.slice(1).toLowerCase()}
+                        </td>
+                      </tr>
+                      <tr>
+                        <td>
+                          <b>Identifier</b>
+                        </td>
+                        <td>
+                          <code>{maybeCardDocument.identifier}</code>
+                        </td>
+                      </tr>
+                      <tr>
+                        <td>
+                          <b>Resolution</b>
+                        </td>
+                        <td>{maybeCardDocument.dpi} DPI</td>
+                      </tr>
+                      <tr>
+                        <td>
+                          <b>Date Created</b>
+                        </td>
+                        <td>{maybeCardDocument.date}</td>
+                      </tr>
+                      <tr>
+                        <td>
+                          <b>File Size</b>
+                        </td>
+                        <td>
+                          {imageSizeToMBString(maybeCardDocument.size, 2)}
+                        </td>
+                      </tr>
+                    </tbody>
+                  </Table>
+                  <div className="d-grid gap-0">
+                    <Button
+                      variant="primary"
+                      onClick={downloadImage}
+                      disabled={getGoogleDriveImageQuery.isFetching}
+                    >
+                      {getGoogleDriveImageQuery.isFetching ? (
+                        <Spinner size={1.5} />
+                      ) : (
+                        "Download Image"
+                      )}
+                    </Button>
+                  </div>
+                </div>
+              </Row>
+            </Modal.Body>
+            <Modal.Footer>
+              <Button variant="secondary" onClick={handleClose}>
+                Close
+              </Button>
+            </Modal.Footer>
+          </Modal>
+        )}
+      </div>
+    </DisableSSR>
   );
 }
 

--- a/frontend/src/features/export/export.tsx
+++ b/frontend/src/features/export/export.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import Dropdown from "react-bootstrap/Dropdown";
+
+import { ExportDecklist } from "@/features/export/exportDecklist";
+import { ExportXML } from "@/features/export/exportXML";
+
+export function Export() {
+  return (
+    <>
+      <Dropdown>
+        <div className="d-grid gap-0">
+          <Dropdown.Toggle variant="success" id="dropdown-basic">
+            <i
+              className="bi bi-cloud-arrow-down"
+              style={{ paddingRight: 0.5 + "em" }}
+            />{" "}
+            Download
+          </Dropdown.Toggle>
+        </div>
+        <Dropdown.Menu>
+          <ExportDecklist />
+          <ExportXML />
+        </Dropdown.Menu>
+      </Dropdown>
+    </>
+  );
+}

--- a/frontend/src/features/export/export.tsx
+++ b/frontend/src/features/export/export.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import Dropdown from "react-bootstrap/Dropdown";
 
 import { ExportDecklist } from "@/features/export/exportDecklist";
+import { ExportImages } from "@/features/export/exportImages";
 import { ExportXML } from "@/features/export/exportXML";
 
 export function Export() {
@@ -20,6 +21,7 @@ export function Export() {
         <Dropdown.Menu>
           <ExportDecklist />
           <ExportXML />
+          <ExportImages />
         </Dropdown.Menu>
       </Dropdown>
     </>

--- a/frontend/src/features/export/exportDecklist.tsx
+++ b/frontend/src/features/export/exportDecklist.tsx
@@ -3,6 +3,12 @@
  * suitable for uploading to deckbuilding websites or sending to a friend.
  */
 
+import { saveAs } from "file-saver";
+import React from "react";
+import Dropdown from "react-bootstrap/Dropdown";
+import { useStore } from "react-redux";
+
+import { RootState } from "@/app/store";
 import { Back, Card, FaceSeparator, Front } from "@/common/constants";
 import { stripTextInParentheses } from "@/common/processing";
 import {
@@ -10,6 +16,7 @@ import {
   ProjectMember,
   SlotProjectMembers,
 } from "@/common/types";
+import { selectProjectMembers } from "@/features/project/projectSlice";
 
 function extractProjectMemberNames(
   projectMembers: Array<SlotProjectMembers>,
@@ -96,4 +103,29 @@ export function generateDecklist(
   );
   const stringifiedCardNames = stringifyCardNames(projectMemberNames);
   return aggregateIntoQuantities(stringifiedCardNames).join("\n");
+}
+
+const selectGeneratedDecklist = (state: RootState): string => {
+  return generateDecklist(
+    selectProjectMembers(state),
+    state.cardDocuments.cardDocuments
+  );
+};
+
+export function ExportDecklist() {
+  const store = useStore();
+  const downloadFile = () => {
+    const generatedDecklist = selectGeneratedDecklist(store.getState());
+    saveAs(
+      new Blob([generatedDecklist], { type: "text/plain;charset=utf-8" }),
+      "decklist.txt" // TODO: use project name here when we eventually track that
+    );
+  };
+
+  return (
+    <Dropdown.Item onClick={downloadFile}>
+      <i className="bi bi-card-text" style={{ paddingRight: 0.5 + "em" }} />{" "}
+      Decklist
+    </Dropdown.Item>
+  );
 }

--- a/frontend/src/features/export/exportDecklist.tsx
+++ b/frontend/src/features/export/exportDecklist.tsx
@@ -123,7 +123,7 @@ export function ExportDecklist() {
   };
 
   return (
-    <Dropdown.Item onClick={downloadFile}>
+    <Dropdown.Item onClick={downloadFile} data-testid="export-decklist-button">
       <i className="bi bi-card-text" style={{ paddingRight: 0.5 + "em" }} />{" "}
       Decklist
     </Dropdown.Item>

--- a/frontend/src/features/export/exportImages.tsx
+++ b/frontend/src/features/export/exportImages.tsx
@@ -8,8 +8,6 @@ import ProgressBar from "react-bootstrap/ProgressBar";
 import { useSelector } from "react-redux";
 import styled from "styled-components";
 import { Pool, spawn, Worker } from "threads";
-// @ts-ignore
-import workerURL from "threads-plugin/dist/loader?name=gitWorker!./workers/download.ts";
 
 import { RootState } from "@/app/store";
 import { ProjectName } from "@/common/constants";

--- a/frontend/src/features/export/exportImages.tsx
+++ b/frontend/src/features/export/exportImages.tsx
@@ -1,0 +1,136 @@
+import { saveAs } from "file-saver";
+import React, { useRef, useState } from "react";
+import Button from "react-bootstrap/Button";
+import Dropdown from "react-bootstrap/Dropdown";
+import Modal from "react-bootstrap/Modal";
+import ProgressBar from "react-bootstrap/ProgressBar";
+import { useSelector } from "react-redux";
+import styled from "styled-components";
+import { Pool, spawn, Worker } from "threads";
+// @ts-ignore
+import workerURL from "threads-plugin/dist/loader?name=gitWorker!./workers/download.ts";
+
+import { RootState } from "@/app/store";
+import { base64StringToBlob } from "@/common/processing";
+import { selectProjectMemberIdentifiers } from "@/features/project/projectSlice";
+import { Spinner } from "@/features/ui/spinner";
+
+const StyledProgressBar = styled(ProgressBar)`
+  --bs-progress-bg: #424e5c;
+`;
+
+export function ExportImages() {
+  const [showImagesModal, setShowImagesModal] = useState(false);
+  const handleCloseImagesModal = () => setShowImagesModal(false);
+  const handleShowImagesModal = () => setShowImagesModal(true);
+
+  const [downloading, setDownloading] = useState<boolean>(false);
+
+  const cardIdentifiers = Array.from(
+    useSelector(selectProjectMemberIdentifiers)
+  );
+  const cardDocumentsByIdentifier = useSelector((state: RootState) =>
+    Object.fromEntries(
+      cardIdentifiers.map((identifier) => [
+        identifier,
+        state.cardDocuments.cardDocuments[identifier],
+      ])
+    )
+  );
+
+  const [downloaded, setDownloaded] = useState<number>(0);
+  const progress = (100 * downloaded) / cardIdentifiers.length;
+
+  // regarding the ts-ignore below: passing this a URL is correct. if you pass it the stringified URL, things break
+  const workerPool = useRef(
+    Pool(
+      () =>
+        // @ts-ignore
+        spawn(new Worker(new URL("./workers/download.ts", import.meta.url))),
+      5
+    )
+  );
+
+  const downloadImages = async () => {
+    setDownloading(true);
+    setDownloaded(0);
+
+    const identifierPool = Array.from(cardIdentifiers);
+    let localDownloaded = 0;
+
+    identifierPool.map((identifier) =>
+      workerPool.current.queue(async (download) => {
+        alert(identifier);
+        const cardDocument = cardDocumentsByIdentifier[identifier];
+        alert(cardDocument);
+        if (cardDocument != null) {
+          const data = await download(identifier);
+          saveAs(
+            base64StringToBlob(data),
+            `${cardDocument.name} (${cardDocument.identifier}).${cardDocument.extension}`
+          );
+        }
+        localDownloaded++;
+        setDownloaded(localDownloaded);
+      })
+    );
+
+    await workerPool.current.settled();
+    await workerPool.current.terminate();
+
+    setDownloading(false);
+  };
+
+  return (
+    <>
+      <Dropdown.Item onClick={handleShowImagesModal}>
+        <i className="bi bi-image" style={{ paddingRight: 0.5 + "em" }} /> Card
+        Images
+      </Dropdown.Item>
+      <Modal
+        show={showImagesModal}
+        onHide={handleCloseImagesModal}
+        data-testid="export-images"
+      >
+        <Modal.Header closeButton>
+          <Modal.Title>Download — Card Images</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          <p>
+            {downloading
+              ? "Your images should be downloading now. Please don't close the page until the process is complete."
+              : "Click the button below to commence the download."}
+          </p>
+          {(downloading ||
+            (downloaded == cardIdentifiers.length && downloaded > 0)) && (
+            <>
+              <StyledProgressBar
+                striped
+                animated={true}
+                now={progress}
+                label={`${downloaded} / ${cardIdentifiers.length}`}
+                variant="success"
+              />
+              <br />
+            </>
+          )}
+
+          <div className="d-grid gap-0">
+            <Button
+              variant="primary"
+              onClick={downloadImages}
+              disabled={downloading}
+            >
+              {downloading ? <Spinner size={1.5} /> : "Download Images"}
+            </Button>
+          </div>
+        </Modal.Body>
+        <Modal.Footer>
+          <Button variant="secondary" onClick={handleCloseImagesModal}>
+            Close
+          </Button>
+        </Modal.Footer>
+      </Modal>
+    </>
+  );
+}

--- a/frontend/src/features/export/exportXML.tsx
+++ b/frontend/src/features/export/exportXML.tsx
@@ -194,7 +194,7 @@ export function ExportXML() {
   };
 
   return (
-    <Dropdown.Item onClick={downloadFile}>
+    <Dropdown.Item onClick={downloadFile} data-testid="export-xml-button">
       <i className="bi bi-file-code" style={{ paddingRight: 0.5 + "em" }} /> XML
     </Dropdown.Item>
   );

--- a/frontend/src/features/export/exportXML.tsx
+++ b/frontend/src/features/export/exportXML.tsx
@@ -4,11 +4,20 @@
  * through the desktop tool CLI.
  */
 
+import { saveAs } from "file-saver";
+import React from "react";
+import Dropdown from "react-bootstrap/Dropdown";
+import { useStore } from "react-redux";
 import formatXML from "xml-formatter";
 
+import { RootState } from "@/app/store";
 import { Back, Front, ReversedCardTypePrefixes } from "@/common/constants";
 import { CardDocuments, SlotProjectMembers } from "@/common/types";
 import { bracket } from "@/common/utils";
+import {
+  selectProjectMembers,
+  selectProjectSize,
+} from "@/features/project/projectSlice";
 
 interface SlotsByIdentifier {
   [identifier: string]: Set<number>;
@@ -95,6 +104,15 @@ function createCardElement(
   return cardElement;
 }
 
+const selectGeneratedXML = (state: RootState): string => {
+  return generateXML(
+    selectProjectMembers(state),
+    state.cardDocuments.cardDocuments,
+    state.project.cardback,
+    selectProjectSize(state)
+  );
+};
+
 export function generateXML(
   projectMembers: Array<SlotProjectMembers>,
   cardDocuments: CardDocuments,
@@ -163,4 +181,21 @@ export function generateXML(
   const xml = serialiser.serializeToString(doc);
 
   return formatXML(xml, { collapseContent: true });
+}
+
+export function ExportXML() {
+  const store = useStore();
+  const downloadFile = () => {
+    const generatedXML = selectGeneratedXML(store.getState());
+    saveAs(
+      new Blob([generatedXML], { type: "text/xml;charset=utf-8" }),
+      "cards.xml"
+    );
+  };
+
+  return (
+    <Dropdown.Item onClick={downloadFile}>
+      <i className="bi bi-file-code" style={{ paddingRight: 0.5 + "em" }} /> XML
+    </Dropdown.Item>
+  );
 }

--- a/frontend/src/features/export/workers/download.ts
+++ b/frontend/src/features/export/workers/download.ts
@@ -1,0 +1,9 @@
+import { expose } from "threads/worker";
+
+expose(async function download(identifier: string) {
+  const response = await fetch(
+    `https://script.google.com/macros/s/AKfycbw8laScKBfxda2Wb0g63gkYDBdy8NWNxINoC4xDOwnCQ3JMFdruam1MdmNmN4wI5k4/exec?id=${identifier}`,
+    { method: "GET", credentials: "same-origin" }
+  );
+  return await response.text();
+});

--- a/frontend/src/features/export/workers/download.ts
+++ b/frontend/src/features/export/workers/download.ts
@@ -1,9 +1,11 @@
 import { expose } from "threads/worker";
 
+import { GoogleDriveImageAPIURL } from "@/common/constants";
+
 expose(async function download(identifier: string) {
-  const response = await fetch(
-    `https://script.google.com/macros/s/AKfycbw8laScKBfxda2Wb0g63gkYDBdy8NWNxINoC4xDOwnCQ3JMFdruam1MdmNmN4wI5k4/exec?id=${identifier}`,
-    { method: "GET", credentials: "same-origin" }
-  );
+  const response = await fetch(GoogleDriveImageAPIURL + `?id=${identifier}`, {
+    method: "GET",
+    credentials: "same-origin",
+  });
   return await response.text();
 });

--- a/frontend/src/features/project/projectSlice.ts
+++ b/frontend/src/features/project/projectSlice.ts
@@ -337,22 +337,6 @@ export const selectProjectSize = (state: RootState): number =>
 export const selectProjectCardback = (state: RootState): string | null =>
   state.project.cardback;
 
-export const selectGeneratedXML = (state: RootState): string => {
-  return generateXML(
-    selectProjectMembers(state),
-    state.cardDocuments.cardDocuments,
-    state.project.cardback,
-    selectProjectSize(state)
-  );
-};
-
-export const selectGeneratedDecklist = (state: RootState): string => {
-  return generateDecklist(
-    selectProjectMembers(state),
-    state.cardDocuments.cardDocuments
-  );
-};
-
 export const selectProjectFileSize = (state: RootState): number => {
   const uniqueCardIdentifiers = new Set<string>();
   for (const slotProjectMembers of state.project.members) {

--- a/frontend/src/features/project/projectSlice.ts
+++ b/frontend/src/features/project/projectSlice.ts
@@ -302,6 +302,15 @@ export const selectProjectMembers = (
   state: RootState
 ): Array<SlotProjectMembers> => state.project.members;
 
+export const selectProjectMemberIdentifiers = (state: RootState): Set<string> =>
+  new Set(
+    state.project.members.flatMap((x: SlotProjectMembers) =>
+      (x.front?.selectedImage != null ? [x.front.selectedImage] : []).concat(
+        x.back?.selectedImage != null ? [x.back.selectedImage] : []
+      )
+    )
+  );
+
 // TODO: this is a bit disgusting
 export const selectSelectedSlots = (state: RootState): Array<[Faces, number]> =>
   state.project.members.flatMap((x: SlotProjectMembers, index: number) =>

--- a/frontend/src/features/project/projectStatus.tsx
+++ b/frontend/src/features/project/projectStatus.tsx
@@ -1,12 +1,6 @@
-import { saveAs } from "file-saver";
 import React from "react";
 import Alert from "react-bootstrap/Alert";
-import Button from "react-bootstrap/Button";
-import Col from "react-bootstrap/Col";
-import OverlayTrigger from "react-bootstrap/OverlayTrigger";
-import Row from "react-bootstrap/Row";
-import Tooltip from "react-bootstrap/Tooltip";
-import { useSelector, useStore } from "react-redux";
+import { useSelector } from "react-redux";
 import styled from "styled-components";
 import { UAParser } from "ua-parser-js";
 
@@ -14,11 +8,10 @@ import { ProjectMaxSize, ProjectName } from "@/common/constants";
 import { bracket, imageSizeToMBString } from "@/common/utils";
 import { SelectedImagesStatus } from "@/features/project/bulkManagement";
 import {
-  selectGeneratedDecklist,
-  selectGeneratedXML,
   selectProjectFileSize,
   selectProjectSize,
 } from "@/features/project/projectSlice";
+import { ViewSettings } from "@/features/viewSettings/viewSettings";
 
 function MobileAlert() {
   const ua = UAParser();
@@ -39,27 +32,8 @@ const SizedIcon = styled.i`
 `;
 
 export function ProjectStatus() {
-  const store = useStore();
   const projectSize = useSelector(selectProjectSize);
   const projectFileSize = useSelector(selectProjectFileSize);
-
-  // TODO: read project name for these file names
-  // note: these functions use the store directly rather than `useSelector`
-  // to avoid recalculating XML and decklist every time state changes
-  const exportXML = () => {
-    const generatedXML = selectGeneratedXML(store.getState());
-    saveAs(
-      new Blob([generatedXML], { type: "text/xml;charset=utf-8" }),
-      "cards.xml"
-    );
-  };
-  const exportDecklist = () => {
-    const generatedDecklist = selectGeneratedDecklist(store.getState());
-    saveAs(
-      new Blob([generatedDecklist], { type: "text/plain;charset=utf-8" }),
-      "decklist.txt"
-    );
-  };
 
   return (
     <>
@@ -79,72 +53,7 @@ export function ProjectStatus() {
               You&apos;ve reached the maximum project size!
             </Alert>
           )}
-          <Row>
-            <Col xs={3}>
-              <div className="d-grid gap-0">
-                <OverlayTrigger
-                  placement="top"
-                  overlay={(props) => (
-                    <Tooltip {...props}>Save Project</Tooltip>
-                  )}
-                >
-                  <Button variant="outline-light">
-                    <SizedIcon className="bi bi-device-ssd" />
-                  </Button>
-                </OverlayTrigger>
-              </div>
-            </Col>
-            <Col xs={3}>
-              <div className="d-grid gap-0">
-                <OverlayTrigger
-                  placement="top"
-                  overlay={(props) => (
-                    <Tooltip {...props}>Download XML</Tooltip>
-                  )}
-                >
-                  <Button
-                    variant="outline-light"
-                    onClick={exportXML}
-                    data-testid="download-xml"
-                  >
-                    <SizedIcon className="bi bi-file-earmark-arrow-down" />
-                  </Button>
-                </OverlayTrigger>
-              </div>
-            </Col>
-            <Col xs={3}>
-              <div className="d-grid gap-0">
-                <OverlayTrigger
-                  placement="top"
-                  overlay={(props) => (
-                    <Tooltip {...props}>Download Decklist</Tooltip>
-                  )}
-                >
-                  <Button
-                    variant="outline-light"
-                    onClick={exportDecklist}
-                    data-testid="download-decklist"
-                  >
-                    <SizedIcon className="bi bi-file-text" />
-                  </Button>
-                </OverlayTrigger>
-              </div>
-            </Col>
-            <Col xs={3}>
-              <div className="d-grid gap-0">
-                <OverlayTrigger
-                  placement="top"
-                  overlay={(props) => (
-                    <Tooltip {...props}>Download Images</Tooltip>
-                  )}
-                >
-                  <Button variant="outline-light">
-                    <SizedIcon className="bi bi-images" />
-                  </Button>
-                </OverlayTrigger>
-              </div>
-            </Col>
-          </Row>
+          <ViewSettings />
         </Alert>
       )}
     </>

--- a/frontend/src/features/viewSettings/viewSettings.tsx
+++ b/frontend/src/features/viewSettings/viewSettings.tsx
@@ -11,18 +11,14 @@ import { useDispatch, useSelector } from "react-redux";
 
 import { RootState } from "@/app/store";
 import { ToggleButtonHeight } from "@/common/constants";
-import { selectIsProjectEmpty } from "@/features/project/projectSlice";
 import { toggleFaces } from "@/features/viewSettings/viewSettingsSlice";
 
 export function ViewSettings() {
-  const isProjectEmpty = useSelector(selectIsProjectEmpty);
   const frontsVisible = useSelector(
     (state: RootState) => state.viewSettings.frontsVisible
   );
   const dispatch = useDispatch();
-  return isProjectEmpty ? (
-    <></>
-  ) : (
+  return (
     <Toggle
       onClick={() => dispatch(toggleFaces())}
       on="Switch to Backs"

--- a/frontend/src/styles/styles.scss
+++ b/frontend/src/styles/styles.scss
@@ -29,7 +29,7 @@
 // @import "~bootstrap/scss/pagination";
 // @import "~bootstrap/scss/badge";
 @import "~bootstrap/scss/alert";
-// @import "~bootstrap/scss/progress";
+@import "~bootstrap/scss/progress";
 // @import "~bootstrap/scss/list-group";
 @import "~bootstrap/scss/close";
 @import "~bootstrap/scss/toasts";

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -25,5 +25,10 @@
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "jest.transformer.js"],
+  "ts-node": {
+    "compilerOptions": {
+      "module": "CommonJS"
+    }
+  }
 }

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "esnext",
     "downlevelIteration": true,
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": false,


### PR DESCRIPTION
# Description
* Previously we would open the link to download the image directly from Google in the user's browser - this approach had several drawbacks:
    * We needed to open one tab per image, which gets out of hand quickly when using the bulk download button. Solved in this PR, no tabs are opened.
    * We weren't able to change the name of the downloaded file, meaning we couldn't format it with the file's ID in parentheses, leading to possible name collisions between different versions of the same card. Solved in this PR, we now format the file's name appropriately.
    * You can easily get rate-limited by Google when downloading many images. Solved in this PR, the gscript endpoint does not rate limit.
* Image downloading in the frontend now utilises a google script endpoint which handles GET requests by returning the base64 encoded version of the requested image
    * Will update the desktop tool to utilise this endpoint at some point too
* The interface for bulk downloading now looks like this:
<img width="1204" alt="image" src="https://github.com/chilli-axe/mpc-autofill/assets/3079166/4ffab1bf-a38c-45f2-8e2d-e1b207d8e4f6">
* Bulk downloading is multi-threaded (tbh I'm a bit scared that javascript can do multi-threading in the first place)

# Checklist

- [x] I have installed `pre-commit` and run the hooks with `pre-commit run`.
- [x] I have updated any related tests for code I modified or added new tests where appropriate.
- [x] I have updated any relevant documentation or created new documentation where appropriate.
    - None required, the feature is self-explanatory
