### PR TITLE
--germany option to use printerstudio.de

### DIFF
--- a/desktop-tool/autofill.py
+++ b/desktop-tool/autofill.py
@@ -117,6 +117,12 @@ os.system("")  # enables ansi escape characters in terminal
 #     help="If this flag is set, non-JPEG images will be converted to JPEG before being uploaded to MPC.",
 #     is_flag=True,
 # )
+@click.option(
+    "--germany",
+    default=False,
+    help="Use printerstudio.de instead of makeplayingcards.com.",
+    is_flag=True,
+)
 def main(
     skipsetup: bool,
     auto_save: bool,
@@ -129,6 +135,7 @@ def main(
     max_dpi: int,
     downscale_alg: str,
     # convert_to_jpeg: bool,
+    germany: bool,
 ) -> None:
     try:
         with keepawake(keep_screen_awake=True) if not allowsleep else nullcontext():
@@ -144,7 +151,7 @@ def main(
             if exportpdf:
                 PdfExporter().execute(post_processing_config=post_processing_config)
             else:
-                AutofillDriver(browser=Browsers[browser], binary_location=binary_location).execute(
+                AutofillDriver(browser=Browsers[browser], binary_location=binary_location, germany=germany).execute(
                     skip_setup=skipsetup,
                     auto_save_threshold=auto_save_threshold if auto_save else None,
                     post_processing_config=post_processing_config,

--- a/desktop-tool/src/constants.py
+++ b/desktop-tool/src/constants.py
@@ -121,3 +121,9 @@ DPI_HEIGHT_RATIO = 300 / 1110  # TODO: share this between desktop tool and backe
 
 BRACKETS = [18, 36, 55, 72, 90, 108, 126, 144, 162, 180, 198, 216, 234, 396, 504, 612]
 THREADS = 5  # shared between CardImageCollections
+STOCKEN_TO_STOCKDE = {
+    "(S30) Standard Smooth": "Standard (glatt)",
+    "(S33) Superior Smooth": "Premium (linen)",
+    "(M31) Linen": "Super (glatt)",
+    "(P10) Plastic": "Kunststoff"
+}


### PR DESCRIPTION
# Description

Add `--germany` parameter to desktop-tool so it configures the tool to work with printerstudio.de (german clone of makeplayingcards.com). 
I've used this version of the tool to set up an order on printerstudio.de successfully.

# Checklist

- [x] I have installed `pre-commit` and run the hooks with `pre-commit run`.
- [x] I have updated any related tests for code I modified or added new tests where appropriate.
- [x] I have updated any relevant documentation or created new documentation where appropriate.
