### PR TITLE
Improve tag filtering

### DIFF
--- a/MPCAutofill/cardpicker/search/search_functions.py
+++ b/MPCAutofill/cardpicker/search/search_functions.py
@@ -206,7 +206,8 @@ class SearchSettings:
     max_dpi: int
     max_size: int  # number of bytes
     languages: list[pycountry.Languages]
-    tags: list[str]
+    includes_tags: list[str]
+    excludes_tags: list[str]
 
     @classmethod
     def from_json_body(cls, json_body: dict[str, Any]) -> "SearchSettings":
@@ -243,7 +244,8 @@ class SearchSettings:
             for language in filter_settings["languages"]
             if (parsed_language := pycountry.languages.get(alpha_2=language)) is not None
         ]
-        tags = filter_settings["tags"]
+        includes_tags = filter_settings["includesTags"]
+        excludes_tags = filter_settings["excludesTags"]
 
         return cls(
             fuzzy_search=fuzzy_search,
@@ -253,7 +255,8 @@ class SearchSettings:
             max_dpi=max_dpi,
             max_size=max_size,
             languages=languages,
-            tags=tags,
+            includes_tags=includes_tags,
+            excludes_tags=excludes_tags,
         )
 
     def get_source_order(self) -> dict[str, int]:
@@ -273,11 +276,15 @@ class SearchSettings:
                 if self.languages
                 else ~Q(pk__in=[])
             )
-            tag_filter = (Q(tags__contains=self.tags) | Q(tags__contained_by=self.tags)) if self.tags else ~Q(pk__in=[])
+            includes_tag_filter = (
+                (Q(tags__contains=self.includes_tags) | Q(tags__contained_by=self.includes_tags))
+                if self.includes_tags
+                else ~Q(pk__in=[])
+            )
             source_order = self.get_source_order()
             hits_iterable = Card.objects.filter(
                 language_filter,
-                tag_filter,
+                includes_tag_filter,
                 card_type=CardTypes.CARDBACK,
                 source__key__in=self.sources,
                 dpi__gte=self.min_dpi,
@@ -363,8 +370,8 @@ class SearchQuery:
                     minimum_should_match=1,
                 )
             )
-        if search_settings.tags:
-            s = s.filter(Bool(should=Terms(tags=search_settings.tags), minimum_should_match=1))
+        if search_settings.includes_tags:
+            s = s.filter(Bool(should=Terms(tags=search_settings.includes_tags), minimum_should_match=1))
         hits_iterable = s.params(preserve_order=True).scan()
 
         source_order = search_settings.get_source_order()

--- a/MPCAutofill/cardpicker/tests/__snapshots__/test_views.ambr
+++ b/MPCAutofill/cardpicker/tests/__snapshots__/test_views.ambr
@@ -1079,6 +1079,17 @@
     'status_code': 200,
   })
 # ---
+# name: TestPostCardbacks.test_get_multiple_rows_filtered_includes_two_tags
+  dict({
+    'json': dict({
+      'cardbacks': list([
+        '1JtXL6Ca9nQkvhwZZRR9ZuKA9_DzsFf1V',
+        '1oigI6wz0zA--pNMuExKTs40kBNH6VRP_',
+      ]),
+    }),
+    'status_code': 200,
+  })
+# ---
 # name: TestPostCardbacks.test_get_multiple_rows_filtered_only_source_1
   dict({
     'json': dict({
@@ -1121,17 +1132,6 @@
     'status_code': 200,
   })
 # ---
-# name: TestPostCardbacks.test_get_multiple_rows_filtered_includes_two_tags
-  dict({
-    'json': dict({
-      'cardbacks': list([
-        '1JtXL6Ca9nQkvhwZZRR9ZuKA9_DzsFf1V',
-        '1oigI6wz0zA--pNMuExKTs40kBNH6VRP_',
-      ]),
-    }),
-    'status_code': 200,
-  })
-# ---
 # name: TestPostCardbacks.test_get_multiple_rows_unfiltered
   dict({
     'json': dict({
@@ -1143,7 +1143,7 @@
     'status_code': 200,
   })
 # ---
-# name: TestPostCardbacks.test_get_one_row_filtered_one_language
+# name: TestPostCardbacks.test_get_one_row_filtered_excludes_one_tag
   dict({
     'json': dict({
       'cardbacks': list([
@@ -1158,6 +1158,26 @@
     'json': dict({
       'cardbacks': list([
         '1JtXL6Ca9nQkvhwZZRR9ZuKA9_DzsFf1V',
+      ]),
+    }),
+    'status_code': 200,
+  })
+# ---
+# name: TestPostCardbacks.test_get_one_row_filtered_includes_one_tag_and_excludes_another
+  dict({
+    'json': dict({
+      'cardbacks': list([
+        '1oigI6wz0zA--pNMuExKTs40kBNH6VRP_',
+      ]),
+    }),
+    'status_code': 200,
+  })
+# ---
+# name: TestPostCardbacks.test_get_one_row_filtered_one_language
+  dict({
+    'json': dict({
+      'cardbacks': list([
+        '1oigI6wz0zA--pNMuExKTs40kBNH6VRP_',
       ]),
     }),
     'status_code': 200,
@@ -1633,14 +1653,13 @@
     'status_code': 200,
   })
 # ---
-# name: TestPostSearchResults.test_get_multiple_rows_filtered_two_languages
+# name: TestPostSearchResults.test_get_multiple_rows_filtered_includes_one_tag_and_excludes_another
   dict({
     'json': dict({
       'results': dict({
         'Pást in Flames': dict({
           'CARD': list([
             '1UPdh7J7hScg4ZnxSPJ-EeBYHLp2s3Oz1',
-            '1dxSLHtw-VwwE09pZCA8OA6LbuWRZPEoU',
           ]),
         }),
       }),
@@ -1663,11 +1682,26 @@
     'status_code': 200,
   })
 # ---
-# name: TestPostSearchResults.test_get_one_row_filtered_one_language
+# name: TestPostSearchResults.test_get_multiple_rows_filtered_two_languages
   dict({
     'json': dict({
       'results': dict({
         'Pást in Flames': dict({
+          'CARD': list([
+            '1UPdh7J7hScg4ZnxSPJ-EeBYHLp2s3Oz1',
+            '1dxSLHtw-VwwE09pZCA8OA6LbuWRZPEoU',
+          ]),
+        }),
+      }),
+    }),
+    'status_code': 200,
+  })
+# ---
+# name: TestPostSearchResults.test_get_one_row_filtered_excludes_one_tag
+  dict({
+    'json': dict({
+      'results': dict({
+        'Past in Flames': dict({
           'CARD': list([
             '1UPdh7J7hScg4ZnxSPJ-EeBYHLp2s3Oz1',
           ]),
@@ -1684,6 +1718,20 @@
         'Pást in Flames': dict({
           'CARD': list([
             '1dxSLHtw-VwwE09pZCA8OA6LbuWRZPEoU',
+          ]),
+        }),
+      }),
+    }),
+    'status_code': 200,
+  })
+# ---
+# name: TestPostSearchResults.test_get_one_row_filtered_one_language
+  dict({
+    'json': dict({
+      'results': dict({
+        'Pást in Flames': dict({
+          'CARD': list([
+            '1UPdh7J7hScg4ZnxSPJ-EeBYHLp2s3Oz1',
           ]),
         }),
       }),

--- a/MPCAutofill/cardpicker/tests/__snapshots__/test_views.ambr
+++ b/MPCAutofill/cardpicker/tests/__snapshots__/test_views.ambr
@@ -1068,7 +1068,7 @@
     'status_code': 400,
   })
 # ---
-# name: TestPostCardbacks.test_get_multiple_rows_filtered_one_tag
+# name: TestPostCardbacks.test_get_multiple_rows_filtered_includes_one_tag
   dict({
     'json': dict({
       'cardbacks': list([
@@ -1121,7 +1121,7 @@
     'status_code': 200,
   })
 # ---
-# name: TestPostCardbacks.test_get_multiple_rows_filtered_two_tags
+# name: TestPostCardbacks.test_get_multiple_rows_filtered_includes_two_tags
   dict({
     'json': dict({
       'cardbacks': list([
@@ -1153,7 +1153,7 @@
     'status_code': 200,
   })
 # ---
-# name: TestPostCardbacks.test_get_one_row_filtered_one_tag
+# name: TestPostCardbacks.test_get_one_row_filtered_includes_one_tag
   dict({
     'json': dict({
       'cardbacks': list([
@@ -1618,7 +1618,7 @@
     'status_code': 200,
   })
 # ---
-# name: TestPostSearchResults.test_get_multiple_rows_filtered_one_tag
+# name: TestPostSearchResults.test_get_multiple_rows_filtered_includes_one_tag
   dict({
     'json': dict({
       'results': dict({
@@ -1648,7 +1648,7 @@
     'status_code': 200,
   })
 # ---
-# name: TestPostSearchResults.test_get_multiple_rows_filtered_two_tags
+# name: TestPostSearchResults.test_get_multiple_rows_filtered_includes_two_tags
   dict({
     'json': dict({
       'results': dict({
@@ -1677,7 +1677,7 @@
     'status_code': 200,
   })
 # ---
-# name: TestPostSearchResults.test_get_one_row_filtered_one_tag
+# name: TestPostSearchResults.test_get_one_row_filtered_includes_one_tag
   dict({
     'json': dict({
       'results': dict({

--- a/MPCAutofill/cardpicker/tests/test_views.py
+++ b/MPCAutofill/cardpicker/tests/test_views.py
@@ -23,7 +23,14 @@ def snapshot_response(response: Response, snapshot: SnapshotAssertion):
 BASE_SEARCH_SETTINGS = {
     "searchTypeSettings": {"fuzzySearch": False, "filterCardbacks": False},
     "sourceSettings": {"sources": [[Sources.EXAMPLE_DRIVE_1.value.pk, True], [Sources.EXAMPLE_DRIVE_2.value.pk, True]]},
-    "filterSettings": {"minimumDPI": 0, "maximumDPI": 1500, "maximumSize": 30, "languages": [], "tags": []},
+    "filterSettings": {
+        "minimumDPI": 0,
+        "maximumDPI": 1500,
+        "maximumSize": 30,
+        "languages": [],
+        "includesTags": [],
+        "excludesTags": [],
+    },
 }
 
 
@@ -292,11 +299,11 @@ class TestPostSearchResults:
         assert response.status_code == 200
         assert len(response.json()["results"][Cards.PAST_IN_FLAMES_1.value.name]["CARD"]) == 2
 
-    def test_get_one_row_filtered_one_tag(
+    def test_get_one_row_filtered_includes_one_tag(
         self, client, snapshot, past_in_flames_1, past_in_flames_2, another_tag_in_data
     ):
         search_settings = deepcopy(BASE_SEARCH_SETTINGS)
-        search_settings["filterSettings"]["tags"] = [another_tag_in_data.name]
+        search_settings["filterSettings"]["includesTags"] = [another_tag_in_data.name]
         response = client.post(
             reverse(views.post_search_results),
             {
@@ -309,11 +316,11 @@ class TestPostSearchResults:
         assert response.status_code == 200
         assert len(response.json()["results"][Cards.PAST_IN_FLAMES_1.value.name]["CARD"]) == 1
 
-    def test_get_multiple_rows_filtered_one_tag(
+    def test_get_multiple_rows_filtered_includes_one_tag(
         self, client, snapshot, past_in_flames_1, past_in_flames_2, tag_in_data
     ):
         search_settings = deepcopy(BASE_SEARCH_SETTINGS)
-        search_settings["filterSettings"]["tags"] = [tag_in_data.name, tag_in_data.name]
+        search_settings["filterSettings"]["includesTags"] = [tag_in_data.name, tag_in_data.name]
         response = client.post(
             reverse(views.post_search_results),
             {
@@ -326,11 +333,11 @@ class TestPostSearchResults:
         assert response.status_code == 200
         assert len(response.json()["results"][Cards.PAST_IN_FLAMES_1.value.name]["CARD"]) == 2
 
-    def test_get_multiple_rows_filtered_two_tags(
+    def test_get_multiple_rows_filtered_includes_two_tags(
         self, client, snapshot, past_in_flames_1, past_in_flames_2, tag_in_data, another_tag_in_data
     ):
         search_settings = deepcopy(BASE_SEARCH_SETTINGS)
-        search_settings["filterSettings"]["tags"] = [tag_in_data.name, another_tag_in_data.name]
+        search_settings["filterSettings"]["includesTags"] = [tag_in_data.name, another_tag_in_data.name]
         response = client.post(
             reverse(views.post_search_results),
             {
@@ -665,9 +672,11 @@ class TestPostCardbacks:
         assert response.status_code == 200
         assert len(response.json()["cardbacks"]) == 2
 
-    def test_get_one_row_filtered_one_tag(self, client, snapshot, simple_cube, simple_lotus, another_tag_in_data):
+    def test_get_one_row_filtered_includes_one_tag(
+        self, client, snapshot, simple_cube, simple_lotus, another_tag_in_data
+    ):
         search_settings = deepcopy(BASE_SEARCH_SETTINGS)
-        search_settings["filterSettings"]["tags"] = [another_tag_in_data.name]
+        search_settings["filterSettings"]["includesTags"] = [another_tag_in_data.name]
         search_settings["searchTypeSettings"]["filterCardbacks"] = True
         response = client.post(
             reverse(views.post_cardbacks), {"searchSettings": search_settings}, content_type="application/json"
@@ -676,9 +685,11 @@ class TestPostCardbacks:
         assert response.status_code == 200
         assert len(response.json()["cardbacks"]) == 1
 
-    def test_get_multiple_rows_filtered_one_tag(self, client, snapshot, simple_cube, simple_lotus, tag_in_data):
+    def test_get_multiple_rows_filtered_includes_one_tag(
+        self, client, snapshot, simple_cube, simple_lotus, tag_in_data
+    ):
         search_settings = deepcopy(BASE_SEARCH_SETTINGS)
-        search_settings["filterSettings"]["tags"] = [tag_in_data.name, tag_in_data.name]
+        search_settings["filterSettings"]["includesTags"] = [tag_in_data.name, tag_in_data.name]
         search_settings["searchTypeSettings"]["filterCardbacks"] = True
         response = client.post(
             reverse(views.post_cardbacks), {"searchSettings": search_settings}, content_type="application/json"
@@ -687,11 +698,11 @@ class TestPostCardbacks:
         assert response.status_code == 200
         assert len(response.json()["cardbacks"]) == 2
 
-    def test_get_multiple_rows_filtered_two_tags(
+    def test_get_multiple_rows_filtered_includes_two_tags(
         self, client, snapshot, simple_cube, simple_lotus, tag_in_data, another_tag_in_data
     ):
         search_settings = deepcopy(BASE_SEARCH_SETTINGS)
-        search_settings["filterSettings"]["tags"] = [tag_in_data.name, another_tag_in_data.name]
+        search_settings["filterSettings"]["includesTags"] = [tag_in_data.name, another_tag_in_data.name]
         search_settings["searchTypeSettings"]["filterCardbacks"] = True
         response = client.post(
             reverse(views.post_cardbacks), {"searchSettings": search_settings}, content_type="application/json"

--- a/MPCAutofill/cardpicker/tests/test_views.py
+++ b/MPCAutofill/cardpicker/tests/test_views.py
@@ -316,11 +316,28 @@ class TestPostSearchResults:
         assert response.status_code == 200
         assert len(response.json()["results"][Cards.PAST_IN_FLAMES_1.value.name]["CARD"]) == 1
 
+    def test_get_one_row_filtered_excludes_one_tag(
+        self, client, snapshot, past_in_flames_1, past_in_flames_2, another_tag_in_data
+    ):
+        search_settings = deepcopy(BASE_SEARCH_SETTINGS)
+        search_settings["filterSettings"]["excludesTags"] = [another_tag_in_data.name]
+        response = client.post(
+            reverse(views.post_search_results),
+            {
+                "searchSettings": search_settings,
+                "queries": [{"query": Cards.PAST_IN_FLAMES_2.value.name, "card_type": "CARD"}],
+            },
+            content_type="application/json",
+        )
+        snapshot_response(response, snapshot)
+        assert response.status_code == 200
+        assert len(response.json()["results"][Cards.PAST_IN_FLAMES_2.value.name]["CARD"]) == 1
+
     def test_get_multiple_rows_filtered_includes_one_tag(
         self, client, snapshot, past_in_flames_1, past_in_flames_2, tag_in_data
     ):
         search_settings = deepcopy(BASE_SEARCH_SETTINGS)
-        search_settings["filterSettings"]["includesTags"] = [tag_in_data.name, tag_in_data.name]
+        search_settings["filterSettings"]["includesTags"] = [tag_in_data.name]
         response = client.post(
             reverse(views.post_search_results),
             {
@@ -332,6 +349,24 @@ class TestPostSearchResults:
         snapshot_response(response, snapshot)
         assert response.status_code == 200
         assert len(response.json()["results"][Cards.PAST_IN_FLAMES_1.value.name]["CARD"]) == 2
+
+    def test_get_multiple_rows_filtered_includes_one_tag_and_excludes_another(
+        self, client, snapshot, past_in_flames_1, past_in_flames_2, tag_in_data, another_tag_in_data
+    ):
+        search_settings = deepcopy(BASE_SEARCH_SETTINGS)
+        search_settings["filterSettings"]["includesTags"] = [tag_in_data.name]
+        search_settings["filterSettings"]["excludesTags"] = [another_tag_in_data.name]
+        response = client.post(
+            reverse(views.post_search_results),
+            {
+                "searchSettings": search_settings,
+                "queries": [{"query": Cards.PAST_IN_FLAMES_1.value.name, "card_type": "CARD"}],
+            },
+            content_type="application/json",
+        )
+        snapshot_response(response, snapshot)
+        assert response.status_code == 200
+        assert len(response.json()["results"][Cards.PAST_IN_FLAMES_1.value.name]["CARD"]) == 1
 
     def test_get_multiple_rows_filtered_includes_two_tags(
         self, client, snapshot, past_in_flames_1, past_in_flames_2, tag_in_data, another_tag_in_data
@@ -685,11 +720,24 @@ class TestPostCardbacks:
         assert response.status_code == 200
         assert len(response.json()["cardbacks"]) == 1
 
+    def test_get_one_row_filtered_excludes_one_tag(
+        self, client, snapshot, simple_cube, simple_lotus, another_tag_in_data
+    ):
+        search_settings = deepcopy(BASE_SEARCH_SETTINGS)
+        search_settings["filterSettings"]["excludesTags"] = [another_tag_in_data.name]
+        search_settings["searchTypeSettings"]["filterCardbacks"] = True
+        response = client.post(
+            reverse(views.post_cardbacks), {"searchSettings": search_settings}, content_type="application/json"
+        )
+        snapshot_response(response, snapshot)
+        assert response.status_code == 200
+        assert len(response.json()["cardbacks"]) == 1
+
     def test_get_multiple_rows_filtered_includes_one_tag(
         self, client, snapshot, simple_cube, simple_lotus, tag_in_data
     ):
         search_settings = deepcopy(BASE_SEARCH_SETTINGS)
-        search_settings["filterSettings"]["includesTags"] = [tag_in_data.name, tag_in_data.name]
+        search_settings["filterSettings"]["includesTags"] = [tag_in_data.name]
         search_settings["searchTypeSettings"]["filterCardbacks"] = True
         response = client.post(
             reverse(views.post_cardbacks), {"searchSettings": search_settings}, content_type="application/json"
@@ -697,6 +745,20 @@ class TestPostCardbacks:
         snapshot_response(response, snapshot)
         assert response.status_code == 200
         assert len(response.json()["cardbacks"]) == 2
+
+    def test_get_one_row_filtered_includes_one_tag_and_excludes_another(
+        self, client, snapshot, simple_cube, simple_lotus, tag_in_data, another_tag_in_data
+    ):
+        search_settings = deepcopy(BASE_SEARCH_SETTINGS)
+        search_settings["filterSettings"]["includesTags"] = [tag_in_data.name]
+        search_settings["filterSettings"]["excludesTags"] = [another_tag_in_data.name]
+        search_settings["searchTypeSettings"]["filterCardbacks"] = True
+        response = client.post(
+            reverse(views.post_cardbacks), {"searchSettings": search_settings}, content_type="application/json"
+        )
+        snapshot_response(response, snapshot)
+        assert response.status_code == 200
+        assert len(response.json()["cardbacks"]) == 1
 
     def test_get_multiple_rows_filtered_includes_two_tags(
         self, client, snapshot, simple_cube, simple_lotus, tag_in_data, another_tag_in_data

--- a/common/schemas/search_settings.json
+++ b/common/schemas/search_settings.json
@@ -80,12 +80,19 @@
           },
           "description": "The language the cards have to be written in to be included in search results"
         },
-        "tags": {
+        "includesTags": {
           "type": "array",
           "items": {
             "type": "string"
           },
           "description": "The tags which the cards must have to be included in search results"
+        },
+        "excludesTags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "The tags which the cards must *not* have to be included in search results"
         }
       },
       "required": [
@@ -93,7 +100,8 @@
         "maximumDPI",
         "maximumSize",
         "languages",
-        "tags"
+        "includesTags",
+        "excludesTags"
       ],
       "additionalProperties": false
     }

--- a/frontend/src/common/cookies.test.ts
+++ b/frontend/src/common/cookies.test.ts
@@ -50,7 +50,7 @@ test("cookies with complete source order are respected", () => {
       maximumSize: 15,
       languages: [],
       includesTags: [],
-      excludesTags: [],
+      excludesTags: ["NSFW"],
     },
   };
   window.localStorage.setItem(
@@ -82,7 +82,7 @@ test("referenced sources that don't exist in database are filtered out", () => {
       maximumSize: MaximumSize,
       languages: [],
       includesTags: [],
-      excludesTags: [],
+      excludesTags: ["NSFW"],
     },
   };
   window.localStorage.setItem(
@@ -115,7 +115,7 @@ test("cookies with incomplete source order are correctly reconciled", () => {
       maximumSize: MaximumSize,
       languages: [],
       includesTags: [],
-      excludesTags: [],
+      excludesTags: ["NSFW"],
     },
   };
   window.localStorage.setItem(
@@ -151,7 +151,7 @@ test("cookies with incomplete source order plus invalid sources are correctly re
       maximumSize: MaximumSize,
       languages: [],
       includesTags: [],
-      excludesTags: [],
+      excludesTags: ["NSFW"],
     },
   };
   window.localStorage.setItem(

--- a/frontend/src/common/cookies.test.ts
+++ b/frontend/src/common/cookies.test.ts
@@ -49,7 +49,8 @@ test("cookies with complete source order are respected", () => {
       maximumDPI: 200,
       maximumSize: 15,
       languages: [],
-      tags: [],
+      includesTags: [],
+      excludesTags: [],
     },
   };
   window.localStorage.setItem(
@@ -80,7 +81,8 @@ test("referenced sources that don't exist in database are filtered out", () => {
       maximumDPI: MaximumDPI,
       maximumSize: MaximumSize,
       languages: [],
-      tags: [],
+      includesTags: [],
+      excludesTags: [],
     },
   };
   window.localStorage.setItem(
@@ -112,7 +114,8 @@ test("cookies with incomplete source order are correctly reconciled", () => {
       maximumDPI: MaximumDPI,
       maximumSize: MaximumSize,
       languages: [],
-      tags: [],
+      includesTags: [],
+      excludesTags: [],
     },
   };
   window.localStorage.setItem(
@@ -147,7 +150,8 @@ test("cookies with incomplete source order plus invalid sources are correctly re
       maximumDPI: MaximumDPI,
       maximumSize: MaximumSize,
       languages: [],
-      tags: [],
+      includesTags: [],
+      excludesTags: [],
     },
   };
   window.localStorage.setItem(

--- a/frontend/src/common/schema_types.ts
+++ b/frontend/src/common/schema_types.ts
@@ -63,5 +63,9 @@ export interface FilterSettings {
   /**
    * The tags which the cards must have to be included in search results
    */
-  tags: string[];
+  includesTags: string[];
+  /**
+   * The tags which the cards must *not* have to be included in search results
+   */
+  excludesTags: string[];
 }

--- a/frontend/src/common/test-constants.ts
+++ b/frontend/src/common/test-constants.ts
@@ -294,7 +294,8 @@ export const defaultSettings: SearchSettings = {
     maximumDPI: MaximumDPI,
     maximumSize: MaximumSize,
     languages: [],
-    tags: [],
+    includesTags: [],
+    excludesTags: ["NSFW"],
   },
 };
 

--- a/frontend/src/features/searchSettings/__snapshots__/searchSettings.test.tsx.snap
+++ b/frontend/src/features/searchSettings/__snapshots__/searchSettings.test.tsx.snap
@@ -221,7 +221,7 @@ exports[`the html structure of search settings 1`] = `
         class="form-label"
         for="selectTags"
       >
-        Select tags
+        Select tags which cards must have
       </label>
       <div
         class="rmsc c0"
@@ -244,6 +244,77 @@ exports[`the html structure of search settings 1`] = `
                 Select...
               </span>
             </div>
+            <svg
+              class="dropdown-heading-dropdown-arrow gray"
+              fill="none"
+              height="24"
+              stroke="currentColor"
+              stroke-width="2"
+              width="24"
+            >
+              <path
+                d="M6 9L12 15 18 9"
+              />
+            </svg>
+          </div>
+        </div>
+      </div>
+      <label
+        class="form-label"
+        for="selectTags"
+      >
+        Select tags which cards must 
+        <b>
+          not
+        </b>
+         have
+      </label>
+      <div
+        class="rmsc c0"
+      >
+        <div
+          aria-labelledby="selectTags"
+          aria-readonly="true"
+          class="dropdown-container"
+          tabindex="0"
+        >
+          <div
+            class="dropdown-heading"
+          >
+            <div
+              class="dropdown-heading-value"
+            >
+              <span>
+                NSFW
+              </span>
+            </div>
+            <button
+              aria-label="Clear Selected"
+              class="clear-selected-button"
+              type="button"
+            >
+              <svg
+                class="dropdown-search-clear-icon gray"
+                fill="none"
+                height="24"
+                stroke="currentColor"
+                stroke-width="2"
+                width="24"
+              >
+                <line
+                  x1="18"
+                  x2="6"
+                  y1="6"
+                  y2="18"
+                />
+                <line
+                  x1="6"
+                  x2="18"
+                  y1="6"
+                  y2="18"
+                />
+              </svg>
+            </button>
             <svg
               class="dropdown-heading-dropdown-arrow gray"
               fill="none"

--- a/frontend/src/features/searchSettings/filterSettings.tsx
+++ b/frontend/src/features/searchSettings/filterSettings.tsx
@@ -140,11 +140,14 @@ export function FilterSettings({
         options={tagOptions}
         disableSearch={true}
         isLoading={getTagsQuery.isFetching}
-        value={filterSettings.tags.map((tag) => ({ label: tag, value: tag }))}
+        value={filterSettings.includesTags.map((tag) => ({
+          label: tag,
+          value: tag,
+        }))}
         onChange={(data: Array<{ label: string; value: string }>) => {
           setFilterSettings({
             ...filterSettings,
-            tags: data.map((row) => row.value),
+            includesTags: data.map((row) => row.value),
           });
         }}
         labelledBy="selectTags"

--- a/frontend/src/features/searchSettings/filterSettings.tsx
+++ b/frontend/src/features/searchSettings/filterSettings.tsx
@@ -135,7 +135,9 @@ export function FilterSettings({
         }}
         labelledBy="selectLanguage"
       />
-      <Form.Label htmlFor="selectTags">Select tags</Form.Label>
+      <Form.Label htmlFor="selectTags">
+        Select tags which cards must have
+      </Form.Label>
       <StyledMultiSelect
         options={tagOptions}
         disableSearch={true}
@@ -145,9 +147,36 @@ export function FilterSettings({
           value: tag,
         }))}
         onChange={(data: Array<{ label: string; value: string }>) => {
+          const selectedTags = data.map((row) => row.value);
           setFilterSettings({
             ...filterSettings,
-            includesTags: data.map((row) => row.value),
+            includesTags: selectedTags,
+            excludesTags: filterSettings.excludesTags.filter(
+              (tag) => !selectedTags.includes(tag)
+            ),
+          });
+        }}
+        labelledBy="selectTags"
+      />
+      <Form.Label htmlFor="selectTags">
+        Select tags which cards must <b>not</b> have
+      </Form.Label>
+      <StyledMultiSelect
+        options={tagOptions}
+        disableSearch={true}
+        isLoading={getTagsQuery.isFetching}
+        value={filterSettings.excludesTags.map((tag) => ({
+          label: tag,
+          value: tag,
+        }))}
+        onChange={(data: Array<{ label: string; value: string }>) => {
+          const selectedTags = data.map((row) => row.value);
+          setFilterSettings({
+            ...filterSettings,
+            excludesTags: selectedTags,
+            includesTags: filterSettings.includesTags.filter(
+              (tag) => !selectedTags.includes(tag)
+            ),
           });
         }}
         labelledBy="selectTags"

--- a/frontend/src/features/searchSettings/searchSettingsSlice.ts
+++ b/frontend/src/features/searchSettings/searchSettingsSlice.ts
@@ -25,7 +25,8 @@ export function getDefaultSearchSettings(
       maximumDPI: MaximumDPI,
       maximumSize: MaximumSize,
       languages: [],
-      tags: [],
+      includesTags: [],
+      excludesTags: [],
     },
   };
 }

--- a/frontend/src/features/searchSettings/searchSettingsSlice.ts
+++ b/frontend/src/features/searchSettings/searchSettingsSlice.ts
@@ -26,7 +26,7 @@ export function getDefaultSearchSettings(
       maximumSize: MaximumSize,
       languages: [],
       includesTags: [],
-      excludesTags: [],
+      excludesTags: ["NSFW"],
     },
   };
 }


### PR DESCRIPTION
# Description

* In my first draft of tag filtering in #167, users could only filter cards on whether they included at least one of the selected tags
* This PR expands the filtering system such that users can now specify tags which search results must not contain
* Implemented as a second multi-select

# Checklist

- [x] I have installed `pre-commit` and run the hooks with `pre-commit run`.
- [x] I have updated any related tests for code I modified or added new tests where appropriate.
- [ ] I have updated any relevant documentation or created new documentation where appropriate.
