### PR TITLE
Automatically save project to MakePlayingCards account

### DIFF
--- a/desktop-tool/autofill.py
+++ b/desktop-tool/autofill.py
@@ -145,7 +145,9 @@ def main(
                 PdfExporter().execute(post_processing_config=post_processing_config)
             else:
                 AutofillDriver(browser=Browsers[browser], binary_location=binary_location).execute(
-                    skip_setup=skipsetup, post_processing_config=post_processing_config
+                    skip_setup=skipsetup,
+                    auto_save_threshold=auto_save_threshold if auto_save else None,
+                    post_processing_config=post_processing_config,
                 )
     except Exception as e:
         print(f"An uncaught exception occurred:\n{TEXT_BOLD}{e}{TEXT_END}\n")

--- a/desktop-tool/autofill.py
+++ b/desktop-tool/autofill.py
@@ -16,7 +16,7 @@ from src.utils import TEXT_BOLD, TEXT_END
 os.system("")  # enables ansi escape characters in terminal
 
 
-@click.command()
+@click.command(context_settings={"show_default": True})
 @click.option(
     "--skipsetup",
     prompt="Skip project setup to continue editing an existing MPC project? (Press Enter if you're not sure.)"
@@ -26,9 +26,30 @@ os.system("")  # enables ansi escape characters in terminal
     help=(
         "If this flag is passed, the tool will prompt the user to navigate to an existing MPC project "
         "and will attempt to align the state of the given project XML with the state of the project "
-        "in MakePlayingCards. Note that this has some caveats - refer to the desktop-tool readme for details."
+        "in MakePlayingCards. Note that this has some caveats - refer to the wiki for details."
     ),
     is_flag=True,
+)
+@click.option(
+    "--auto-save",
+    prompt=(
+        "Automatically save this project to your MakePlayingAccounts while the tool is running? "
+        "(Press Enter if you're not sure.)"
+    )
+    if len(sys.argv) == 1
+    else False,
+    default=True,
+    help=(
+        "If this flag is passed, the tool will automatically save your project to your MakePlayingCards after "
+        "processing each batch of cards."
+    ),
+    is_flag=True,
+)
+@click.option(
+    "--auto-save-threshold",
+    type=click.IntRange(1, None),
+    default=5,
+    help="Controls how often the project should be saved in terms of the number of cards uploaded.",
 )
 @click.option(
     "-b",
@@ -76,8 +97,8 @@ os.system("")  # enables ansi escape characters in terminal
 @click.option(
     "--max-dpi",
     default=800,
-    type=click.INT,
-    help="Images above this DPI will be downscaled to it before being uploaded to MPC. Defaults to 800 DPI.",
+    type=click.IntRange(100, 1200),
+    help="Images above this DPI will be downscaled to it before being uploaded to MPC.",
 )
 @click.option(
     "--downscale-alg",
@@ -98,6 +119,8 @@ os.system("")  # enables ansi escape characters in terminal
 # )
 def main(
     skipsetup: bool,
+    auto_save: bool,
+    auto_save_threshold: int,
     browser: str,
     binary_location: Optional[str],
     exportpdf: bool,

--- a/desktop-tool/tests/test_desktop_client.py
+++ b/desktop-tool/tests/test_desktop_client.py
@@ -892,7 +892,7 @@ def test_pdf_export_complete_separate_faces(monkeypatch, card_order_valid):
 @pytest.mark.parametrize("browser", [constants.Browsers.chrome])
 def test_card_order_complete_run_single_cardback(browser, input_enter, card_order_valid):
     autofill_driver = AutofillDriver(order=card_order_valid, browser=browser, headless=True)
-    autofill_driver.execute(skip_setup=False, post_processing_config=DEFAULT_POST_PROCESSING)
+    autofill_driver.execute(skip_setup=False, auto_save_threshold=None, post_processing_config=DEFAULT_POST_PROCESSING)
     assert (
         len(
             WebDriverWait(autofill_driver.driver, 30).until(
@@ -906,7 +906,7 @@ def test_card_order_complete_run_single_cardback(browser, input_enter, card_orde
 @pytest.mark.parametrize("browser", [constants.Browsers.chrome, constants.Browsers.edge])
 def test_card_order_complete_run_multiple_cardbacks(browser, input_enter, card_order_multiple_cardbacks):
     autofill_driver = AutofillDriver(order=card_order_multiple_cardbacks, browser=browser, headless=True)
-    autofill_driver.execute(skip_setup=False, post_processing_config=DEFAULT_POST_PROCESSING)
+    autofill_driver.execute(skip_setup=False, auto_save_threshold=None, post_processing_config=DEFAULT_POST_PROCESSING)
     assert (
         len(
             WebDriverWait(autofill_driver.driver, 30).until(


### PR DESCRIPTION
# Description

* Resolves #107
* This PR adds two new args to the click CLI:
    * Whether or not to automatically save the project to the user's account - boolean flag - the user is prompted to answer this if no CLI args are passed
    * The number of images to upload before saving the project to the user's account - 5 by default (so save every 5 images)
* I have also introduced a bit of scaffolding for handling user logins. After contemplating our options here I decided I didn't want users to have to type their credentials into the tool directly (I'd feel uneasy having to do that as a user and I bet others would too), so instead we prompt the user to log in, then they indicate when they've logged in and we validate that
* Saving the project to the user's account is turned on by default

# Checklist

- [x] I have installed `pre-commit` and run the hooks with `pre-commit run`.
- [x] I have updated any related tests for code I modified or added new tests where appropriate.
    - Existing tests should continue to pass
    - We can't really write automated tests for this stuff but I tested it manually with a 326 card project
- [x] I have updated any relevant documentation or created new documentation where appropriate.
    - Help text in click CLI