### PR TITLE
Reduce useEffect usages throughout the frontend

### DIFF
--- a/frontend/src/app/app.tsx
+++ b/frontend/src/app/app.tsx
@@ -54,11 +54,6 @@ function App() {
   //# region effects
 
   useEffect(() => {
-    if (backendConfigured) {
-      fetchSourceDocumentsAndReportError(dispatch);
-    }
-  }, [dispatch, backendConfigured, backendURL]);
-  useEffect(() => {
     /**
      * Ask the user for confirmation before they close the page if their project has any cards in it.
      */

--- a/frontend/src/app/listenerMiddleware.ts
+++ b/frontend/src/app/listenerMiddleware.ts
@@ -8,8 +8,12 @@ import {
   createListenerMiddleware,
   isAnyOf,
 } from "@reduxjs/toolkit";
+import { useEffect } from "react";
 
-import { selectBackendConfigured } from "@/features/backend/backendSlice";
+import {
+  selectBackendConfigured,
+  setURL,
+} from "@/features/backend/backendSlice";
 import {
   addMembers,
   bulkSetQuery,
@@ -17,6 +21,7 @@ import {
 } from "@/features/project/projectSlice";
 import { fetchCardDocumentsAndReportError } from "@/features/search/cardDocumentsSlice";
 import { clearSearchResults } from "@/features/search/searchResultsSlice";
+import { fetchSourceDocumentsAndReportError } from "@/features/search/sourceDocumentsSlice";
 import {
   selectSearchSettingsSourcesValid,
   setFilterSettings,
@@ -40,6 +45,21 @@ const addAppListener = addListener as TypedAddListener<RootState, AppDispatch>;
 //# endregion
 
 //# region listeners
+
+startAppListening({
+  matcher: isAnyOf(setURL),
+  effect: async (action, { getState, dispatch }) => {
+    /**
+     * Fetch sources whenever the backend configuration changes.
+     */
+
+    const state = getState();
+    const isBackendConfigured = selectBackendConfigured(state);
+    if (isBackendConfigured) {
+      await fetchSourceDocumentsAndReportError(dispatch);
+    }
+  },
+});
 
 startAppListening({
   matcher: isAnyOf(setSearchTypeSettings, setSourceSettings, setFilterSettings),

--- a/frontend/src/app/listenerMiddleware.ts
+++ b/frontend/src/app/listenerMiddleware.ts
@@ -3,18 +3,70 @@
  */
 
 import type { TypedAddListener, TypedStartListening } from "@reduxjs/toolkit";
-import { addListener, createListenerMiddleware } from "@reduxjs/toolkit";
+import {
+  addListener,
+  createListenerMiddleware,
+  isAnyOf,
+} from "@reduxjs/toolkit";
+
+import { selectBackendConfigured } from "@/features/backend/backendSlice";
+import {
+  addMembers,
+  bulkSetQuery,
+  setQuery,
+} from "@/features/project/projectSlice";
+import { fetchCardDocumentsAndReportError } from "@/features/search/cardDocumentsSlice";
+import { clearSearchResults } from "@/features/search/searchResultsSlice";
+import {
+  selectSearchSettingsSourcesValid,
+  setFilterSettings,
+  setSearchTypeSettings,
+  setSourceSettings,
+} from "@/features/searchSettings/searchSettingsSlice";
 
 import type { AppDispatch, RootState } from "./store";
+
+//# region boilerplate
 
 export const listenerMiddleware = createListenerMiddleware();
 
 export type AppStartListening = TypedStartListening<RootState, AppDispatch>;
 
-export const startAppListening =
+const startAppListening =
   listenerMiddleware.startListening as AppStartListening;
 
-export const addAppListener = addListener as TypedAddListener<
-  RootState,
-  AppDispatch
->;
+const addAppListener = addListener as TypedAddListener<RootState, AppDispatch>;
+
+//# endregion
+
+//# region listeners
+
+startAppListening({
+  matcher: isAnyOf(setSearchTypeSettings, setSourceSettings, setFilterSettings),
+  effect: async (action, { getState, dispatch }) => {
+    /**
+     * Recalculate search results whenever search settings change.
+     */
+
+    const state = getState();
+    const isBackendConfigured = selectBackendConfigured(state);
+    const searchSettingsSourcesValid = selectSearchSettingsSourcesValid(state);
+    if (isBackendConfigured && searchSettingsSourcesValid) {
+      await dispatch(clearSearchResults());
+      await fetchCardDocumentsAndReportError(dispatch);
+    }
+  },
+});
+
+startAppListening({
+  matcher: isAnyOf(addMembers, setQuery, bulkSetQuery),
+  effect: async (action, { dispatch }) => {
+    /**
+     * Fetch card documents whenever new members are added to the project or search results are cleared.
+     */
+
+    await fetchCardDocumentsAndReportError(dispatch);
+  },
+});
+
+//# endregion

--- a/frontend/src/app/listenerMiddleware.ts
+++ b/frontend/src/app/listenerMiddleware.ts
@@ -17,10 +17,13 @@ import {
   selectBackendConfigured,
   setURL,
 } from "@/features/backend/backendSlice";
+import { fetchCardbacks, selectCardbacks } from "@/features/card/cardbackSlice";
 import {
   addMembers,
   bulkSetQuery,
+  selectProjectCardback,
   setQuery,
+  setSelectedCardback,
 } from "@/features/project/projectSlice";
 import { fetchCardDocumentsAndReportError } from "@/features/search/cardDocumentsSlice";
 import { clearSearchResults } from "@/features/search/searchResultsSlice";
@@ -124,6 +127,34 @@ startAppListening({
      */
 
     await fetchCardDocumentsAndReportError(dispatch);
+  },
+});
+
+startAppListening({
+  actionCreator: fetchCardbacks.fulfilled,
+  effect: async (action, { dispatch, getState }) => {
+    /**
+     * Whenever the list of cardbacks changes, this listener will deselect the cardback
+     * if it's no longer valid, then select the first cardback in the list if there are
+     * any cardbacks if necessary.
+     * Note that this means you can end up with no selected cardback.
+     */
+
+    const state = getState();
+    const currentCardback = selectProjectCardback(state);
+    const cardbacks = selectCardbacks(state);
+
+    let newCardback = currentCardback;
+    if (newCardback != null && !cardbacks.includes(newCardback)) {
+      newCardback = undefined;
+    }
+    if (newCardback == null && cardbacks.length > 0) {
+      newCardback = cardbacks[0];
+    }
+
+    if (newCardback != currentCardback) {
+      dispatch(setSelectedCardback({ selectedImage: newCardback ?? null }));
+    }
   },
 });
 

--- a/frontend/src/app/listenerMiddleware.ts
+++ b/frontend/src/app/listenerMiddleware.ts
@@ -8,9 +8,11 @@ import {
   createListenerMiddleware,
   isAnyOf,
 } from "@reduxjs/toolkit";
-import { useEffect } from "react";
 
+import { api } from "@/app/api";
+import { QueryTags } from "@/common/constants";
 import {
+  clearURL,
   selectBackendConfigured,
   setURL,
 } from "@/features/backend/backendSlice";
@@ -50,7 +52,7 @@ startAppListening({
   matcher: isAnyOf(setURL),
   effect: async (action, { getState, dispatch }) => {
     /**
-     * Fetch sources whenever the backend configuration changes.
+     * Fetch sources whenever the backend configuration is set.
      */
 
     const state = getState();
@@ -58,6 +60,17 @@ startAppListening({
     if (isBackendConfigured) {
       await fetchSourceDocumentsAndReportError(dispatch);
     }
+  },
+});
+
+startAppListening({
+  matcher: isAnyOf(setURL, clearURL),
+  effect: async (action, { dispatch }) => {
+    /**
+     * Invalidate previous backend-specific data whenever the backend configuration is updated.
+     */
+
+    dispatch(api.util.invalidateTags([QueryTags.BackendSpecific]));
   },
 });
 

--- a/frontend/src/app/store.ts
+++ b/frontend/src/app/store.ts
@@ -1,13 +1,10 @@
 import type { PreloadedState } from "@reduxjs/toolkit";
 import type { Middleware, MiddlewareAPI } from "@reduxjs/toolkit";
-import { combineReducers, configureStore, isAnyOf } from "@reduxjs/toolkit";
+import { combineReducers, configureStore } from "@reduxjs/toolkit";
 import { isRejectedWithValue } from "@reduxjs/toolkit";
 
 import { api } from "@/app/api";
-import {
-  listenerMiddleware,
-  startAppListening,
-} from "@/app/listenerMiddleware";
+import { listenerMiddleware } from "@/app/listenerMiddleware";
 import backendReducer, {
   selectBackendConfigured,
 } from "@/features/backend/backendSlice";
@@ -15,24 +12,11 @@ import cardbacksReducer from "@/features/card/cardbackSlice";
 import finishSettingsReducer from "@/features/finishSettings/finishSettingsSlice";
 import invalidIdentifiersReducer from "@/features/invalidIdentifiers/invalidIdentifiersSlice";
 import modalsReducer from "@/features/modals/modalsSlice";
-import projectReducer, {
-  addMembers,
-  bulkSetQuery,
-  setQuery,
-} from "@/features/project/projectSlice";
-import cardDocumentsReducer, {
-  fetchCardDocumentsAndReportError,
-} from "@/features/search/cardDocumentsSlice";
-import searchResultsReducer, {
-  clearSearchResults,
-} from "@/features/search/searchResultsSlice";
+import projectReducer from "@/features/project/projectSlice";
+import cardDocumentsReducer from "@/features/search/cardDocumentsSlice";
+import searchResultsReducer from "@/features/search/searchResultsSlice";
 import sourceDocumentsReducer from "@/features/search/sourceDocumentsSlice";
-import searchSettingsReducer, {
-  selectSearchSettingsSourcesValid,
-  setFilterSettings,
-  setSearchTypeSettings,
-  setSourceSettings,
-} from "@/features/searchSettings/searchSettingsSlice";
+import searchSettingsReducer from "@/features/searchSettings/searchSettingsSlice";
 import toastsReducer, { setError } from "@/features/toasts/toastsSlice";
 import viewSettingsReducer from "@/features/viewSettings/viewSettingsSlice";
 
@@ -80,34 +64,6 @@ const rtkQueryErrorLogger: Middleware =
 
     return next(action);
   };
-
-startAppListening({
-  matcher: isAnyOf(setSearchTypeSettings, setSourceSettings, setFilterSettings),
-  effect: async (action, { getState, dispatch }) => {
-    /**
-     * Recalculate search results whenever search settings change.
-     */
-
-    const state = getState();
-    const isBackendConfigured = selectBackendConfigured(state);
-    const searchSettingsSourcesValid = selectSearchSettingsSourcesValid(state);
-    if (isBackendConfigured && searchSettingsSourcesValid) {
-      await dispatch(clearSearchResults());
-      await fetchCardDocumentsAndReportError(dispatch);
-    }
-  },
-});
-
-startAppListening({
-  matcher: isAnyOf(addMembers, setQuery, bulkSetQuery),
-  effect: async (action, { dispatch }) => {
-    /**
-     * Fetch card documents whenever new members are added to the project or search results are cleared.
-     */
-
-    await fetchCardDocumentsAndReportError(dispatch);
-  },
-});
 
 //# endregion
 

--- a/frontend/src/common/test-utils.tsx
+++ b/frontend/src/common/test-utils.tsx
@@ -16,6 +16,8 @@ import { Provider } from "react-redux";
 import { RootState, setupStore } from "@/app/store";
 import { localBackendURL } from "@/common/test-constants";
 import { Faces } from "@/common/types";
+import { setURL } from "@/features/backend/backendSlice";
+import { LayoutWithoutProvider } from "@/features/ui/layout";
 
 //# region redux test setup
 
@@ -33,17 +35,27 @@ export function renderWithProviders(
     // Automatically create a store instance if no store was passed in
     store = setupStore(preloadedState),
     ...renderOptions
-  }: ExtendedRenderOptions = {}
+  }: ExtendedRenderOptions = {},
+  configureLocalBackend: boolean = true
 ) {
   function Wrapper({ children }: PropsWithChildren<{}>): JSX.Element {
     if (store != undefined) {
+      if (configureLocalBackend) {
+        store.dispatch(setURL(localBackendURL));
+      }
       return (
         <MemoryRouterProvider>
-          <Provider store={store}>{children}</Provider>
+          <Provider store={store}>
+            <LayoutWithoutProvider>{children}</LayoutWithoutProvider>
+          </Provider>
         </MemoryRouterProvider>
       );
     } else {
-      return <MemoryRouterProvider>{children}</MemoryRouterProvider>;
+      return (
+        <MemoryRouterProvider>
+          <LayoutWithoutProvider>{children}</LayoutWithoutProvider>
+        </MemoryRouterProvider>
+      );
     }
   }
 
@@ -384,7 +396,7 @@ export async function deleteSelectedImages() {
 }
 
 export async function openSearchSettingsModal() {
-  screen.getByText("Search Settings", { exact: false }).click();
+  screen.getByText(/Search Settings/).click();
   await waitFor(() => expect(screen.getByText("Search Settings")));
   return screen.getByTestId("search-settings");
 }

--- a/frontend/src/common/test-utils.tsx
+++ b/frontend/src/common/test-utils.tsx
@@ -83,9 +83,9 @@ export async function expectCardSlotToNotExist(slot: number) {
 
 async function expectCardSlotState(
   testId: string,
-  cardName?: string,
-  selectedImage?: number,
-  totalImages?: number
+  cardName?: string | null,
+  selectedImage?: number | null,
+  totalImages?: number | null
 ) {
   /**
    * This function helps with asserting that a particular card slot exists
@@ -117,9 +117,9 @@ async function expectCardSlotState(
 export async function expectCardGridSlotState(
   slot: number,
   face: Faces,
-  cardName?: string,
-  selectedImage?: number,
-  totalImages?: number
+  cardName?: string | null,
+  selectedImage?: number | null,
+  totalImages?: number | null
 ) {
   // note: the specified `slot` should be 1-indexed
   return await expectCardSlotState(

--- a/frontend/src/features/backend/backend.tsx
+++ b/frontend/src/features/backend/backend.tsx
@@ -11,8 +11,7 @@ import Button from "react-bootstrap/Button";
 import Form from "react-bootstrap/Form";
 import Offcanvas from "react-bootstrap/Offcanvas";
 
-import { api } from "@/app/api";
-import { ProjectName, QueryTags } from "@/common/constants";
+import { ProjectName } from "@/common/constants";
 import {
   clearLocalStorageBackendURL,
   getLocalStorageBackendURL,
@@ -108,7 +107,6 @@ export function BackendConfig({ show, handleClose }: BackendConfigProps) {
   const clearBackendURL = () => {
     dispatch(clearURL());
     clearLocalStorageBackendURL();
-    dispatch(api.util.invalidateTags([QueryTags.BackendSpecific]));
     setValidationStatus([]);
   };
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
@@ -145,7 +143,6 @@ export function BackendConfig({ show, handleClose }: BackendConfigProps) {
     ) {
       dispatch(setURL(formattedURL));
       setLocalStorageBackendURL(formattedURL);
-      dispatch(api.util.invalidateTags([QueryTags.BackendSpecific]));
       setLocalBackendURL("");
     }
     setValidating(false);
@@ -156,15 +153,9 @@ export function BackendConfig({ show, handleClose }: BackendConfigProps) {
   //# region effects
 
   useEffect(() => {
-    /**
-     * TODO: This could be turned into a Redux listener. The reason I haven't done so here is because it's a bit funky
-     *       in terms of how it interacts with pre-loading the Redux state in tests with a backend URL.
-     */
-
     const localStorageBackendURL = getLocalStorageBackendURL();
     if (localStorageBackendURL != undefined) {
       dispatch(setURL(localStorageBackendURL));
-      dispatch(api.util.invalidateTags([QueryTags.BackendSpecific]));
     }
   }, [dispatch]);
 

--- a/frontend/src/features/backend/backendSlice.ts
+++ b/frontend/src/features/backend/backendSlice.ts
@@ -20,7 +20,6 @@ export const backendSlice = createSlice({
   initialState,
   reducers: {
     setURL: (state, action) => {
-      // TODO: can we force queries to re-fetch when we change the URL here?
       state.url = action.payload;
     },
     clearURL: (state) => {

--- a/frontend/src/features/bulkManagement/bulkManagementStatus.test.tsx
+++ b/frontend/src/features/bulkManagement/bulkManagementStatus.test.tsx
@@ -9,7 +9,6 @@ import {
   cardDocument1,
   cardDocument2,
   cardDocument5,
-  localBackend,
 } from "@/common/test-constants";
 import {
   changeImageForSelectedImages,
@@ -24,7 +23,6 @@ import {
   renderWithProviders,
   selectSlot,
 } from "@/common/test-utils";
-import { LayoutWithoutProvider } from "@/features/ui/layout";
 import {
   cardbacksOneOtherResult,
   cardbacksOneResult,
@@ -49,20 +47,14 @@ test("selecting a single card and changing its query", async () => {
     searchResultsSixResults,
     ...defaultHandlers
   );
-  renderWithProviders(
-    <LayoutWithoutProvider>
-      <App />
-    </LayoutWithoutProvider>,
-    {
-      preloadedState: {
-        backend: localBackend,
-        project: {
-          members: [],
-          cardback: cardDocument5.identifier,
-        },
+  renderWithProviders(<App />, {
+    preloadedState: {
+      project: {
+        members: [],
+        cardback: cardDocument5.identifier,
       },
-    }
-  );
+    },
+  });
 
   await importText("query 1");
   await expectCardGridSlotState(1, Front, cardDocument1.name, 1, 1);
@@ -80,20 +72,14 @@ test("selecting multiple cards and changing both of their queries", async () => 
     searchResultsSixResults,
     ...defaultHandlers
   );
-  renderWithProviders(
-    <LayoutWithoutProvider>
-      <App />
-    </LayoutWithoutProvider>,
-    {
-      preloadedState: {
-        backend: localBackend,
-        project: {
-          members: [],
-          cardback: cardDocument5.identifier,
-        },
+  renderWithProviders(<App />, {
+    preloadedState: {
+      project: {
+        members: [],
+        cardback: cardDocument5.identifier,
       },
-    }
-  );
+    },
+  });
 
   await importText("2x query 1");
   await expectCardGridSlotState(1, Front, cardDocument1.name, 1, 1);
@@ -114,20 +100,14 @@ test("selecting a single card and changing its selected image", async () => {
     searchResultsThreeResults,
     ...defaultHandlers
   );
-  renderWithProviders(
-    <LayoutWithoutProvider>
-      <App />
-    </LayoutWithoutProvider>,
-    {
-      preloadedState: {
-        backend: localBackend,
-        project: {
-          members: [],
-          cardback: cardDocument5.identifier,
-        },
+  renderWithProviders(<App />, {
+    preloadedState: {
+      project: {
+        members: [],
+        cardback: cardDocument5.identifier,
       },
-    }
-  );
+    },
+  });
 
   await importText("my search query");
   await expectCardGridSlotState(1, Front, cardDocument1.name, 1, 3);
@@ -145,20 +125,14 @@ test("selecting multiple cards with the same query and changing both of their se
     searchResultsThreeResults,
     ...defaultHandlers
   );
-  renderWithProviders(
-    <LayoutWithoutProvider>
-      <App />
-    </LayoutWithoutProvider>,
-    {
-      preloadedState: {
-        backend: localBackend,
-        project: {
-          members: [],
-          cardback: cardDocument5.identifier,
-        },
+  renderWithProviders(<App />, {
+    preloadedState: {
+      project: {
+        members: [],
+        cardback: cardDocument5.identifier,
       },
-    }
-  );
+    },
+  });
 
   await importText("2x my search query");
   await expectCardGridSlotState(1, Front, cardDocument1.name, 1, 3);
@@ -179,20 +153,14 @@ test("selecting multiple cardbacks and changing both of their selected images", 
     searchResultsThreeResults,
     ...defaultHandlers
   );
-  renderWithProviders(
-    <LayoutWithoutProvider>
-      <App />
-    </LayoutWithoutProvider>,
-    {
-      preloadedState: {
-        backend: localBackend,
-        project: {
-          members: [],
-          cardback: cardDocument1.identifier,
-        },
+  renderWithProviders(<App />, {
+    preloadedState: {
+      project: {
+        members: [],
+        cardback: cardDocument1.identifier,
       },
-    }
-  );
+    },
+  });
 
   await importText("2x my search query");
   await expectCardGridSlotState(1, Back, cardDocument1.name, 1, 2);
@@ -213,20 +181,14 @@ test("cannot change the images of multiple selected images when they don't share
     searchResultsSixResults,
     ...defaultHandlers
   );
-  renderWithProviders(
-    <LayoutWithoutProvider>
-      <App />
-    </LayoutWithoutProvider>,
-    {
-      preloadedState: {
-        backend: localBackend,
-        project: {
-          members: [],
-          cardback: cardDocument5.identifier,
-        },
+  renderWithProviders(<App />, {
+    preloadedState: {
+      project: {
+        members: [],
+        cardback: cardDocument5.identifier,
       },
-    }
-  );
+    },
+  });
 
   await importText("query 1\nquery 2");
   await expectCardGridSlotState(1, Front, cardDocument1.name, 1, 1);
@@ -249,20 +211,14 @@ test("selecting a single card and clearing its front query", async () => {
     searchResultsOneResult,
     ...defaultHandlers
   );
-  renderWithProviders(
-    <LayoutWithoutProvider>
-      <App />
-    </LayoutWithoutProvider>,
-    {
-      preloadedState: {
-        backend: localBackend,
-        project: {
-          members: [],
-          cardback: cardDocument5.identifier,
-        },
+  renderWithProviders(<App />, {
+    preloadedState: {
+      project: {
+        members: [],
+        cardback: cardDocument5.identifier,
       },
-    }
-  );
+    },
+  });
 
   await importText("my search query");
   await expectCardGridSlotState(1, Front, cardDocument1.name, 1, 1);
@@ -280,20 +236,14 @@ test("selecting a single card and clearing its back query", async () => {
     searchResultsOneResult,
     ...defaultHandlers
   );
-  renderWithProviders(
-    <LayoutWithoutProvider>
-      <App />
-    </LayoutWithoutProvider>,
-    {
-      preloadedState: {
-        backend: localBackend,
-        project: {
-          members: [],
-          cardback: cardDocument5.identifier,
-        },
+  renderWithProviders(<App />, {
+    preloadedState: {
+      project: {
+        members: [],
+        cardback: cardDocument5.identifier,
       },
-    }
-  );
+    },
+  });
 
   await importText("my search query | my search query");
   await expectCardGridSlotState(1, Front, cardDocument1.name, 1, 1);
@@ -315,20 +265,14 @@ test("selecting multiple cards and clearing their front queries", async () => {
     searchResultsOneResult,
     ...defaultHandlers
   );
-  renderWithProviders(
-    <LayoutWithoutProvider>
-      <App />
-    </LayoutWithoutProvider>,
-    {
-      preloadedState: {
-        backend: localBackend,
-        project: {
-          members: [],
-          cardback: cardDocument5.identifier,
-        },
+  renderWithProviders(<App />, {
+    preloadedState: {
+      project: {
+        members: [],
+        cardback: cardDocument5.identifier,
       },
-    }
-  );
+    },
+  });
 
   await importText("2x my search query");
   await expectCardGridSlotState(1, Front, cardDocument1.name, 1, 1);
@@ -349,20 +293,14 @@ test("selecting a single card and deleting it", async () => {
     searchResultsOneResult,
     ...defaultHandlers
   );
-  renderWithProviders(
-    <LayoutWithoutProvider>
-      <App />
-    </LayoutWithoutProvider>,
-    {
-      preloadedState: {
-        backend: localBackend,
-        project: {
-          members: [],
-          cardback: cardDocument5.identifier,
-        },
+  renderWithProviders(<App />, {
+    preloadedState: {
+      project: {
+        members: [],
+        cardback: cardDocument5.identifier,
       },
-    }
-  );
+    },
+  });
 
   await importText("my search query");
   await expectCardGridSlotState(1, Front, cardDocument1.name, 1, 1);
@@ -380,20 +318,14 @@ test("selecting multiple cards and deleting them", async () => {
     searchResultsOneResult,
     ...defaultHandlers
   );
-  renderWithProviders(
-    <LayoutWithoutProvider>
-      <App />
-    </LayoutWithoutProvider>,
-    {
-      preloadedState: {
-        backend: localBackend,
-        project: {
-          members: [],
-          cardback: cardDocument5.identifier,
-        },
+  renderWithProviders(<App />, {
+    preloadedState: {
+      project: {
+        members: [],
+        cardback: cardDocument5.identifier,
       },
-    }
-  );
+    },
+  });
 
   await importText("2x my search query");
   await expectCardGridSlotState(1, Front, cardDocument1.name, 1, 1);
@@ -414,20 +346,14 @@ test("selecting then clearing the selection", async () => {
     searchResultsOneResult,
     ...defaultHandlers
   );
-  renderWithProviders(
-    <LayoutWithoutProvider>
-      <App />
-    </LayoutWithoutProvider>,
-    {
-      preloadedState: {
-        backend: localBackend,
-        project: {
-          members: [],
-          cardback: cardDocument5.identifier,
-        },
+  renderWithProviders(<App />, {
+    preloadedState: {
+      project: {
+        members: [],
+        cardback: cardDocument5.identifier,
       },
-    }
-  );
+    },
+  });
 
   await importText("my search query");
   await expectCardGridSlotState(1, Front, cardDocument1.name, 1, 1);

--- a/frontend/src/features/bulkManagement/bulkManagementStatus.tsx
+++ b/frontend/src/features/bulkManagement/bulkManagementStatus.tsx
@@ -15,12 +15,12 @@ import { RightPaddedIcon } from "@/components/icon";
 import { GridSelectorModal } from "@/features/gridSelector/gridSelectorModal";
 import { setSelectedSlotsAndShowModal } from "@/features/modals/modalsSlice";
 import {
-  bulkClearQuery,
-  bulkDeleteSlots,
   bulkSetMemberSelection,
-  bulkSetSelectedImage,
+  clearQueries,
+  deleteSlots,
   selectAllSelectedProjectMembersHaveTheSameQuery,
   selectSelectedSlots,
+  setSelectedImages,
 } from "@/features/project/projectSlice";
 import { selectSearchResultsForQueryOrDefault } from "@/features/search/searchResultsSlice";
 
@@ -36,7 +36,7 @@ function ChangeSelectedImageSelectedImages({ slots }: { slots: Slots }) {
   const handleHideModal = () => setShowModal(false);
 
   const handleChangeImages = (selectedImage: string): void => {
-    dispatch(bulkSetSelectedImage({ selectedImage, slots }));
+    dispatch(setSelectedImages({ selectedImage, slots }));
     handleHideModal();
   };
 
@@ -92,7 +92,7 @@ function ChangeSelectedImageQueries({ slots }: { slots: Slots }) {
 
 function ClearSelectedImageQueries({ slots }: { slots: Slots }) {
   const dispatch = useAppDispatch();
-  const onClick = () => dispatch(bulkClearQuery({ slots }));
+  const onClick = () => dispatch(clearQueries({ slots }));
   return (
     <Dropdown.Item onClick={onClick} className="text-decoration-none">
       <RightPaddedIcon bootstrapIconName="slash-circle" /> Clear Query
@@ -104,7 +104,7 @@ function DeleteSelectedImages({ slots }: { slots: Slots }) {
   const dispatch = useAppDispatch();
 
   const slotNumbers = slots.map(([face, slot]) => slot);
-  const onClick = () => dispatch(bulkDeleteSlots({ slots: slotNumbers }));
+  const onClick = () => dispatch(deleteSlots({ slots: slotNumbers }));
 
   return (
     <Dropdown.Item onClick={onClick} className="text-decoration-none">

--- a/frontend/src/features/card/__snapshots__/card.test.tsx.snap
+++ b/frontend/src/features/card/__snapshots__/card.test.tsx.snap
@@ -16,56 +16,52 @@ exports[`the html structure of a Card with a single document 1`] = `
   border: solid 0px black;
 }
 
-<body>
+<div
+  class="mpccard mpccard-hover card"
+>
+  <div
+    class="pb-0 text-center card-header"
+  >
+    <p
+      class="mpccard-slot"
+    >
+      Slot 1
+    </p>
+  </div>
   <div>
     <div
-      class="mpccard mpccard-hover card"
+      class="c0 rounded-lg shadow-lg ratio ratio-7x5"
+    >
+      <img
+        alt="Card 1"
+        class="c1 card-img card-img-fade-in"
+        data-nimg="fill"
+        decoding="async"
+        loading="lazy"
+        src=""
+        style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+      />
+    </div>
+    <div
+      class="mb-0 text-center card-body"
     >
       <div
-        class="pb-0 text-center card-header"
+        class="mpccard-name card-subtitle h6"
+      >
+        Card 1
+      </div>
+      <div
+        class="mpccard-spacing"
       >
         <p
-          class="mpccard-slot"
+          class="mpccard-source card-text"
         >
-          Card 1
+          Source 1 [1200 DPI]
         </p>
-      </div>
-      <div>
-        <div
-          class="c0 rounded-lg shadow-lg ratio ratio-7x5"
-        >
-          <img
-            alt="Card 1"
-            class="c1 card-img card-img-fade-in"
-            data-nimg="fill"
-            decoding="async"
-            loading="lazy"
-            src=""
-            style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
-          />
-        </div>
-        <div
-          class="mb-0 text-center card-body"
-        >
-          <div
-            class="mpccard-name card-subtitle h6"
-          >
-            Card 1
-          </div>
-          <div
-            class="mpccard-spacing"
-          >
-            <p
-              class="mpccard-source card-text"
-            >
-              Source 1 [1200 DPI]
-            </p>
-          </div>
-        </div>
       </div>
     </div>
   </div>
-</body>
+</div>
 `;
 
 exports[`the html structure of a Card with no search results 1`] = `
@@ -75,58 +71,54 @@ exports[`the html structure of a Card with no search results 1`] = `
   border: solid 0px black;
 }
 
-<body>
+<div
+  class="mpccard mpccard-hover card"
+>
+  <div
+    class="pb-0 text-center card-header"
+  >
+    <p
+      class="mpccard-slot"
+    >
+      Slot 1
+    </p>
+  </div>
   <div>
     <div
-      class="mpccard mpccard-hover card"
+      class="c0 rounded-lg shadow-lg ratio ratio-7x5"
+    >
+      <img
+        alt="Card not found"
+        class="card-img card-img-fade-in"
+        data-nimg="fill"
+        decoding="async"
+        loading="lazy"
+        sizes="100vw"
+        src="/_next/image?url=%2Fblank.png&w=3840&q=75"
+        srcset="/_next/image?url=%2Fblank.png&w=640&q=75 640w, /_next/image?url=%2Fblank.png&w=750&q=75 750w, /_next/image?url=%2Fblank.png&w=828&q=75 828w, /_next/image?url=%2Fblank.png&w=1080&q=75 1080w, /_next/image?url=%2Fblank.png&w=1200&q=75 1200w, /_next/image?url=%2Fblank.png&w=1920&q=75 1920w, /_next/image?url=%2Fblank.png&w=2048&q=75 2048w, /_next/image?url=%2Fblank.png&w=3840&q=75 3840w"
+        style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent; z-index: 1;"
+      />
+    </div>
+    <div
+      class="mb-0 text-center card-body"
     >
       <div
-        class="pb-0 text-center card-header"
+        class="mpccard-name card-subtitle h6"
+      >
+        My Invalid Query
+      </div>
+      <div
+        class="mpccard-spacing"
       >
         <p
-          class="mpccard-slot"
+          class="mpccard-source card-text"
         >
-          Card 1
+          Your search query
         </p>
-      </div>
-      <div>
-        <div
-          class="c0 rounded-lg shadow-lg ratio ratio-7x5"
-        >
-          <img
-            alt="Card not found"
-            class="card-img card-img-fade-in"
-            data-nimg="fill"
-            decoding="async"
-            loading="lazy"
-            sizes="100vw"
-            src="/_next/image?url=%2Fblank.png&w=3840&q=75"
-            srcset="/_next/image?url=%2Fblank.png&w=640&q=75 640w, /_next/image?url=%2Fblank.png&w=750&q=75 750w, /_next/image?url=%2Fblank.png&w=828&q=75 828w, /_next/image?url=%2Fblank.png&w=1080&q=75 1080w, /_next/image?url=%2Fblank.png&w=1200&q=75 1200w, /_next/image?url=%2Fblank.png&w=1920&q=75 1920w, /_next/image?url=%2Fblank.png&w=2048&q=75 2048w, /_next/image?url=%2Fblank.png&w=3840&q=75 3840w"
-            style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent; z-index: 1;"
-          />
-        </div>
-        <div
-          class="mb-0 text-center card-body"
-        >
-          <div
-            class="mpccard-name card-subtitle h6"
-          >
-            My Invalid Query
-          </div>
-          <div
-            class="mpccard-spacing"
-          >
-            <p
-              class="mpccard-source card-text"
-            >
-              Your search query
-            </p>
-          </div>
-        </div>
       </div>
     </div>
   </div>
-</body>
+</div>
 `;
 
 exports[`the html structure of a Card with three documents 1`] = `
@@ -150,74 +142,70 @@ exports[`the html structure of a Card with three documents 1`] = `
   border: solid 0px black;
 }
 
-<body>
+<div
+  class="mpccard mpccard-hover card"
+>
+  <div
+    class="pb-0 text-center card-header"
+  >
+    <p
+      class="mpccard-slot"
+    >
+      Slot 3
+    </p>
+  </div>
   <div>
     <div
-      class="mpccard mpccard-hover card"
+      class="c0 rounded-lg shadow-lg ratio ratio-7x5"
+    >
+      <img
+        alt="Card 1"
+        class="c1 card-img card-img-fade-in"
+        data-nimg="fill"
+        decoding="async"
+        loading="lazy"
+        src=""
+        style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+      />
+      <img
+        alt="Card 2"
+        class="c2 card-img"
+        data-nimg="fill"
+        decoding="async"
+        loading="lazy"
+        src=""
+        style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+      />
+      <img
+        alt="Card 3"
+        class="c2 card-img"
+        data-nimg="fill"
+        decoding="async"
+        loading="lazy"
+        src=""
+        style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+      />
+    </div>
+    <div
+      class="mb-0 text-center card-body"
     >
       <div
-        class="pb-0 text-center card-header"
+        class="mpccard-name card-subtitle h6"
+      >
+        Card 1
+      </div>
+      <div
+        class="mpccard-spacing"
       >
         <p
-          class="mpccard-slot"
+          class="mpccard-source card-text"
         >
-          Card 3
+          Source 1 [1200 DPI]
         </p>
-      </div>
-      <div>
-        <div
-          class="c0 rounded-lg shadow-lg ratio ratio-7x5"
-        >
-          <img
-            alt="Card 1"
-            class="c1 card-img card-img-fade-in"
-            data-nimg="fill"
-            decoding="async"
-            loading="lazy"
-            src=""
-            style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
-          />
-          <img
-            alt="Card 2"
-            class="c2 card-img"
-            data-nimg="fill"
-            decoding="async"
-            loading="lazy"
-            src=""
-            style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
-          />
-          <img
-            alt="Card 3"
-            class="c2 card-img"
-            data-nimg="fill"
-            decoding="async"
-            loading="lazy"
-            src=""
-            style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
-          />
-        </div>
-        <div
-          class="mb-0 text-center card-body"
-        >
-          <div
-            class="mpccard-name card-subtitle h6"
-          >
-            Card 1
-          </div>
-          <div
-            class="mpccard-spacing"
-          >
-            <p
-              class="mpccard-source card-text"
-            >
-              Source 1 [1200 DPI]
-            </p>
-          </div>
-        </div>
       </div>
     </div>
   </div>
-</body>
+</div>
 `;
 
 exports[`the html structure of a Card with two documents 1`] = `
@@ -241,63 +229,59 @@ exports[`the html structure of a Card with two documents 1`] = `
   border: solid 0px black;
 }
 
-<body>
+<div
+  class="mpccard mpccard-hover card"
+>
+  <div
+    class="pb-0 text-center card-header"
+  >
+    <p
+      class="mpccard-slot"
+    >
+      Slot 2
+    </p>
+  </div>
   <div>
     <div
-      class="mpccard mpccard-hover card"
+      class="c0 rounded-lg shadow-lg ratio ratio-7x5"
+    >
+      <img
+        alt="Card 1"
+        class="c1 card-img card-img-fade-in"
+        data-nimg="fill"
+        decoding="async"
+        loading="lazy"
+        src=""
+        style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+      />
+      <img
+        alt="Card 2"
+        class="c2 card-img"
+        data-nimg="fill"
+        decoding="async"
+        loading="lazy"
+        src=""
+        style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+      />
+    </div>
+    <div
+      class="mb-0 text-center card-body"
     >
       <div
-        class="pb-0 text-center card-header"
+        class="mpccard-name card-subtitle h6"
+      >
+        Card 1
+      </div>
+      <div
+        class="mpccard-spacing"
       >
         <p
-          class="mpccard-slot"
+          class="mpccard-source card-text"
         >
-          Card 2
+          Source 1 [1200 DPI]
         </p>
-      </div>
-      <div>
-        <div
-          class="c0 rounded-lg shadow-lg ratio ratio-7x5"
-        >
-          <img
-            alt="Card 1"
-            class="c1 card-img card-img-fade-in"
-            data-nimg="fill"
-            decoding="async"
-            loading="lazy"
-            src=""
-            style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
-          />
-          <img
-            alt="Card 2"
-            class="c2 card-img"
-            data-nimg="fill"
-            decoding="async"
-            loading="lazy"
-            src=""
-            style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
-          />
-        </div>
-        <div
-          class="mb-0 text-center card-body"
-        >
-          <div
-            class="mpccard-name card-subtitle h6"
-          >
-            Card 1
-          </div>
-          <div
-            class="mpccard-spacing"
-          >
-            <p
-              class="mpccard-source card-text"
-            >
-              Source 1 [1200 DPI]
-            </p>
-          </div>
-        </div>
       </div>
     </div>
   </div>
-</body>
+</div>
 `;

--- a/frontend/src/features/card/card.test.tsx
+++ b/frontend/src/features/card/card.test.tsx
@@ -9,7 +9,7 @@ import { MemoizedEditorCard } from "@/features/card/card";
 test("the html structure of a Card with a single document", () => {
   const rendered = renderWithProviders(
     <MemoizedEditorCard
-      cardHeaderTitle="Card 1"
+      cardHeaderTitle="Slot 1"
       noResultsFound={false}
       imageIdentifier={cardDocument1.identifier}
     />,
@@ -25,13 +25,15 @@ test("the html structure of a Card with a single document", () => {
       },
     }
   );
-  expect(rendered.baseElement).toMatchSnapshot();
+  expect(
+    rendered.getByText("Slot 1").parentElement!.parentElement!
+  ).toMatchSnapshot();
 });
 
 test("the html structure of a Card with two documents", () => {
   const rendered = renderWithProviders(
     <MemoizedEditorCard
-      cardHeaderTitle="Card 2"
+      cardHeaderTitle="Slot 2"
       noResultsFound={false}
       imageIdentifier={cardDocument1.identifier}
       previousImageIdentifier={cardDocument2.identifier}
@@ -49,13 +51,15 @@ test("the html structure of a Card with two documents", () => {
       },
     }
   );
-  expect(rendered.baseElement).toMatchSnapshot();
+  expect(
+    rendered.getByText("Slot 2").parentElement!.parentElement!
+  ).toMatchSnapshot();
 });
 
 test("the html structure of a Card with three documents", () => {
   const rendered = renderWithProviders(
     <MemoizedEditorCard
-      cardHeaderTitle="Card 3"
+      cardHeaderTitle="Slot 3"
       noResultsFound={false}
       imageIdentifier={cardDocument1.identifier}
       previousImageIdentifier={cardDocument2.identifier}
@@ -75,14 +79,16 @@ test("the html structure of a Card with three documents", () => {
       },
     }
   );
-  expect(rendered.baseElement).toMatchSnapshot();
+  expect(
+    rendered.getByText("Slot 3").parentElement!.parentElement!
+  ).toMatchSnapshot();
 });
 
 test("the html structure of a Card with no search results", () => {
   const rendered = renderWithProviders(
     <MemoizedEditorCard
       imageIdentifier={undefined}
-      cardHeaderTitle="Card 1"
+      cardHeaderTitle="Slot 1"
       noResultsFound={true}
       searchQuery={{ query: "My Invalid Query", card_type: "CARD" }}
     />,
@@ -96,5 +102,7 @@ test("the html structure of a Card with no search results", () => {
       },
     }
   );
-  expect(rendered.baseElement).toMatchSnapshot();
+  expect(
+    rendered.getByText("Slot 1").parentElement!.parentElement!
+  ).toMatchSnapshot();
 });

--- a/frontend/src/features/card/cardSlot.test.tsx
+++ b/frontend/src/features/card/cardSlot.test.tsx
@@ -6,7 +6,6 @@ import {
   cardDocument1,
   cardDocument2,
   cardDocument3,
-  localBackend,
   projectSelectedImage1,
   projectSelectedImage2,
   projectThreeMembersSelectedImage1,
@@ -20,7 +19,6 @@ import {
   renderWithProviders,
   selectSlot,
 } from "@/common/test-utils";
-import { LayoutWithoutProvider } from "@/features/ui/layout";
 import {
   cardbacksTwoResults,
   cardDocumentsFourResults,
@@ -47,7 +45,6 @@ test("the html structure of a CardSlot with a single search result, no image sel
   );
   renderWithProviders(<App />, {
     preloadedState: {
-      backend: localBackend,
       project: {
         members: [
           {
@@ -76,7 +73,6 @@ test("the html structure of a CardSlot with a single search result, slot selecte
   );
   renderWithProviders(<App />, {
     preloadedState: {
-      backend: localBackend,
       project: {
         members: [
           {
@@ -112,7 +108,6 @@ test("the html structure of a CardSlot with a single search result, image select
 
   renderWithProviders(<App />, {
     preloadedState: {
-      backend: localBackend,
       project: projectSelectedImage1,
     },
   });
@@ -130,7 +125,7 @@ test("the html structure of a CardSlot with multiple search results, image selec
   );
 
   renderWithProviders(<App />, {
-    preloadedState: { backend: localBackend, project: projectSelectedImage1 },
+    preloadedState: { project: projectSelectedImage1 },
   });
 
   await expectCardGridSlotState(1, Front, cardDocument1.name, 1, 3);
@@ -147,7 +142,6 @@ test("the html structure of a CardSlot's grid selector, cards faceted by source"
 
   renderWithProviders(<App />, {
     preloadedState: {
-      backend: localBackend,
       project: projectSelectedImage1,
     },
   });
@@ -166,7 +160,6 @@ test("the html structure of a CardSlot's grid selector, cards grouped together",
 
   renderWithProviders(<App />, {
     preloadedState: {
-      backend: localBackend,
       project: projectSelectedImage1,
       viewSettings: {
         frontsVisible: true,
@@ -191,7 +184,6 @@ test("switching to the next image in a CardSlot", async () => {
   );
   renderWithProviders(<App />, {
     preloadedState: {
-      backend: localBackend,
       project: projectSelectedImage1,
     },
   });
@@ -213,7 +205,6 @@ test("switching to the previous image in a CardSlot", async () => {
   );
   renderWithProviders(<App />, {
     preloadedState: {
-      backend: localBackend,
       project: projectSelectedImage2,
     },
   });
@@ -235,7 +226,6 @@ test("switching images in a CardSlot wraps around", async () => {
   );
   renderWithProviders(<App />, {
     preloadedState: {
-      backend: localBackend,
       project: projectSelectedImage2,
     },
   });
@@ -263,7 +253,6 @@ test("selecting an image in a CardSlot via the grid selector", async () => {
   );
   renderWithProviders(<App />, {
     preloadedState: {
-      backend: localBackend,
       project: projectSelectedImage2,
     },
   });
@@ -290,7 +279,6 @@ test("deleting a CardSlot", async () => {
   );
   renderWithProviders(<App />, {
     preloadedState: {
-      backend: localBackend,
       project: projectSelectedImage1,
     },
   });
@@ -312,7 +300,6 @@ test("deleting multiple CardSlots", async () => {
   );
   renderWithProviders(<App />, {
     preloadedState: {
-      backend: localBackend,
       project: projectThreeMembersSelectedImage1,
     },
   });
@@ -336,7 +323,6 @@ test("CardSlot automatically selects the first search result", async () => {
   );
   renderWithProviders(<App />, {
     preloadedState: {
-      backend: localBackend,
       project: {
         members: [
           {
@@ -365,7 +351,6 @@ test("CardSlot automatically deselects invalid image then selects the first sear
   );
   renderWithProviders(<App />, {
     preloadedState: {
-      backend: localBackend,
       project: projectSelectedImage2, // not in search results
     },
   });
@@ -382,7 +367,6 @@ test("CardSlot uses cardbacks as search results for backs with no search query",
   );
   renderWithProviders(<App />, {
     preloadedState: {
-      backend: localBackend,
       project: {
         members: [
           {
@@ -412,7 +396,6 @@ test("CardSlot defaults to project cardback for backs with no search query", asy
   );
   renderWithProviders(<App />, {
     preloadedState: {
-      backend: localBackend,
       project: {
         members: [
           {
@@ -438,7 +421,6 @@ test("double clicking the select button selects all slots for the same query", a
   );
   renderWithProviders(<App />, {
     preloadedState: {
-      backend: localBackend,
       project: {
         members: [
           {
@@ -487,29 +469,23 @@ test("changing a card slot's query", async () => {
     ...defaultHandlers
   );
 
-  renderWithProviders(
-    <LayoutWithoutProvider>
-      <App />
-    </LayoutWithoutProvider>,
-    {
-      preloadedState: {
-        backend: localBackend,
-        project: {
-          members: [
-            {
-              front: {
-                query: { query: "query 1", card_type: Card },
-                selectedImage: undefined,
-                selected: false,
-              },
-              back: null,
+  renderWithProviders(<App />, {
+    preloadedState: {
+      project: {
+        members: [
+          {
+            front: {
+              query: { query: "query 1", card_type: Card },
+              selectedImage: undefined,
+              selected: false,
             },
-          ],
-          cardback: null,
-        },
+            back: null,
+          },
+        ],
+        cardback: null,
       },
-    }
-  );
+    },
+  });
 
   await expectCardGridSlotState(1, Front, cardDocument1.name, 1, 1);
 
@@ -526,29 +502,23 @@ test("clearing a card slot's query", async () => {
     ...defaultHandlers
   );
 
-  renderWithProviders(
-    <LayoutWithoutProvider>
-      <App />
-    </LayoutWithoutProvider>,
-    {
-      preloadedState: {
-        backend: localBackend,
-        project: {
-          members: [
-            {
-              front: {
-                query: { query: "query 1", card_type: Card },
-                selectedImage: undefined,
-                selected: false,
-              },
-              back: null,
+  renderWithProviders(<App />, {
+    preloadedState: {
+      project: {
+        members: [
+          {
+            front: {
+              query: { query: "query 1", card_type: Card },
+              selectedImage: undefined,
+              selected: false,
             },
-          ],
-          cardback: null,
-        },
+            back: null,
+          },
+        ],
+        cardback: null,
       },
-    }
-  );
+    },
+  });
 
   await expectCardGridSlotState(1, Front, cardDocument1.name, 1, 1);
 
@@ -565,37 +535,31 @@ test("changing a card slot's query doesn't affect a different slot", async () =>
     ...defaultHandlers
   );
 
-  renderWithProviders(
-    <LayoutWithoutProvider>
-      <App />
-    </LayoutWithoutProvider>,
-    {
-      preloadedState: {
-        backend: localBackend,
-        project: {
-          members: [
-            {
-              front: {
-                query: { query: "query 1", card_type: Card },
-                selectedImage: undefined,
-                selected: false,
-              },
-              back: null,
+  renderWithProviders(<App />, {
+    preloadedState: {
+      project: {
+        members: [
+          {
+            front: {
+              query: { query: "query 1", card_type: Card },
+              selectedImage: undefined,
+              selected: false,
             },
-            {
-              front: {
-                query: { query: "query 2", card_type: Card },
-                selectedImage: undefined,
-                selected: false,
-              },
-              back: null,
+            back: null,
+          },
+          {
+            front: {
+              query: { query: "query 2", card_type: Card },
+              selectedImage: undefined,
+              selected: false,
             },
-          ],
-          cardback: null,
-        },
+            back: null,
+          },
+        ],
+        cardback: null,
       },
-    }
-  );
+    },
+  });
 
   await expectCardGridSlotState(1, Front, cardDocument1.name, 1, 1);
   await expectCardGridSlotState(2, Front, cardDocument2.name, 1, 1);

--- a/frontend/src/features/card/cardSlot.test.tsx
+++ b/frontend/src/features/card/cardSlot.test.tsx
@@ -1,7 +1,7 @@
 import { screen, waitFor } from "@testing-library/react";
 
 import App from "@/app/app";
-import { Back, Card, Front } from "@/common/constants";
+import { Back, Card, FaceSeparator, Front } from "@/common/constants";
 import {
   cardDocument1,
   cardDocument2,
@@ -15,6 +15,7 @@ import {
   expectCardbackSlotState,
   expectCardGridSlotState,
   expectCardSlotToNotExist,
+  importText,
   openCardSlotGridSelector,
   renderWithProviders,
   selectSlot,
@@ -367,22 +368,11 @@ test("CardSlot uses cardbacks as search results for backs with no search query",
   );
   renderWithProviders(<App />, {
     preloadedState: {
-      project: {
-        members: [
-          {
-            front: null,
-            back: {
-              query: { query: null, card_type: Card },
-              selectedImage: cardDocument1.identifier,
-              selected: false,
-            },
-          },
-        ],
-        cardback: null,
-      },
+      project: { members: [], cardback: null },
     },
   });
 
+  await importText("my search query");
   await expectCardGridSlotState(1, Back, cardDocument1.name, 1, 2);
   await expectCardbackSlotState(cardDocument1.name, 1, 2);
 });
@@ -396,20 +386,13 @@ test("CardSlot defaults to project cardback for backs with no search query", asy
   );
   renderWithProviders(<App />, {
     preloadedState: {
-      project: {
-        members: [
-          {
-            front: null,
-            back: null,
-          },
-        ],
-        cardback: cardDocument1.identifier,
-      },
+      project: { members: [], cardback: cardDocument2.identifier },
     },
   });
 
-  await expectCardGridSlotState(1, Back, cardDocument1.name, 1, 2);
-  await expectCardbackSlotState(cardDocument1.name, 1, 2);
+  await importText(FaceSeparator);
+  await expectCardGridSlotState(1, Back, cardDocument2.name, 2, 2);
+  await expectCardbackSlotState(cardDocument2.name, 2, 2);
 });
 
 test("double clicking the select button selects all slots for the same query", async () => {

--- a/frontend/src/features/card/cardbackSlice.ts
+++ b/frontend/src/features/card/cardbackSlice.ts
@@ -15,7 +15,7 @@ import { setError } from "@/features/toasts/toastsSlice";
 
 const typePrefix = "cardbacks/fetchCardbacks";
 
-const fetchCardbacks = createAppAsyncThunk(
+export const fetchCardbacks = createAppAsyncThunk(
   typePrefix,
   async (arg, { getState }) => {
     const state = getState();

--- a/frontend/src/features/card/commonCardback.test.tsx
+++ b/frontend/src/features/card/commonCardback.test.tsx
@@ -1,7 +1,7 @@
 import { screen } from "@testing-library/react";
 
 import App from "@/app/app";
-import { cardDocument1, localBackend } from "@/common/test-constants";
+import { cardDocument1 } from "@/common/test-constants";
 import {
   expectCardbackSlotState,
   renderWithProviders,
@@ -27,7 +27,6 @@ test("the html structure of a CommonCardback with a single search result", async
 
   renderWithProviders(<App />, {
     preloadedState: {
-      backend: localBackend,
       project: { members: [], cardback: null },
     },
   });
@@ -46,7 +45,6 @@ test("the html structure of a CommonCardback with multiple search results", asyn
 
   renderWithProviders(<App />, {
     preloadedState: {
-      backend: localBackend,
       project: { members: [], cardback: null },
     },
   });

--- a/frontend/src/features/card/commonCardback.tsx
+++ b/frontend/src/features/card/commonCardback.tsx
@@ -4,7 +4,7 @@
  * the project cardback (displayed in the right panel of the project editor).
  */
 
-import React, { memo, useEffect, useState } from "react";
+import React, { memo, useState } from "react";
 import Button from "react-bootstrap/Button";
 
 import { Back } from "@/common/constants";
@@ -120,33 +120,6 @@ export function CommonCardback({ selectedImage }: CommonCardbackProps) {
       );
     }
   };
-
-  //# endregion
-
-  //# region effects
-
-  useEffect(() => {
-    let mutatedSelectedImage = selectedImage;
-
-    // If an image is selected and it's not in the search results, deselect the image
-    if (
-      mutatedSelectedImage != null &&
-      !searchResults.includes(mutatedSelectedImage)
-    ) {
-      mutatedSelectedImage = undefined;
-    }
-
-    // If no image is selected and there are cardbacks, select the first image in search results
-    if (searchResults.length > 0 && mutatedSelectedImage == null) {
-      mutatedSelectedImage = searchResults[0];
-    }
-
-    dispatch(
-      setSelectedCardback({
-        selectedImage: mutatedSelectedImage ?? null,
-      })
-    );
-  }, [dispatch, selectedImage, searchResults]);
 
   //# endregion
 

--- a/frontend/src/features/cardDetailedView/cardDetailedViewModal.test.tsx
+++ b/frontend/src/features/cardDetailedView/cardDetailedViewModal.test.tsx
@@ -2,12 +2,11 @@ import { screen, waitFor } from "@testing-library/react";
 
 import App from "@/app/app";
 import { Card, Front } from "@/common/constants";
-import { cardDocument1, localBackend } from "@/common/test-constants";
+import { cardDocument1 } from "@/common/test-constants";
 import {
   expectCardGridSlotState,
   renderWithProviders,
 } from "@/common/test-utils";
-import { LayoutWithoutProvider } from "@/features/ui/layout";
 import {
   cardDocumentsOneResult,
   defaultHandlers,
@@ -25,29 +24,23 @@ test("the html structure of a CardDetailedViewModal", async () => {
     searchResultsOneResult,
     ...defaultHandlers
   );
-  renderWithProviders(
-    <LayoutWithoutProvider>
-      <App />
-    </LayoutWithoutProvider>,
-    {
-      preloadedState: {
-        backend: localBackend,
-        project: {
-          members: [
-            {
-              front: {
-                query: { query: "my search query", card_type: Card },
-                selectedImage: cardDocument1.identifier,
-                selected: false,
-              },
-              back: null,
+  renderWithProviders(<App />, {
+    preloadedState: {
+      project: {
+        members: [
+          {
+            front: {
+              query: { query: "my search query", card_type: Card },
+              selectedImage: cardDocument1.identifier,
+              selected: false,
             },
-          ],
-          cardback: null,
-        },
+            back: null,
+          },
+        ],
+        cardback: null,
       },
-    }
-  );
+    },
+  });
   await expectCardGridSlotState(1, Front, cardDocument1.name, 1, 1);
 
   screen.getByAltText(cardDocument1.name).click();

--- a/frontend/src/features/changeQuery/changeQueryModal.tsx
+++ b/frontend/src/features/changeQuery/changeQueryModal.tsx
@@ -6,7 +6,7 @@ import Modal from "react-bootstrap/Modal";
 import { useGetSampleCardsQuery } from "@/app/api";
 import { Card } from "@/common/constants";
 import { Slots, useAppDispatch } from "@/common/types";
-import { bulkClearQuery, bulkSetQuery } from "@/features/project/projectSlice";
+import { clearQueries, setQueries } from "@/features/project/projectSlice";
 
 interface ChangeQueryModalProps {
   slots: Slots;
@@ -44,10 +44,10 @@ export function ChangeQueryModal({
     event.preventDefault(); // to avoid reloading the page
     if (changeSelectedImageQueriesModalValue.length > 0) {
       dispatch(
-        bulkSetQuery({ query: changeSelectedImageQueriesModalValue, slots })
+        setQueries({ query: changeSelectedImageQueriesModalValue, slots })
       );
     } else {
-      dispatch(bulkClearQuery({ slots }));
+      dispatch(clearQueries({ slots }));
     }
     handleClose();
   };

--- a/frontend/src/features/export/exportDecklist.test.tsx
+++ b/frontend/src/features/export/exportDecklist.test.tsx
@@ -7,7 +7,6 @@ import {
   cardDocument2,
   cardDocument5,
   cardDocument6,
-  localBackend,
 } from "@/common/test-constants";
 import {
   downloadDecklist,
@@ -40,7 +39,6 @@ test("the decklist representation of a simple project with no custom backs", asy
   );
   renderWithProviders(<App />, {
     preloadedState: {
-      backend: localBackend,
       project: {
         members: [],
         cardback: cardDocument5.identifier,
@@ -76,7 +74,6 @@ test("the decklist representation of a simple project with a custom back for one
   );
   renderWithProviders(<App />, {
     preloadedState: {
-      backend: localBackend,
       project: {
         members: [],
         cardback: cardDocument5.identifier,
@@ -113,7 +110,6 @@ test("the decklist representation of a simple project with multiple instances of
   );
   renderWithProviders(<App />, {
     preloadedState: {
-      backend: localBackend,
       project: {
         members: [],
         cardback: cardDocument5.identifier,

--- a/frontend/src/features/export/exportXML.test.tsx
+++ b/frontend/src/features/export/exportXML.test.tsx
@@ -7,7 +7,6 @@ import {
   cardDocument2,
   cardDocument5,
   cardDocument6,
-  localBackend,
 } from "@/common/test-constants";
 import {
   downloadXML,
@@ -40,7 +39,6 @@ test("the XML representation of a simple project with no custom backs", async ()
   );
   renderWithProviders(<App />, {
     preloadedState: {
-      backend: localBackend,
       project: {
         members: [],
         cardback: cardDocument5.identifier,
@@ -96,7 +94,6 @@ test("the XML representation of a simple project with a custom back for one card
   );
   renderWithProviders(<App />, {
     preloadedState: {
-      backend: localBackend,
       project: {
         members: [],
         cardback: cardDocument5.identifier,
@@ -161,7 +158,6 @@ test("the XML representation of a simple project with multiple instances of a ca
   );
   renderWithProviders(<App />, {
     preloadedState: {
-      backend: localBackend,
       project: {
         members: [],
         cardback: cardDocument5.identifier,

--- a/frontend/src/features/gridSelector/gridSelectorModal.test.tsx
+++ b/frontend/src/features/gridSelector/gridSelectorModal.test.tsx
@@ -3,7 +3,6 @@ import { waitFor, within } from "@testing-library/react";
 import App from "@/app/app";
 import { Front } from "@/common/constants";
 import {
-  localBackend,
   projectSelectedImage1,
   sourceDocument1,
 } from "@/common/test-constants";
@@ -29,7 +28,6 @@ test("toggling between faceting cards by source vs grouped together works as exp
 
   renderWithProviders(<App />, {
     preloadedState: {
-      backend: localBackend,
       project: projectSelectedImage1,
     },
   });
@@ -59,7 +57,6 @@ test("collapsing a source in the faceted view then expanding it works as expecte
 
   renderWithProviders(<App />, {
     preloadedState: {
-      backend: localBackend,
       project: projectSelectedImage1,
     },
   });
@@ -100,7 +97,6 @@ test("collapsing and expanding all sources works as expected", async () => {
 
   renderWithProviders(<App />, {
     preloadedState: {
-      backend: localBackend,
       project: projectSelectedImage1,
     },
   });

--- a/frontend/src/features/import/importCSV.test.tsx
+++ b/frontend/src/features/import/importCSV.test.tsx
@@ -9,7 +9,6 @@ import {
   cardDocument4,
   cardDocument5,
   cardDocument6,
-  localBackend,
 } from "@/common/test-constants";
 import {
   expectCardbackSlotState,
@@ -34,7 +33,6 @@ import {
 import { server } from "@/mocks/server";
 
 const preloadedState = {
-  backend: localBackend,
   project: {
     members: [],
     cardback: cardDocument2.identifier,

--- a/frontend/src/features/import/importText.test.tsx
+++ b/frontend/src/features/import/importText.test.tsx
@@ -2,7 +2,7 @@ import { within } from "@testing-library/dom";
 import { screen, waitFor } from "@testing-library/react";
 
 import App from "@/app/app";
-import { Back, Card, Front } from "@/common/constants";
+import { Back, Card, Front, SelectedImageSeparator } from "@/common/constants";
 import {
   cardDocument1,
   cardDocument2,
@@ -174,23 +174,15 @@ test("importing multiple instances of one card by text into a non-empty project"
   renderWithProviders(<App />, {
     preloadedState: {
       ...preloadedState,
-      project: {
-        members: [
-          {
-            front: {
-              query: { query: "my search query", card_type: Card },
-              selectedImage: cardDocument1.identifier,
-              selected: false,
-            },
-            back: null,
-          },
-        ],
-        cardback: cardDocument2.identifier,
-      },
+      project: { members: [], cardback: cardDocument2.identifier },
     },
   });
 
-  // this slot should already exist from our preloaded state
+  // this used to preload the redux state, but with the shift to listeners,
+  // we have to add the first card manually like this.
+  await importText(
+    `1x my search query${SelectedImageSeparator}${cardDocument1.identifier}`
+  );
   await expectCardSlotToExist(1);
   await expectCardGridSlotState(1, Front, cardDocument1.name, 1, 1);
   await expectCardGridSlotState(1, Back, cardDocument2.name, 1, 2);

--- a/frontend/src/features/import/importText.test.tsx
+++ b/frontend/src/features/import/importText.test.tsx
@@ -10,7 +10,6 @@ import {
   cardDocument4,
   cardDocument5,
   cardDocument6,
-  localBackend,
 } from "@/common/test-constants";
 import {
   expectCardbackSlotState,
@@ -51,7 +50,6 @@ afterEach(() => {
 //# endregion
 
 const preloadedState = {
-  backend: localBackend,
   project: {
     members: [],
     cardback: cardDocument2.identifier,

--- a/frontend/src/features/import/importXML.test.tsx
+++ b/frontend/src/features/import/importXML.test.tsx
@@ -9,7 +9,6 @@ import {
   cardDocument4,
   cardDocument5,
   cardDocument6,
-  localBackend,
 } from "@/common/test-constants";
 import {
   expectCardbackSlotState,
@@ -34,7 +33,6 @@ import {
 import { server } from "@/mocks/server";
 
 const preloadedState = {
-  backend: localBackend,
   project: {
     members: [],
     cardback: cardDocument2.identifier,

--- a/frontend/src/features/import/importXML.test.tsx
+++ b/frontend/src/features/import/importXML.test.tsx
@@ -1,7 +1,13 @@
 import { screen } from "@testing-library/react";
 
 import App from "@/app/app";
-import { Back, Card, Front, S30 } from "@/common/constants";
+import {
+  Back,
+  Card,
+  Front,
+  S30,
+  SelectedImageSeparator,
+} from "@/common/constants";
 import {
   cardDocument1,
   cardDocument2,
@@ -14,6 +20,7 @@ import {
   expectCardbackSlotState,
   expectCardGridSlotState,
   expectCardSlotToExist,
+  importText,
   importXML,
   openImportXMLModal,
   renderWithProviders,
@@ -365,22 +372,17 @@ test("importing a more complex XML into a non-empty project", async () => {
     preloadedState: {
       ...preloadedState,
       project: {
-        members: [
-          {
-            front: {
-              query: { query: "my search query", card_type: Card },
-              selectedImage: cardDocument1.identifier,
-              selected: false,
-            },
-            back: null,
-          },
-        ],
+        members: [],
         cardback: cardDocument2.identifier,
       },
     },
   });
 
-  // this slot should already exist from our preloaded state
+  // this used to preload the redux state, but with the shift to listeners,
+  // we have to add the first card manually like this.
+  await importText(
+    `1x my search query${SelectedImageSeparator}${cardDocument1.identifier}`
+  );
   await expectCardSlotToExist(1);
   await expectCardGridSlotState(1, Front, cardDocument1.name, 1, 4);
   await expectCardGridSlotState(1, Back, cardDocument2.name, 1, 2);

--- a/frontend/src/features/invalidIdentifiers/invalidIdentifiersModal.test.tsx
+++ b/frontend/src/features/invalidIdentifiers/invalidIdentifiersModal.test.tsx
@@ -3,13 +3,12 @@ import { screen } from "@testing-library/react";
 
 import App from "@/app/app";
 import { FaceSeparator, SelectedImageSeparator } from "@/common/constants";
-import { cardDocument5, localBackend } from "@/common/test-constants";
+import { cardDocument5 } from "@/common/test-constants";
 import {
   expectCardSlotToExist,
   importText,
   renderWithProviders,
 } from "@/common/test-utils";
-import { LayoutWithoutProvider } from "@/features/ui/layout";
 import {
   cardDocumentsSixResults,
   defaultHandlers,
@@ -25,20 +24,14 @@ test("invalidIdentifiersModal displays the appropriate data", async () => {
     searchResultsSixResults,
     ...defaultHandlers
   );
-  renderWithProviders(
-    <LayoutWithoutProvider>
-      <App />
-    </LayoutWithoutProvider>,
-    {
-      preloadedState: {
-        backend: localBackend,
-        project: {
-          members: [],
-          cardback: cardDocument5.identifier,
-        },
+  renderWithProviders(<App />, {
+    preloadedState: {
+      project: {
+        members: [],
+        cardback: cardDocument5.identifier,
       },
-    }
-  );
+    },
+  });
   await importText(
     `2x query 1${SelectedImageSeparator}123\n1 query 2${FaceSeparator}query 3${SelectedImageSeparator}456`
   );

--- a/frontend/src/features/invalidIdentifiers/invalidIdentifiersStatus.test.tsx
+++ b/frontend/src/features/invalidIdentifiers/invalidIdentifiersStatus.test.tsx
@@ -3,18 +3,13 @@ import { screen } from "@testing-library/react";
 
 import App from "@/app/app";
 import { Front, SelectedImageSeparator } from "@/common/constants";
-import {
-  cardDocument1,
-  cardDocument5,
-  localBackend,
-} from "@/common/test-constants";
+import { cardDocument1, cardDocument5 } from "@/common/test-constants";
 import {
   expectCardGridSlotState,
   expectCardSlotToExist,
   importText,
   renderWithProviders,
 } from "@/common/test-utils";
-import { LayoutWithoutProvider } from "@/features/ui/layout";
 import {
   cardDocumentsOneResult,
   defaultHandlers,
@@ -45,20 +40,14 @@ test.each([
       searchResultsOneResult,
       ...defaultHandlers
     );
-    renderWithProviders(
-      <LayoutWithoutProvider>
-        <App />
-      </LayoutWithoutProvider>,
-      {
-        preloadedState: {
-          backend: localBackend,
-          project: {
-            members: [],
-            cardback: cardDocument5.identifier,
-          },
+    renderWithProviders(<App />, {
+      preloadedState: {
+        project: {
+          members: [],
+          cardback: cardDocument5.identifier,
         },
-      }
-    );
+      },
+    });
     await importText(query);
     await expectCardSlotToExist(1);
     await expectCardGridSlotState(

--- a/frontend/src/features/new/__snapshots__/new.test.tsx.snap
+++ b/frontend/src/features/new/__snapshots__/new.test.tsx.snap
@@ -1,15 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`the html structure of the new cards page with no data 1`] = `
-<body>
-  <div>
-    <p>
-      Looks like nothing was added to 
-      Test Site
-       in the last two weeks. :(
-    </p>
-  </div>
-</body>
+<div>
+  <p>
+    Looks like nothing was added to 
+    Test Site
+     in the last two weeks. :(
+  </p>
+</div>
 `;
 
 exports[`the html structure of the new cards page with two sources, each with result/s 1`] = `
@@ -36,214 +34,212 @@ exports[`the html structure of the new cards page with two sources, each with re
   display: inline;
 }
 
-<body>
-  <div>
-    <p>
-      Check out the new cards added to 
-      Test Site
-       in the last two weeks.
-    </p>
-    <h3
-      class="c0 orpheus"
-    >
-      <em>
-        Source 1
-      </em>
-    </h3>
-       
-    <p
-      class="c1 text-primary"
-    >
-      4
-       new card
-      s
-    </p>
+<div>
+  <p>
+    Check out the new cards added to 
+    Test Site
+     in the last two weeks.
+  </p>
+  <h3
+    class="c0 orpheus"
+  >
+    <em>
+      Source 1
+    </em>
+  </h3>
+     
+  <p
+    class="c1 text-primary"
+  >
+    4
+     new card
+    s
+  </p>
+  <div
+    class="g-0 row row-cols-xxl-6 row-cols-lg-4 row-cols-md-3 row-cols-sm-2 row-cols-2"
+  >
     <div
-      class="g-0 row row-cols-xxl-6 row-cols-lg-4 row-cols-md-3 row-cols-sm-2 row-cols-2"
+      class="col"
     >
       <div
-        class="col"
+        class="mpccard mpccard-hover card"
       >
         <div
-          class="mpccard mpccard-hover card"
+          class="pb-0 text-center card-header"
         >
-          <div
-            class="pb-0 text-center card-header"
+          <p
+            class="mpccard-slot"
           >
-            <p
-              class="mpccard-slot"
-            >
-              1st January, 2000
-            </p>
-          </div>
-          <div>
-            <div
-              class="c2 rounded-lg shadow-lg ratio ratio-7x5"
-            >
-              <img
-                alt="Card 1"
-                class="c3 card-img card-img-fade-in"
-                data-nimg="fill"
-                decoding="async"
-                loading="lazy"
-                src=""
-                style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
-              />
-            </div>
-            <div
-              class="mb-0 text-center card-body"
-            >
-              <div
-                class="mpccard-name card-subtitle h6"
-              >
-                Card 1
-              </div>
-              <div
-                class="mpccard-spacing"
-              >
-                <p
-                  class="mpccard-source card-text"
-                >
-                  Source 1 [1200 DPI]
-                </p>
-              </div>
-            </div>
-          </div>
+            1st January, 2000
+          </p>
         </div>
-      </div>
-      <div
-        class="col"
-      >
-        <div
-          class="mpccard mpccard-hover card"
-        >
+        <div>
           <div
-            class="pb-0 text-center card-header"
+            class="c2 rounded-lg shadow-lg ratio ratio-7x5"
           >
-            <p
-              class="mpccard-slot"
-            >
-              1st January, 2000
-            </p>
+            <img
+              alt="Card 1"
+              class="c3 card-img card-img-fade-in"
+              data-nimg="fill"
+              decoding="async"
+              loading="lazy"
+              src=""
+              style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+            />
           </div>
-          <div>
+          <div
+            class="mb-0 text-center card-body"
+          >
             <div
-              class="c2 rounded-lg shadow-lg ratio ratio-7x5"
+              class="mpccard-name card-subtitle h6"
             >
-              <img
-                alt="Card 2"
-                class="c3 card-img card-img-fade-in"
-                data-nimg="fill"
-                decoding="async"
-                loading="lazy"
-                src=""
-                style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
-              />
+              Card 1
             </div>
             <div
-              class="mb-0 text-center card-body"
+              class="mpccard-spacing"
             >
-              <div
-                class="mpccard-name card-subtitle h6"
+              <p
+                class="mpccard-source card-text"
               >
-                Card 2
-              </div>
-              <div
-                class="mpccard-spacing"
-              >
-                <p
-                  class="mpccard-source card-text"
-                >
-                  Source 1 [1200 DPI]
-                </p>
-              </div>
+                Source 1 [1200 DPI]
+              </p>
             </div>
           </div>
         </div>
       </div>
     </div>
-    <br />
     <div
-      class="d-grid gap-0 mx-auto"
-      style="max-width: 20%;"
-    >
-      <button
-        class="btn btn-primary"
-        type="button"
-      >
-        Load More
-      </button>
-    </div>
-    <hr />
-    <h3
-      class="c0 orpheus"
-    >
-      <em>
-        Source 2
-      </em>
-    </h3>
-       
-    <p
-      class="c1 text-primary"
-    >
-      1
-       new card
-    </p>
-    <div
-      class="g-0 row row-cols-xxl-6 row-cols-lg-4 row-cols-md-3 row-cols-sm-2 row-cols-2"
+      class="col"
     >
       <div
-        class="col"
+        class="mpccard mpccard-hover card"
       >
         <div
-          class="mpccard mpccard-hover card"
+          class="pb-0 text-center card-header"
         >
-          <div
-            class="pb-0 text-center card-header"
+          <p
+            class="mpccard-slot"
           >
-            <p
-              class="mpccard-slot"
-            >
-              1st January, 2000
-            </p>
+            1st January, 2000
+          </p>
+        </div>
+        <div>
+          <div
+            class="c2 rounded-lg shadow-lg ratio ratio-7x5"
+          >
+            <img
+              alt="Card 2"
+              class="c3 card-img card-img-fade-in"
+              data-nimg="fill"
+              decoding="async"
+              loading="lazy"
+              src=""
+              style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+            />
           </div>
-          <div>
+          <div
+            class="mb-0 text-center card-body"
+          >
             <div
-              class="c2 rounded-lg shadow-lg ratio ratio-7x5"
+              class="mpccard-name card-subtitle h6"
             >
-              <img
-                alt="Card 5"
-                class="c3 card-img card-img-fade-in"
-                data-nimg="fill"
-                decoding="async"
-                loading="lazy"
-                src=""
-                style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
-              />
+              Card 2
             </div>
             <div
-              class="mb-0 text-center card-body"
+              class="mpccard-spacing"
             >
-              <div
-                class="mpccard-name card-subtitle h6"
+              <p
+                class="mpccard-source card-text"
               >
-                Card 5
-              </div>
-              <div
-                class="mpccard-spacing"
-              >
-                <p
-                  class="mpccard-source card-text"
-                >
-                  Source 2 Cardbacks [1200 DPI]
-                </p>
-              </div>
+                Source 1 [1200 DPI]
+              </p>
             </div>
           </div>
         </div>
       </div>
     </div>
-    <br />
   </div>
-</body>
+  <br />
+  <div
+    class="d-grid gap-0 mx-auto"
+    style="max-width: 20%;"
+  >
+    <button
+      class="btn btn-primary"
+      type="button"
+    >
+      Load More
+    </button>
+  </div>
+  <hr />
+  <h3
+    class="c0 orpheus"
+  >
+    <em>
+      Source 2
+    </em>
+  </h3>
+     
+  <p
+    class="c1 text-primary"
+  >
+    1
+     new card
+  </p>
+  <div
+    class="g-0 row row-cols-xxl-6 row-cols-lg-4 row-cols-md-3 row-cols-sm-2 row-cols-2"
+  >
+    <div
+      class="col"
+    >
+      <div
+        class="mpccard mpccard-hover card"
+      >
+        <div
+          class="pb-0 text-center card-header"
+        >
+          <p
+            class="mpccard-slot"
+          >
+            1st January, 2000
+          </p>
+        </div>
+        <div>
+          <div
+            class="c2 rounded-lg shadow-lg ratio ratio-7x5"
+          >
+            <img
+              alt="Card 5"
+              class="c3 card-img card-img-fade-in"
+              data-nimg="fill"
+              decoding="async"
+              loading="lazy"
+              src=""
+              style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+            />
+          </div>
+          <div
+            class="mb-0 text-center card-body"
+          >
+            <div
+              class="mpccard-name card-subtitle h6"
+            >
+              Card 5
+            </div>
+            <div
+              class="mpccard-spacing"
+            >
+              <p
+                class="mpccard-source card-text"
+              >
+                Source 2 Cardbacks [1200 DPI]
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <br />
+</div>
 `;

--- a/frontend/src/features/new/new.test.tsx
+++ b/frontend/src/features/new/new.test.tsx
@@ -5,7 +5,6 @@ import {
   cardDocument2,
   cardDocument3,
   cardDocument4,
-  localBackend,
   sourceDocument1,
 } from "@/common/test-constants";
 import { renderWithProviders } from "@/common/test-utils";
@@ -20,24 +19,24 @@ import { server } from "@/mocks/server";
 
 test("the html structure of the new cards page with two sources, each with result/s", async () => {
   server.use(newCardsFirstPageWithTwoSources, ...defaultHandlers);
-  const rendered = renderWithProviders(<NewCards />, {
-    preloadedState: { backend: localBackend },
-  });
+  const rendered = renderWithProviders(<NewCards />);
   await waitFor(() =>
     expect(screen.getByText(sourceDocument1.name)).toBeInTheDocument()
   );
-  expect(rendered.baseElement).toMatchSnapshot();
+  expect(
+    screen.getByText("Check out the new cards", { exact: false }).parentElement!
+  ).toMatchSnapshot();
 });
 
 test("the html structure of the new cards page with no data", async () => {
   server.use(newCardsFirstPageNoResults, ...defaultHandlers);
-  const rendered = renderWithProviders(<NewCards />, {
-    preloadedState: { backend: localBackend },
-  });
+  const rendered = renderWithProviders(<NewCards />);
   await waitFor(() =>
     expect(screen.getByText(":(", { exact: false })).toBeInTheDocument()
   );
-  expect(rendered.baseElement).toMatchSnapshot();
+  expect(
+    screen.getByText(":(", { exact: false }).parentElement!
+  ).toMatchSnapshot();
 });
 
 test("clicking to show another page of results in the new cards page", async () => {
@@ -46,9 +45,7 @@ test("clicking to show another page of results in the new cards page", async () 
     newCardsPageForSource1,
     ...defaultHandlers
   );
-  renderWithProviders(<NewCards />, {
-    preloadedState: { backend: localBackend },
-  });
+  renderWithProviders(<NewCards />);
   await waitFor(() =>
     expect(screen.getByText(sourceDocument1.name)).toBeInTheDocument()
   );

--- a/frontend/src/features/new/new.tsx
+++ b/frontend/src/features/new/new.tsx
@@ -99,7 +99,7 @@ export function NewCards() {
   return getNewCardsQuery.isFetching || getNewCardsQuery.data == null ? (
     <Spinner />
   ) : (
-    <>
+    <div>
       {Object.keys(getNewCardsQuery.data).length > 0 ? (
         <>
           <p>
@@ -125,6 +125,6 @@ export function NewCards() {
           :(
         </p>
       )}
-    </>
+    </div>
   );
 }

--- a/frontend/src/features/project/projectSlice.ts
+++ b/frontend/src/features/project/projectSlice.ts
@@ -24,29 +24,6 @@ export const projectSlice = createSlice({
   name: "project",
   initialState,
   reducers: {
-    setSelectedImage: (
-      state,
-      action: PayloadAction<{
-        face: Faces;
-        slot: number;
-        selectedImage?: string;
-      }>
-    ) => {
-      // TODO: this is a bit awkward
-      if (state.members[action.payload.slot][action.payload.face] == null) {
-        state.members[action.payload.slot][action.payload.face] = {
-          query: {
-            query: null,
-            card_type: Card,
-          },
-          selectedImage: action.payload.selectedImage,
-          selected: false,
-        };
-      } else {
-        state.members[action.payload.slot][action.payload.face]!.selectedImage =
-          action.payload.selectedImage;
-      }
-    },
     bulkReplaceSelectedImage: (
       state,
       action: PayloadAction<{
@@ -86,10 +63,10 @@ export const projectSlice = createSlice({
         }
       }
     },
-    bulkSetSelectedImage: (
+    setSelectedImages: (
       state,
       action: PayloadAction<{
-        selectedImage: string;
+        selectedImage: string | undefined;
         slots: Array<[Faces, number]>;
       }>
     ) => {
@@ -107,23 +84,7 @@ export const projectSlice = createSlice({
         }
       }
     },
-    setQuery: (
-      state,
-      action: PayloadAction<{ query: string; face: Faces; slot: number }>
-    ) => {
-      const newQuery = processPrefix(action.payload.query);
-      if (state.members[action.payload.slot][action.payload.face] == null) {
-        state.members[action.payload.slot][action.payload.face] = {
-          query: newQuery,
-          selectedImage: undefined,
-          selected: false,
-        };
-      } else {
-        state.members[action.payload.slot][action.payload.face]!.query =
-          newQuery;
-      }
-    },
-    bulkSetQuery: (
+    setQueries: (
       state,
       action: PayloadAction<{ query: string; slots: Array<[Faces, number]> }>
     ) => {
@@ -141,27 +102,18 @@ export const projectSlice = createSlice({
         }
       }
     },
-    clearQuery: (
-      state,
-      action: PayloadAction<{ face: Faces; slot: number }>
-    ) => {
-      state.members[action.payload.slot][action.payload.face] = {
-        query: {
-          query: null,
-          card_type: action.payload.face === Back ? Cardback : Card,
-        },
-        selectedImage: undefined,
-        selected: false,
-      };
-    },
-    bulkClearQuery: (
+    clearQueries: (
       state,
       action: PayloadAction<{ slots: Array<[Faces, number]> }>
     ) => {
+      const projectCardback = state.cardback;
       for (const [face, slot] of action.payload.slots) {
         state.members[slot][face] = {
           query: { query: null, card_type: face === Back ? Cardback : Card },
-          selectedImage: undefined,
+          selectedImage:
+            face === Back && projectCardback != null
+              ? projectCardback
+              : undefined,
           selected: false,
         };
       }
@@ -246,13 +198,7 @@ export const projectSlice = createSlice({
         }
       }
     },
-    deleteSlot: (state, action: PayloadAction<{ slot: number }>) => {
-      state.members.splice(action.payload.slot, 1);
-    },
-    bulkDeleteSlots: (
-      state,
-      action: PayloadAction<{ slots: Array<number> }>
-    ) => {
+    deleteSlots: (state, action: PayloadAction<{ slots: Array<number> }>) => {
       action.payload.slots
         .sort(function (a, b) {
           return b - a;
@@ -265,20 +211,16 @@ export const projectSlice = createSlice({
 });
 
 export const {
-  setSelectedImage,
   bulkReplaceSelectedImage,
-  bulkSetSelectedImage,
-  setQuery,
-  bulkSetQuery,
-  clearQuery,
-  bulkClearQuery,
+  setSelectedImages,
+  setQueries,
+  clearQueries,
   setSelectedCardback,
   addMembers,
   toggleMemberSelection,
   bulkSetMemberSelection,
   bulkAlignMemberSelection,
-  deleteSlot,
-  bulkDeleteSlots,
+  deleteSlots,
 } = projectSlice.actions;
 
 export default projectSlice.reducer;

--- a/frontend/src/features/search/searchResultsSlice.ts
+++ b/frontend/src/features/search/searchResultsSlice.ts
@@ -23,7 +23,7 @@ import { setError } from "@/features/toasts/toastsSlice";
 
 const typePrefix = "searchResults/fetchCards";
 
-const fetchSearchResults = createAppAsyncThunk(
+export const fetchSearchResults = createAppAsyncThunk(
   typePrefix,
   async (arg, { getState, rejectWithValue }) => {
     const state = getState();
@@ -118,7 +118,7 @@ export default searchResultsSlice.reducer;
 
 export const selectSearchResultsForQuery = (
   state: RootState,
-  searchQuery: SearchQuery | null | undefined
+  searchQuery: SearchQuery | undefined
 ) =>
   searchQuery?.query != null
     ? (state.searchResults.searchResults[searchQuery.query] ?? {})[
@@ -137,7 +137,7 @@ export const selectSearchResultsForQueryOrDefault = (
    * Handle the fallback logic where cardbacks with no query use the common cardback's list of cards.
    */
 
-  searchQuery?.query != null
+  searchQuery?.query != null && searchQuery.query.length > 0
     ? selectSearchResultsForQuery(state, searchQuery)
     : face === Back
     ? cardbacks

--- a/frontend/src/features/search/sourceDocumentsSlice.ts
+++ b/frontend/src/features/search/sourceDocumentsSlice.ts
@@ -13,7 +13,7 @@ import { setError } from "@/features/toasts/toastsSlice";
 
 const typePrefix = "sourceDocuments/fetchSourceDocuments";
 
-const fetchSourceDocuments = createAppAsyncThunk(
+export const fetchSourceDocuments = createAppAsyncThunk(
   typePrefix,
   async (arg, { getState }) => {
     const state = getState();

--- a/frontend/src/features/searchSettings/searchSettings.test.tsx
+++ b/frontend/src/features/searchSettings/searchSettings.test.tsx
@@ -2,11 +2,7 @@ import { waitFor, within } from "@testing-library/dom";
 
 import App from "@/app/app";
 import { Front } from "@/common/constants";
-import {
-  cardDocument1,
-  localBackend,
-  sourceDocument1,
-} from "@/common/test-constants";
+import { cardDocument1, sourceDocument1 } from "@/common/test-constants";
 import {
   expectCardGridSlotState,
   importText,
@@ -34,7 +30,6 @@ test("the html structure of search settings", async () => {
   );
   const { container } = renderWithProviders(<App />, {
     preloadedState: {
-      backend: localBackend,
       project: { members: [], cardback: null },
     },
   });

--- a/frontend/src/features/searchSettings/searchSettings.tsx
+++ b/frontend/src/features/searchSettings/searchSettings.tsx
@@ -48,18 +48,6 @@ export function SearchSettings() {
   const [localFilterSettings, setLocalFilterSettings] =
     useState<FilterSettings>(globalSearchSettings.filterSettings);
 
-  const maybeSourceDocuments = useAppSelector(selectSourceDocuments);
-
-  useEffect(() => {
-    if (maybeSourceDocuments != null) {
-      const localStorageSettings =
-        getLocalStorageSearchSettings(maybeSourceDocuments);
-      dispatch(setSearchTypeSettings(localStorageSettings.searchTypeSettings));
-      dispatch(setSourceSettings(localStorageSettings.sourceSettings));
-      dispatch(setFilterSettings(localStorageSettings.filterSettings));
-    }
-  }, [dispatch, maybeSourceDocuments]);
-
   // modal management functions
   const handleClose = () => setShow(false);
 

--- a/frontend/src/features/ui/__snapshots__/dynamicLogo.test.tsx.snap
+++ b/frontend/src/features/ui/__snapshots__/dynamicLogo.test.tsx.snap
@@ -109,124 +109,121 @@ exports[`the html structure of the dynamic logo, backend configured 1`] = `
   animation: iZNvIp 1s ease-in-out 0.01s forwards;
 }
 
-<body>
-  <div>
+<div
+  class="justify-content-center row"
+  data-testid="dynamic-logo"
+>
+  <div
+    class="col-xl-6 col-lg-7 col-md-8 col-sm-12 col-12"
+  >
     <div
-      class="justify-content-center row"
+      class="c0"
     >
+      <p
+        class="c1 className"
+      >
+        Test Site
+      </p>
       <div
-        class="col-xl-6 col-lg-7 col-md-8 col-sm-12 col-12"
+        class="c2"
+      >
+        <img
+          alt="logo-arrow"
+          data-nimg="fill"
+          decoding="async"
+          loading="lazy"
+          src="/arrow.svg"
+          style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+        />
+      </div>
+      <div
+        class="c3 c4"
       >
         <div
-          class="c0"
+          class="c5 rounded-lg shadow-lg ratio ratio-7x5"
         >
-          <p
-            class="c1 className"
-          >
-            Test Site
-          </p>
-          <div
-            class="c2"
-          >
-            <img
-              alt="logo-arrow"
-              data-nimg="fill"
-              decoding="async"
-              loading="lazy"
-              src="/arrow.svg"
-              style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
-            />
-          </div>
-          <div
-            class="c3 c4"
-          >
-            <div
-              class="c5 rounded-lg shadow-lg ratio ratio-7x5"
-            >
-              <img
-                alt="Card 6"
-                class="c6 card-img card-img-fade-in"
-                data-nimg="fill"
-                decoding="async"
-                loading="lazy"
-                src=""
-                style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
-              />
-            </div>
-          </div>
-          <div
-            class="c3 c7"
-          >
-            <div
-              class="c5 rounded-lg shadow-lg ratio ratio-7x5"
-            >
-              <img
-                alt="Card 1"
-                class="c6 card-img card-img-fade-in"
-                data-nimg="fill"
-                decoding="async"
-                loading="lazy"
-                src=""
-                style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
-              />
-            </div>
-          </div>
-          <div
-            class="c3 c8"
-          >
-            <div
-              class="c5 rounded-lg shadow-lg ratio ratio-7x5"
-            >
-              <img
-                alt="Card 2"
-                class="c6 card-img card-img-fade-in"
-                data-nimg="fill"
-                decoding="async"
-                loading="lazy"
-                src=""
-                style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
-              />
-            </div>
-          </div>
-          <div
-            class="c3 c9"
-          >
-            <div
-              class="c5 rounded-lg shadow-lg ratio ratio-7x5"
-            >
-              <img
-                alt="Card 3"
-                class="c6 card-img card-img-fade-in"
-                data-nimg="fill"
-                decoding="async"
-                loading="lazy"
-                src=""
-                style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
-              />
-            </div>
-          </div>
-          <div
-            class="c3 c10"
-          >
-            <div
-              class="c5 rounded-lg shadow-lg ratio ratio-7x5"
-            >
-              <img
-                alt="Card 4"
-                class="c6 card-img card-img-fade-in"
-                data-nimg="fill"
-                decoding="async"
-                loading="lazy"
-                src=""
-                style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
-              />
-            </div>
-          </div>
+          <img
+            alt="Card 6"
+            class="c6 card-img card-img-fade-in"
+            data-nimg="fill"
+            decoding="async"
+            loading="lazy"
+            src=""
+            style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+          />
+        </div>
+      </div>
+      <div
+        class="c3 c7"
+      >
+        <div
+          class="c5 rounded-lg shadow-lg ratio ratio-7x5"
+        >
+          <img
+            alt="Card 1"
+            class="c6 card-img card-img-fade-in"
+            data-nimg="fill"
+            decoding="async"
+            loading="lazy"
+            src=""
+            style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+          />
+        </div>
+      </div>
+      <div
+        class="c3 c8"
+      >
+        <div
+          class="c5 rounded-lg shadow-lg ratio ratio-7x5"
+        >
+          <img
+            alt="Card 2"
+            class="c6 card-img card-img-fade-in"
+            data-nimg="fill"
+            decoding="async"
+            loading="lazy"
+            src=""
+            style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+          />
+        </div>
+      </div>
+      <div
+        class="c3 c9"
+      >
+        <div
+          class="c5 rounded-lg shadow-lg ratio ratio-7x5"
+        >
+          <img
+            alt="Card 3"
+            class="c6 card-img card-img-fade-in"
+            data-nimg="fill"
+            decoding="async"
+            loading="lazy"
+            src=""
+            style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+          />
+        </div>
+      </div>
+      <div
+        class="c3 c10"
+      >
+        <div
+          class="c5 rounded-lg shadow-lg ratio ratio-7x5"
+        >
+          <img
+            alt="Card 4"
+            class="c6 card-img card-img-fade-in"
+            data-nimg="fill"
+            decoding="async"
+            loading="lazy"
+            src=""
+            style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+          />
         </div>
       </div>
     </div>
   </div>
-</body>
+</div>
 `;
 
 exports[`the html structure of the dynamic logo, no backend configured 1`] = `
@@ -344,207 +341,204 @@ exports[`the html structure of the dynamic logo, no backend configured 1`] = `
   animation: iZNvIp 1s ease-in-out 0.01s forwards;
 }
 
-<body>
-  <div>
+<div
+  class="justify-content-center row"
+  data-testid="dynamic-logo"
+>
+  <div
+    class="col-xl-6 col-lg-7 col-md-8 col-sm-12 col-12"
+  >
     <div
-      class="justify-content-center row"
+      class="c0"
     >
+      <p
+        class="c1 className"
+      >
+        MPC Autofill
+      </p>
       <div
-        class="col-xl-6 col-lg-7 col-md-8 col-sm-12 col-12"
+        class="c2"
+      >
+        <img
+          alt="logo-arrow"
+          data-nimg="fill"
+          decoding="async"
+          loading="lazy"
+          src="/arrow.svg"
+          style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+        />
+      </div>
+      <div
+        class="c3 c4"
       >
         <div
-          class="c0"
+          class="c5 rounded-lg shadow-lg ratio ratio-7x5"
         >
-          <p
-            class="c1 className"
-          >
-            MPC Autofill
-          </p>
           <div
-            class="c2"
-          >
-            <img
-              alt="logo-arrow"
-              data-nimg="fill"
-              decoding="async"
-              loading="lazy"
-              src="/arrow.svg"
-              style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
-            />
-          </div>
-          <div
-            class="c3 c4"
+            class="d-flex justify-content-center align-items-center"
           >
             <div
-              class="c5 rounded-lg shadow-lg ratio ratio-7x5"
+              class="c6 spinner-border"
+              role="status"
+              size="4"
             >
-              <div
-                class="d-flex justify-content-center align-items-center"
+              <span
+                class="visually-hidden"
               >
-                <div
-                  class="c6 spinner-border"
-                  role="status"
-                  size="4"
-                >
-                  <span
-                    class="visually-hidden"
-                  >
-                    Loading...
-                  </span>
-                </div>
-              </div>
-              <img
-                alt="Your Design Here"
-                class="c7 card-img card-img-fade-in"
-                data-nimg="fill"
-                decoding="async"
-                loading="lazy"
-                sizes="100vw"
-                src="/_next/image?url=%2Flogo-blank.png&w=3840&q=75"
-                srcset="/_next/image?url=%2Flogo-blank.png&w=640&q=75 640w, /_next/image?url=%2Flogo-blank.png&w=750&q=75 750w, /_next/image?url=%2Flogo-blank.png&w=828&q=75 828w, /_next/image?url=%2Flogo-blank.png&w=1080&q=75 1080w, /_next/image?url=%2Flogo-blank.png&w=1200&q=75 1200w, /_next/image?url=%2Flogo-blank.png&w=1920&q=75 1920w, /_next/image?url=%2Flogo-blank.png&w=2048&q=75 2048w, /_next/image?url=%2Flogo-blank.png&w=3840&q=75 3840w"
-                style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
-              />
+                Loading...
+              </span>
             </div>
           </div>
+          <img
+            alt="Your Design Here"
+            class="c7 card-img card-img-fade-in"
+            data-nimg="fill"
+            decoding="async"
+            loading="lazy"
+            sizes="100vw"
+            src="/_next/image?url=%2Flogo-blank.png&w=3840&q=75"
+            srcset="/_next/image?url=%2Flogo-blank.png&w=640&q=75 640w, /_next/image?url=%2Flogo-blank.png&w=750&q=75 750w, /_next/image?url=%2Flogo-blank.png&w=828&q=75 828w, /_next/image?url=%2Flogo-blank.png&w=1080&q=75 1080w, /_next/image?url=%2Flogo-blank.png&w=1200&q=75 1200w, /_next/image?url=%2Flogo-blank.png&w=1920&q=75 1920w, /_next/image?url=%2Flogo-blank.png&w=2048&q=75 2048w, /_next/image?url=%2Flogo-blank.png&w=3840&q=75 3840w"
+            style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+          />
+        </div>
+      </div>
+      <div
+        class="c3 c8"
+      >
+        <div
+          class="c5 rounded-lg shadow-lg ratio ratio-7x5"
+        >
           <div
-            class="c3 c8"
+            class="d-flex justify-content-center align-items-center"
           >
             <div
-              class="c5 rounded-lg shadow-lg ratio ratio-7x5"
+              class="c6 spinner-border"
+              role="status"
+              size="4"
             >
-              <div
-                class="d-flex justify-content-center align-items-center"
+              <span
+                class="visually-hidden"
               >
-                <div
-                  class="c6 spinner-border"
-                  role="status"
-                  size="4"
-                >
-                  <span
-                    class="visually-hidden"
-                  >
-                    Loading...
-                  </span>
-                </div>
-              </div>
-              <img
-                alt="Your Design Here"
-                class="c7 card-img card-img-fade-in"
-                data-nimg="fill"
-                decoding="async"
-                loading="lazy"
-                sizes="100vw"
-                src="/_next/image?url=%2Flogo-blank.png&w=3840&q=75"
-                srcset="/_next/image?url=%2Flogo-blank.png&w=640&q=75 640w, /_next/image?url=%2Flogo-blank.png&w=750&q=75 750w, /_next/image?url=%2Flogo-blank.png&w=828&q=75 828w, /_next/image?url=%2Flogo-blank.png&w=1080&q=75 1080w, /_next/image?url=%2Flogo-blank.png&w=1200&q=75 1200w, /_next/image?url=%2Flogo-blank.png&w=1920&q=75 1920w, /_next/image?url=%2Flogo-blank.png&w=2048&q=75 2048w, /_next/image?url=%2Flogo-blank.png&w=3840&q=75 3840w"
-                style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
-              />
+                Loading...
+              </span>
             </div>
           </div>
+          <img
+            alt="Your Design Here"
+            class="c7 card-img card-img-fade-in"
+            data-nimg="fill"
+            decoding="async"
+            loading="lazy"
+            sizes="100vw"
+            src="/_next/image?url=%2Flogo-blank.png&w=3840&q=75"
+            srcset="/_next/image?url=%2Flogo-blank.png&w=640&q=75 640w, /_next/image?url=%2Flogo-blank.png&w=750&q=75 750w, /_next/image?url=%2Flogo-blank.png&w=828&q=75 828w, /_next/image?url=%2Flogo-blank.png&w=1080&q=75 1080w, /_next/image?url=%2Flogo-blank.png&w=1200&q=75 1200w, /_next/image?url=%2Flogo-blank.png&w=1920&q=75 1920w, /_next/image?url=%2Flogo-blank.png&w=2048&q=75 2048w, /_next/image?url=%2Flogo-blank.png&w=3840&q=75 3840w"
+            style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+          />
+        </div>
+      </div>
+      <div
+        class="c3 c9"
+      >
+        <div
+          class="c5 rounded-lg shadow-lg ratio ratio-7x5"
+        >
           <div
-            class="c3 c9"
+            class="d-flex justify-content-center align-items-center"
           >
             <div
-              class="c5 rounded-lg shadow-lg ratio ratio-7x5"
+              class="c6 spinner-border"
+              role="status"
+              size="4"
             >
-              <div
-                class="d-flex justify-content-center align-items-center"
+              <span
+                class="visually-hidden"
               >
-                <div
-                  class="c6 spinner-border"
-                  role="status"
-                  size="4"
-                >
-                  <span
-                    class="visually-hidden"
-                  >
-                    Loading...
-                  </span>
-                </div>
-              </div>
-              <img
-                alt="Your Design Here"
-                class="c7 card-img card-img-fade-in"
-                data-nimg="fill"
-                decoding="async"
-                loading="lazy"
-                sizes="100vw"
-                src="/_next/image?url=%2Flogo-blank.png&w=3840&q=75"
-                srcset="/_next/image?url=%2Flogo-blank.png&w=640&q=75 640w, /_next/image?url=%2Flogo-blank.png&w=750&q=75 750w, /_next/image?url=%2Flogo-blank.png&w=828&q=75 828w, /_next/image?url=%2Flogo-blank.png&w=1080&q=75 1080w, /_next/image?url=%2Flogo-blank.png&w=1200&q=75 1200w, /_next/image?url=%2Flogo-blank.png&w=1920&q=75 1920w, /_next/image?url=%2Flogo-blank.png&w=2048&q=75 2048w, /_next/image?url=%2Flogo-blank.png&w=3840&q=75 3840w"
-                style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
-              />
+                Loading...
+              </span>
             </div>
           </div>
+          <img
+            alt="Your Design Here"
+            class="c7 card-img card-img-fade-in"
+            data-nimg="fill"
+            decoding="async"
+            loading="lazy"
+            sizes="100vw"
+            src="/_next/image?url=%2Flogo-blank.png&w=3840&q=75"
+            srcset="/_next/image?url=%2Flogo-blank.png&w=640&q=75 640w, /_next/image?url=%2Flogo-blank.png&w=750&q=75 750w, /_next/image?url=%2Flogo-blank.png&w=828&q=75 828w, /_next/image?url=%2Flogo-blank.png&w=1080&q=75 1080w, /_next/image?url=%2Flogo-blank.png&w=1200&q=75 1200w, /_next/image?url=%2Flogo-blank.png&w=1920&q=75 1920w, /_next/image?url=%2Flogo-blank.png&w=2048&q=75 2048w, /_next/image?url=%2Flogo-blank.png&w=3840&q=75 3840w"
+            style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+          />
+        </div>
+      </div>
+      <div
+        class="c3 c10"
+      >
+        <div
+          class="c5 rounded-lg shadow-lg ratio ratio-7x5"
+        >
           <div
-            class="c3 c10"
+            class="d-flex justify-content-center align-items-center"
           >
             <div
-              class="c5 rounded-lg shadow-lg ratio ratio-7x5"
+              class="c6 spinner-border"
+              role="status"
+              size="4"
             >
-              <div
-                class="d-flex justify-content-center align-items-center"
+              <span
+                class="visually-hidden"
               >
-                <div
-                  class="c6 spinner-border"
-                  role="status"
-                  size="4"
-                >
-                  <span
-                    class="visually-hidden"
-                  >
-                    Loading...
-                  </span>
-                </div>
-              </div>
-              <img
-                alt="Your Design Here"
-                class="c7 card-img card-img-fade-in"
-                data-nimg="fill"
-                decoding="async"
-                loading="lazy"
-                sizes="100vw"
-                src="/_next/image?url=%2Flogo-blank.png&w=3840&q=75"
-                srcset="/_next/image?url=%2Flogo-blank.png&w=640&q=75 640w, /_next/image?url=%2Flogo-blank.png&w=750&q=75 750w, /_next/image?url=%2Flogo-blank.png&w=828&q=75 828w, /_next/image?url=%2Flogo-blank.png&w=1080&q=75 1080w, /_next/image?url=%2Flogo-blank.png&w=1200&q=75 1200w, /_next/image?url=%2Flogo-blank.png&w=1920&q=75 1920w, /_next/image?url=%2Flogo-blank.png&w=2048&q=75 2048w, /_next/image?url=%2Flogo-blank.png&w=3840&q=75 3840w"
-                style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
-              />
+                Loading...
+              </span>
             </div>
           </div>
+          <img
+            alt="Your Design Here"
+            class="c7 card-img card-img-fade-in"
+            data-nimg="fill"
+            decoding="async"
+            loading="lazy"
+            sizes="100vw"
+            src="/_next/image?url=%2Flogo-blank.png&w=3840&q=75"
+            srcset="/_next/image?url=%2Flogo-blank.png&w=640&q=75 640w, /_next/image?url=%2Flogo-blank.png&w=750&q=75 750w, /_next/image?url=%2Flogo-blank.png&w=828&q=75 828w, /_next/image?url=%2Flogo-blank.png&w=1080&q=75 1080w, /_next/image?url=%2Flogo-blank.png&w=1200&q=75 1200w, /_next/image?url=%2Flogo-blank.png&w=1920&q=75 1920w, /_next/image?url=%2Flogo-blank.png&w=2048&q=75 2048w, /_next/image?url=%2Flogo-blank.png&w=3840&q=75 3840w"
+            style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+          />
+        </div>
+      </div>
+      <div
+        class="c3 c11"
+      >
+        <div
+          class="c5 rounded-lg shadow-lg ratio ratio-7x5"
+        >
           <div
-            class="c3 c11"
+            class="d-flex justify-content-center align-items-center"
           >
             <div
-              class="c5 rounded-lg shadow-lg ratio ratio-7x5"
+              class="c6 spinner-border"
+              role="status"
+              size="4"
             >
-              <div
-                class="d-flex justify-content-center align-items-center"
+              <span
+                class="visually-hidden"
               >
-                <div
-                  class="c6 spinner-border"
-                  role="status"
-                  size="4"
-                >
-                  <span
-                    class="visually-hidden"
-                  >
-                    Loading...
-                  </span>
-                </div>
-              </div>
-              <img
-                alt="Your Design Here"
-                class="c7 card-img card-img-fade-in"
-                data-nimg="fill"
-                decoding="async"
-                loading="lazy"
-                sizes="100vw"
-                src="/_next/image?url=%2Flogo-blank.png&w=3840&q=75"
-                srcset="/_next/image?url=%2Flogo-blank.png&w=640&q=75 640w, /_next/image?url=%2Flogo-blank.png&w=750&q=75 750w, /_next/image?url=%2Flogo-blank.png&w=828&q=75 828w, /_next/image?url=%2Flogo-blank.png&w=1080&q=75 1080w, /_next/image?url=%2Flogo-blank.png&w=1200&q=75 1200w, /_next/image?url=%2Flogo-blank.png&w=1920&q=75 1920w, /_next/image?url=%2Flogo-blank.png&w=2048&q=75 2048w, /_next/image?url=%2Flogo-blank.png&w=3840&q=75 3840w"
-                style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
-              />
+                Loading...
+              </span>
             </div>
           </div>
+          <img
+            alt="Your Design Here"
+            class="c7 card-img card-img-fade-in"
+            data-nimg="fill"
+            decoding="async"
+            loading="lazy"
+            sizes="100vw"
+            src="/_next/image?url=%2Flogo-blank.png&w=3840&q=75"
+            srcset="/_next/image?url=%2Flogo-blank.png&w=640&q=75 640w, /_next/image?url=%2Flogo-blank.png&w=750&q=75 750w, /_next/image?url=%2Flogo-blank.png&w=828&q=75 828w, /_next/image?url=%2Flogo-blank.png&w=1080&q=75 1080w, /_next/image?url=%2Flogo-blank.png&w=1200&q=75 1200w, /_next/image?url=%2Flogo-blank.png&w=1920&q=75 1920w, /_next/image?url=%2Flogo-blank.png&w=2048&q=75 2048w, /_next/image?url=%2Flogo-blank.png&w=3840&q=75 3840w"
+            style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
+          />
         </div>
       </div>
     </div>
   </div>
-</body>
+</div>
 `;

--- a/frontend/src/features/ui/dynamicLogo.test.tsx
+++ b/frontend/src/features/ui/dynamicLogo.test.tsx
@@ -1,10 +1,6 @@
 import { screen, waitFor } from "@testing-library/react";
 
-import {
-  cardDocument1,
-  localBackend,
-  noBackend,
-} from "@/common/test-constants";
+import { cardDocument1, noBackend } from "@/common/test-constants";
 import { renderWithProviders } from "@/common/test-utils";
 import { DynamicLogo } from "@/features/ui/dynamicLogo";
 import { defaultHandlers } from "@/mocks/handlers";
@@ -12,24 +8,26 @@ import { server } from "@/mocks/server";
 
 test("the html structure of the dynamic logo, backend configured", async () => {
   server.use(...defaultHandlers);
-  const rendered = renderWithProviders(<DynamicLogo />, {
-    preloadedState: { backend: localBackend },
-  });
+  const rendered = renderWithProviders(<DynamicLogo />);
 
   await waitFor(() =>
     expect(screen.getByAltText(cardDocument1.name)).toBeInTheDocument()
   );
-  expect(rendered.baseElement).toMatchSnapshot();
+  expect(rendered.getByTestId("dynamic-logo")).toMatchSnapshot();
 });
 
 test("the html structure of the dynamic logo, no backend configured", async () => {
   server.use(...defaultHandlers);
-  const rendered = renderWithProviders(<DynamicLogo />, {
-    preloadedState: { backend: noBackend },
-  });
+  const rendered = renderWithProviders(
+    <DynamicLogo />,
+    {
+      preloadedState: { backend: noBackend },
+    },
+    false
+  );
 
   await waitFor(() =>
     expect(screen.getAllByAltText("Your Design Here")).toHaveLength(5)
   );
-  expect(rendered.baseElement).toMatchSnapshot();
+  expect(rendered.getByTestId("dynamic-logo")).toMatchSnapshot();
 });

--- a/frontend/src/features/ui/dynamicLogo.tsx
+++ b/frontend/src/features/ui/dynamicLogo.tsx
@@ -291,7 +291,7 @@ export function DynamicLogo() {
       {loading ? (
         <Spinner size={12} />
       ) : (
-        <Row className="justify-content-center">
+        <Row className="justify-content-center" data-testid="dynamic-logo">
           <Col xl={6} lg={7} md={8} sm={12} xs={12}>
             <DynamicLogoContainer>
               <DynamicLogoLabel className={lato.className}>


### PR DESCRIPTION
# Description

* I wasn't fully across how Redux Toolkit's listener middleware worked for most of the development process - now I understand it a bit better so I'm aware of some room we have for improvement in the side effect space
* This PR refactors a bunch of `useEffect` usages into listener middleware
* I think this is a more logical separation of concerns and might (?) lead to performance improvements as these side effects will run less often now
  * I haven't benchmarked anything though
* The remaining six `useEffect` usages are well justified and don't interact with the Redux store at all

# Checklist

- [x] I have installed `pre-commit` and run the hooks with `pre-commit run`.
- [x] I have updated any related tests for code I modified or added new tests where appropriate.
- [x] I have updated any relevant documentation or created new documentation where appropriate.
  - Purely developer-facing change so no docs are required but I did add docstrings