### PR TITLE
PrinterStudio support

### DIFF
--- a/desktop-tool/autofill.py
+++ b/desktop-tool/autofill.py
@@ -21,46 +21,14 @@ def prompt_if_no_arguments(prompt: str) -> Union[str, bool]:
     We only prompt users to specify some flags if the tool was executed with no command-line arguments.
     """
 
-    return prompt if len(sys.argv) == 1 else False
+    return f"{prompt} (Press Enter if you're not sure.)" if len(sys.argv) == 1 else False
 
 
 @click.command(context_settings={"show_default": True})
 @click.option(
-    "--skipsetup",
-    prompt=prompt_if_no_arguments(
-        "Skip project setup to continue editing an existing MPC project? (Press Enter if you're not sure.)"
-    ),
-    default=False,
-    help=(
-        "If this flag is passed, the tool will prompt the user to navigate to an existing MPC project "
-        "and will attempt to align the state of the given project XML with the state of the project "
-        "in the targeted site. Note that this has some caveats - refer to the wiki for details."
-    ),
-    is_flag=True,
-)
-@click.option(
-    "--auto-save/--no-auto-save",
-    prompt=prompt_if_no_arguments(
-        "Automatically save this project to your account while the tool is running? "
-        "(Press Enter if you're not sure.)"
-    ),
-    default=True,
-    help=(
-        "If this flag is passed, the tool will automatically save your project to your account after "
-        "processing each batch of cards."
-    ),
-    is_flag=True,
-)
-@click.option(
-    "--auto-save-threshold",
-    type=click.IntRange(1, None),
-    default=5,
-    help="Controls how often the project should be saved in terms of the number of cards uploaded.",
-)
-@click.option(
     "-b",
     "--browser",
-    prompt=prompt_if_no_arguments("Which web browser should the tool run on?  (Press Enter if you're not sure.)"),
+    prompt=prompt_if_no_arguments("Which web browser should the tool run on?"),
     default=Browsers.chrome.name,
     type=click.Choice(sorted([browser.name for browser in Browsers]), case_sensitive=False),
     help="The web browser to run the tool on.",
@@ -76,9 +44,37 @@ def prompt_if_no_arguments(prompt: str) -> Union[str, bool]:
 )
 @click.option(
     "--site",
+    prompt=prompt_if_no_arguments("Which site should the tool auto-fill your project into?"),
     default=TargetSites.MakePlayingCards.name,
     type=click.Choice(sorted([site.name for site in TargetSites]), case_sensitive=False),
     help="The card printing site into which your order should be auto-filled.",
+)
+@click.option(
+    "--skipsetup",
+    prompt=prompt_if_no_arguments("Skip project setup to continue editing an existing project?"),
+    default=False,
+    help=(
+        "If this flag is passed, the tool will prompt the user to navigate to an existing project "
+        "and will attempt to align the state of the given project XML with the state of the project "
+        "in the targeted site. Note that this has some caveats - refer to the wiki for details."
+    ),
+    is_flag=True,
+)
+@click.option(
+    "--auto-save/--no-auto-save",
+    prompt=prompt_if_no_arguments("Automatically save this project to your account while the tool is running?"),
+    default=True,
+    help=(
+        "If this flag is passed, the tool will automatically save your project to your account after "
+        "processing each batch of cards."
+    ),
+    is_flag=True,
+)
+@click.option(
+    "--auto-save-threshold",
+    type=click.IntRange(1, None),
+    default=5,
+    help="Controls how often the project should be saved in terms of the number of cards uploaded.",
 )
 @click.option(
     "--exportpdf",
@@ -97,7 +93,7 @@ def prompt_if_no_arguments(prompt: str) -> Union[str, bool]:
     default=True,
     prompt=prompt_if_no_arguments(
         "Should the tool post-process your images to reduce upload times? "
-        "By default, images will be downscaled to 800 DPI. (Press Enter if you're not sure.)"
+        "By default, images will be downscaled to 800 DPI."
     ),
     help="Post-process images to reduce file upload time.",
     is_flag=True,
@@ -106,7 +102,7 @@ def prompt_if_no_arguments(prompt: str) -> Union[str, bool]:
     "--max-dpi",
     default=800,
     type=click.IntRange(100, 1200),
-    help="Images above this DPI will be downscaled to it before being uploaded to MPC.",
+    help="Images above this DPI will be downscaled to it before being uploaded to the targeted site.",
 )
 @click.option(
     "--downscale-alg",
@@ -122,7 +118,7 @@ def prompt_if_no_arguments(prompt: str) -> Union[str, bool]:
 #     "--convert-to-jpeg",
 #     default=True,
 #     type=click.BOOL,
-#     help="If this flag is set, non-JPEG images will be converted to JPEG before being uploaded to MPC.",
+#     help="If this flag is set, non-JPEG images will be converted to JPEG before being uploaded to the targeted site.",
 #     is_flag=True,
 # )
 def main(

--- a/desktop-tool/autofill.py
+++ b/desktop-tool/autofill.py
@@ -1,12 +1,12 @@
 import os
 import sys
 from contextlib import nullcontext
-from typing import Optional
+from typing import Optional, Union
 
 import click
 from wakepy import keepawake
 
-from src.constants import Browsers, ImageResizeMethods
+from src.constants import Browsers, ImageResizeMethods, TargetSites
 from src.driver import AutofillDriver
 from src.pdf_maker import PdfExporter
 from src.processing import ImagePostProcessingConfig
@@ -16,31 +16,37 @@ from src.utils import TEXT_BOLD, TEXT_END
 os.system("")  # enables ansi escape characters in terminal
 
 
+def prompt_if_no_arguments(prompt: str) -> Union[str, bool]:
+    """
+    We only prompt users to specify some flags if the tool was executed with no command-line arguments.
+    """
+
+    return prompt if len(sys.argv) == 1 else False
+
+
 @click.command(context_settings={"show_default": True})
 @click.option(
     "--skipsetup",
-    prompt="Skip project setup to continue editing an existing MPC project? (Press Enter if you're not sure.)"
-    if len(sys.argv) == 1
-    else False,
+    prompt=prompt_if_no_arguments(
+        "Skip project setup to continue editing an existing MPC project? (Press Enter if you're not sure.)"
+    ),
     default=False,
     help=(
         "If this flag is passed, the tool will prompt the user to navigate to an existing MPC project "
         "and will attempt to align the state of the given project XML with the state of the project "
-        "in MakePlayingCards. Note that this has some caveats - refer to the wiki for details."
+        "in the targeted site. Note that this has some caveats - refer to the wiki for details."
     ),
     is_flag=True,
 )
 @click.option(
-    "--auto-save",
-    prompt=(
-        "Automatically save this project to your MakePlayingAccounts while the tool is running? "
+    "--auto-save/--no-auto-save",
+    prompt=prompt_if_no_arguments(
+        "Automatically save this project to your account while the tool is running? "
         "(Press Enter if you're not sure.)"
-    )
-    if len(sys.argv) == 1
-    else False,
+    ),
     default=True,
     help=(
-        "If this flag is passed, the tool will automatically save your project to your MakePlayingCards after "
+        "If this flag is passed, the tool will automatically save your project to your account after "
         "processing each batch of cards."
     ),
     is_flag=True,
@@ -54,9 +60,7 @@ os.system("")  # enables ansi escape characters in terminal
 @click.option(
     "-b",
     "--browser",
-    prompt="Which web browser should the tool run on?  (Press Enter if you're not sure.)"
-    if len(sys.argv) == 1
-    else False,
+    prompt=prompt_if_no_arguments("Which web browser should the tool run on?  (Press Enter if you're not sure.)"),
     default=Browsers.chrome.name,
     type=click.Choice(sorted([browser.name for browser in Browsers]), case_sensitive=False),
     help="The web browser to run the tool on.",
@@ -71,26 +75,30 @@ os.system("")  # enables ansi escape characters in terminal
     ),
 )
 @click.option(
+    "--site",
+    default=TargetSites.MakePlayingCards.name,
+    type=click.Choice(sorted([site.name for site in TargetSites]), case_sensitive=False),
+    help="The card printing site into which your order should be auto-filled.",
+)
+@click.option(
     "--exportpdf",
     default=False,
-    help="Create a PDF export of the card images instead of creating a project for MPC.",
+    help="Create a PDF export of the card images instead of creating a project with a printing site.",
     is_flag=True,
 )
 @click.option(
-    "--allowsleep",
+    "--allowsleep/--disallow-sleep",
     default=False,
     help="Allows the system to fall asleep during execution.",
     is_flag=True,
 )
 @click.option(
-    "--post-process-images",
+    "--image-post-processing/--no-image-post-processing",
     default=True,
-    prompt=(
+    prompt=prompt_if_no_arguments(
         "Should the tool post-process your images to reduce upload times? "
         "By default, images will be downscaled to 800 DPI. (Press Enter if you're not sure.)"
-    )
-    if len(sys.argv) == 1
-    else False,
+    ),
     help="Post-process images to reduce file upload time.",
     is_flag=True,
 )
@@ -117,41 +125,37 @@ os.system("")  # enables ansi escape characters in terminal
 #     help="If this flag is set, non-JPEG images will be converted to JPEG before being uploaded to MPC.",
 #     is_flag=True,
 # )
-@click.option(
-    "--germany",
-    default=False,
-    help="Use printerstudio.de instead of makeplayingcards.com.",
-    is_flag=True,
-)
 def main(
     skipsetup: bool,
     auto_save: bool,
     auto_save_threshold: int,
     browser: str,
     binary_location: Optional[str],
+    site: str,
     exportpdf: bool,
     allowsleep: bool,
-    post_process_images: bool,
+    image_post_processing: bool,
     max_dpi: int,
     downscale_alg: str,
     # convert_to_jpeg: bool,
-    germany: bool,
 ) -> None:
     try:
         with keepawake(keep_screen_awake=True) if not allowsleep else nullcontext():
             if not allowsleep:
                 print("System sleep is being prevented during this execution.")
-            if post_process_images:
+            if image_post_processing:
                 print("Images are being post-processed during this execution.")
             post_processing_config = (
                 ImagePostProcessingConfig(max_dpi=max_dpi, downscale_alg=ImageResizeMethods[downscale_alg])
-                if post_process_images
+                if image_post_processing
                 else None
             )
             if exportpdf:
                 PdfExporter().execute(post_processing_config=post_processing_config)
             else:
-                AutofillDriver(browser=Browsers[browser], binary_location=binary_location, germany=germany).execute(
+                AutofillDriver(
+                    browser=Browsers[browser], target_site=TargetSites[site], binary_location=binary_location
+                ).execute(
                     skip_setup=skipsetup,
                     auto_save_threshold=auto_save_threshold if auto_save else None,
                     post_processing_config=post_processing_config,

--- a/desktop-tool/requirements.txt
+++ b/desktop-tool/requirements.txt
@@ -10,6 +10,7 @@ pillow==10.0.1
 pre-commit
 pyinstaller~=5.13.0
 pytest~=7.3
+pytest-retry~=1.5
 ratelimit~=2.2.1
 requests~=2.31.0
 sanitize-filename~=1.2.0

--- a/desktop-tool/src/constants.py
+++ b/desktop-tool/src/constants.py
@@ -135,6 +135,7 @@ class TargetSite:
     accept_settings_url_route: str = attr.ib(default="products/pro_item_process_flow.aspx")
     # endregion
     # region project configuration
+    supports_foil: bool = attr.ib(default=True)
     quantity_dropdown_element_id: str = attr.ib(default="dro_choosesize")
     cardstock_dropdown_element_id: str = attr.ib(default="dro_paper_type")
     print_type_dropdown_element_id: str = attr.ib(default="dro_product_effect")
@@ -179,6 +180,7 @@ class TargetSites(Enum):
     PrinterStudio = TargetSite(
         base_url="https://www.printerstudio.com",
         starting_url_route="personalized/custom-playing-cards-blank-cards.html",
+        supports_foil=False,
         cardstock_site_name_mapping={
             Cardstocks.S30: "Standard (smooth)",
             Cardstocks.S33: "Superior (smooth)",
@@ -189,6 +191,7 @@ class TargetSites(Enum):
     PrinterStudioDE = TargetSite(
         base_url="https://www.printerstudio.de",
         starting_url_route="machen/blanko-spielkarten-63x88mm-personalisieren.html",
+        supports_foil=False,
         cardstock_site_name_mapping={
             Cardstocks.S30: "Standard (glatt)",
             Cardstocks.S33: "Super (glatt)",

--- a/desktop-tool/src/driver.py
+++ b/desktop-tool/src/driver.py
@@ -402,7 +402,7 @@ class AutofillDriver:
         input(
             textwrap.dedent(
                 f"""
-                The specified inputs require you to sign into your {self.target_site.name} account.
+                The specified inputs require you to sign into your {bold(self.target_site.name)} account.
                 Please sign in, then return to the console window and press Enter.
                 """
             )
@@ -442,11 +442,21 @@ class AutofillDriver:
 
         # Switch the finish to foil if the user ordered foil cards
         if self.order.details.foil:
-            foil_dropdown = Select(
-                self.driver.find_element(by=By.ID, value=self.target_site.value.print_type_dropdown_element_id)
-            )
-            foil_dropdown.select_by_value(self.target_site.value.foil_dropdown_element_value)
-            # TODO: try/except here. printerstudio doesn't do foils.
+            if self.target_site.value.supports_foil:
+                foil_dropdown = Select(
+                    self.driver.find_element(by=By.ID, value=self.target_site.value.print_type_dropdown_element_id)
+                )
+                foil_dropdown.select_by_value(self.target_site.value.foil_dropdown_element_value)
+            else:
+                print(
+                    textwrap.dedent(
+                        f"""
+                        {bold('WARNING')}: Your project is configured to be printed in foil,
+                        but {bold(self.target_site.name)} does not support foil printing.
+                        {bold('Your project will be auto-filled as non-foil.')}
+                        """
+                    )
+                )
 
         self.set_state(States.paging_to_fronts)
 

--- a/desktop-tool/src/driver.py
+++ b/desktop-tool/src/driver.py
@@ -619,7 +619,6 @@ class AutofillDriver:
                 self.authenticate()
 
             if skip_setup:
-
                 self.redefine_project()
 
             else:

--- a/desktop-tool/src/driver.py
+++ b/desktop-tool/src/driver.py
@@ -472,9 +472,9 @@ class AutofillDriver:
         self.driver.get(f"{self.target_site.value.saved_projects_url}")
         input(
             textwrap.dedent(
-                """
+                f"""
                 Continuing to edit an existing order. Please enter the project editor for your selected project,
-                then return to the console window and press Enter.
+                wait for the page to load {bold('fully')}, then return to the console window and press Enter.
                 """
             )
         )

--- a/desktop-tool/src/order.py
+++ b/desktop-tool/src/order.py
@@ -295,7 +295,7 @@ class CardOrder:
         if self.name is not None:
             print(f"Successfully parsed card order: {bold(self.name)}")
         print(
-            f"Your order has a total of {bold(self.details.quantity)} cards, in the MPC bracket of up "
+            f"Your order has a total of {bold(self.details.quantity)} cards, in the bracket of up "
             f"to {bold(self.details.bracket)} cards.\n{bold(self.details.stock)} "
             f"cardstock ({bold('foil' if self.details.foil else 'nonfoil')}.\n "
         )

--- a/desktop-tool/tests/test_desktop_client.py
+++ b/desktop-tool/tests/test_desktop_client.py
@@ -890,8 +890,16 @@ def test_pdf_export_complete_separate_faces(monkeypatch, card_order_valid):
 
 
 @pytest.mark.parametrize("browser", [constants.Browsers.chrome])
-def test_card_order_complete_run_single_cardback(browser, input_enter, card_order_valid):
-    autofill_driver = AutofillDriver(order=card_order_valid, browser=browser, headless=True)
+@pytest.mark.parametrize(
+    "site",
+    [
+        constants.TargetSites.MakePlayingCards,
+        constants.TargetSites.PrinterStudio,
+        constants.TargetSites.PrinterStudioDE,
+    ],
+)
+def test_card_order_complete_run_single_cardback(browser, site, input_enter, card_order_valid):
+    autofill_driver = AutofillDriver(order=card_order_valid, browser=browser, target_site=site, headless=True)
     autofill_driver.execute(skip_setup=False, auto_save_threshold=None, post_processing_config=DEFAULT_POST_PROCESSING)
     assert (
         len(
@@ -904,8 +912,18 @@ def test_card_order_complete_run_single_cardback(browser, input_enter, card_orde
 
 
 @pytest.mark.parametrize("browser", [constants.Browsers.chrome, constants.Browsers.edge])
-def test_card_order_complete_run_multiple_cardbacks(browser, input_enter, card_order_multiple_cardbacks):
-    autofill_driver = AutofillDriver(order=card_order_multiple_cardbacks, browser=browser, headless=True)
+@pytest.mark.parametrize(
+    "site",
+    [
+        constants.TargetSites.MakePlayingCards,
+        constants.TargetSites.PrinterStudio,
+        constants.TargetSites.PrinterStudioDE,
+    ],
+)
+def test_card_order_complete_run_multiple_cardbacks(browser, site, input_enter, card_order_multiple_cardbacks):
+    autofill_driver = AutofillDriver(
+        order=card_order_multiple_cardbacks, browser=browser, target_site=site, headless=True
+    )
     autofill_driver.execute(skip_setup=False, auto_save_threshold=None, post_processing_config=DEFAULT_POST_PROCESSING)
     assert (
         len(

--- a/desktop-tool/tests/test_desktop_client.py
+++ b/desktop-tool/tests/test_desktop_client.py
@@ -889,6 +889,7 @@ def test_pdf_export_complete_separate_faces(monkeypatch, card_order_valid):
 # region test driver.py
 
 
+@pytest.mark.flaky(retries=3, delay=1)
 @pytest.mark.parametrize("browser", [constants.Browsers.chrome])
 @pytest.mark.parametrize(
     "site",
@@ -911,6 +912,7 @@ def test_card_order_complete_run_single_cardback(browser, site, input_enter, car
     )
 
 
+@pytest.mark.flaky(retries=3, delay=1)
 @pytest.mark.parametrize("browser", [constants.Browsers.chrome, constants.Browsers.edge])
 @pytest.mark.parametrize(
     "site",


### PR DESCRIPTION
# Description
* Extends upon #181 to support https://printerstudio.com in addition to https://printerstudio.de
* Users are prompted on which site the tool should target when they run the tool:
<img width="950" alt="image" src="https://github.com/chilli-axe/mpc-autofill/assets/3079166/58d9635d-bb6c-4b98-a26d-94ac11923d02">

* Resolves #82

# Checklist

- [x] I have installed `pre-commit` and run the hooks with `pre-commit run`.
- [x] I have updated any related tests for code I modified or added new tests where appropriate.
    - End-to-end tests now run on all targeted sites
- [x] I have updated any relevant documentation or created new documentation where appropriate.
    - Still ongoing but haven't found any issues yet - the surface area for manual testing is increasing here by a factor of 3 so it'll take a bit longer to get releases out now