### PR TITLE
 Allow processing multiple projects in desktop tool

### DIFF
--- a/desktop-tool/autofill.py
+++ b/desktop-tool/autofill.py
@@ -8,6 +8,7 @@ from wakepy import keepawake
 
 from src.constants import Browsers, ImageResizeMethods, TargetSites
 from src.driver import AutofillDriver
+from src.order import CardOrder
 from src.pdf_maker import PdfExporter
 from src.processing import ImagePostProcessingConfig
 from src.utils import bold
@@ -149,9 +150,11 @@ def main(
             if exportpdf:
                 PdfExporter().execute(post_processing_config=post_processing_config)
             else:
+                card_order = CardOrder.from_xml_in_folder()
                 AutofillDriver(
                     browser=Browsers[browser], target_site=TargetSites[site], binary_location=binary_location
-                ).execute(
+                ).execute_order(
+                    order=card_order,
                     skip_setup=skipsetup,
                     auto_save_threshold=auto_save_threshold if auto_save else None,
                     post_processing_config=post_processing_config,

--- a/desktop-tool/autofill.py
+++ b/desktop-tool/autofill.py
@@ -8,7 +8,7 @@ from wakepy import keepawake
 
 from src.constants import Browsers, ImageResizeMethods, TargetSites
 from src.driver import AutofillDriver
-from src.order import CardOrder
+from src.order import CardOrder, aggregate_and_split_orders
 from src.pdf_maker import PdfExporter
 from src.processing import ImagePostProcessingConfig
 from src.utils import bold
@@ -150,9 +150,14 @@ def main(
             if exportpdf:
                 PdfExporter().execute(post_processing_config=post_processing_config)
             else:
-                card_order = CardOrder.from_xml_in_folder()
+                target_site = TargetSites[site]
+                card_orders = aggregate_and_split_orders(
+                    orders=CardOrder.from_xmls_in_folder(), target_site=target_site
+                )
+                # TODO: temporary hack
+                card_order = card_orders[0]  # bad, obviously
                 AutofillDriver(
-                    browser=Browsers[browser], target_site=TargetSites[site], binary_location=binary_location
+                    browser=Browsers[browser], target_site=target_site, binary_location=binary_location
                 ).execute_order(
                     order=card_order,
                     skip_setup=skipsetup,

--- a/desktop-tool/src/constants.py
+++ b/desktop-tool/src/constants.py
@@ -48,6 +48,7 @@ import src.webdrivers as wd
 
 class States(str, Enum):
     initialising = "Initialising"
+    initialised = "Initialised"
     defining_order = "Defining Order"
     paging_to_fronts = "Paging to Fronts"
     paging_to_backs = "Paging to Backs"

--- a/desktop-tool/src/driver.py
+++ b/desktop-tool/src/driver.py
@@ -344,15 +344,14 @@ class AutofillDriver:
     @exception_retry_skip_handler
     def insert_image(self, pid: Optional[str], image: CardImage, slots: list[int]) -> None:
         """
-        Inserts the image identified by `pid` into `image.slots`.
-        If `slots` is specified, fill the image into those slots instead.
+        Inserts the image identified by `pid` into `slots`.
         """
 
         self.wait_until_javascript_object_is_defined("PageLayout.prototype.applyDragPhoto")
 
         if pid:
-            self.set_state(self.state, f'Inserting "{image.name}"')
-            for slot in slots:
+            for i, slot in enumerate(slots, start=1):
+                self.set_state(state=self.state, action=f"Inserting {image.name} into slot {slot+1} ({i}/{len(slots)})")
                 # Insert the card into each slot and wait for the page to load before continuing
                 self.execute_javascript(
                     f'PageLayout.prototype.applyDragPhoto({self.get_element_for_slot_js(slot)}, 0, "{pid}")'

--- a/desktop-tool/src/driver.py
+++ b/desktop-tool/src/driver.py
@@ -372,11 +372,13 @@ class AutofillDriver:
         Returns whether any action to modify the targeted site's project state was taken.
         """
 
-        valid_slots = [
-            slot
-            for slot in image.slots
-            if self.execute_javascript(self.get_element_for_slot_js(slot=slot), return_=True)
-        ]
+        valid_slots = sorted(
+            [
+                slot
+                for slot in image.slots
+                if self.execute_javascript(self.get_element_for_slot_js(slot=slot), return_=True)
+            ]
+        )
         slots_filled = [self.is_slot_filled(slot) for slot in valid_slots]
         if all(slots_filled):
             return False

--- a/desktop-tool/src/driver.py
+++ b/desktop-tool/src/driver.py
@@ -596,7 +596,10 @@ class AutofillDriver:
         self.next_step()
         self.wait()
         try:
-            self.driver.find_element(by=By.ID, value="closeBtn").click()
+            close_btn = self.driver.find_element(by=By.ID, value="closeBtn")
+            if close_btn.is_displayed():  # type: ignore  # TODO: because of missing types in selenium i guess?
+                # this may not be clickable after processing one card order
+                close_btn.click()
         except NoSuchElementException:
             pass
         self.next_step()

--- a/desktop-tool/src/driver.py
+++ b/desktop-tool/src/driver.py
@@ -89,7 +89,7 @@ class AutofillDriver:
         self.upload_bar.refresh()
 
     def configure_bars_for_order(self, order: CardOrder) -> None:
-        num_images = len(order.fronts.cards) + len(order.backs.cards)
+        num_images = len(order.fronts.cards_by_id) + len(order.backs.cards_by_id)
         self.set_state(state=States.initialising, action=None)
         self.upload_bar.total = num_images
         self.download_bar.total = num_images
@@ -398,7 +398,7 @@ class AutofillDriver:
     def upload_and_insert_images(
         self, order: CardOrder, images: CardImageCollection, auto_save_threshold: Optional[int]
     ) -> None:
-        image_count = len(images.cards)
+        image_count = len(images.cards_by_id)
         for i in range(image_count):
             image: CardImage = images.queue.get()
             if image.downloaded:
@@ -626,7 +626,7 @@ class AutofillDriver:
                 pass
         with self.switch_to_frame("sysifm_loginFrame"):
             try:
-                if len(order.backs.cards) == 1:
+                if len(order.backs.cards_by_id) == 1:
                     # Same cardback for every card
                     self.same_images()
                 else:
@@ -709,13 +709,13 @@ class AutofillDriver:
         self.order_progress_bar.total = len(orders)
         self.order_progress_bar.refresh()
         for i, order in enumerate(orders, start=1):
+            print(f"Auto-filling project {bold(i)} of {bold(len(orders))}.")
             skip_setup = inquirer.confirm(
                 message=(
                     "Do you want the tool to continue editing an existing project? (Press Enter if you're not sure.)"
                 ),
                 default=False,
             ).execute()
-            print(f"Auto-filling project {bold(i)} of {bold(len(orders))}.")
             self.execute_order(
                 order=order,
                 skip_setup=skip_setup,

--- a/desktop-tool/src/order.py
+++ b/desktop-tool/src/order.py
@@ -1,15 +1,17 @@
 import os
 import sys
 from concurrent.futures import ThreadPoolExecutor
+from functools import reduce
 from glob import glob
+from itertools import groupby
 from queue import Queue
 from typing import Optional
 from xml.etree.ElementTree import Element, ParseError
 
 import attr
 import enlighten
-import InquirerPy
 from defusedxml.ElementTree import parse as defused_parse
+from InquirerPy import prompt
 from sanitize_filename import sanitize
 
 from src import constants
@@ -28,7 +30,7 @@ from src.utils import bold, text_to_list, unpack_element
 @attr.s
 class CardImage:
     drive_id: str = attr.ib(default="")
-    slots: list[int] = attr.ib(default=[])
+    slots: list[int] = attr.ib(factory=list)
     name: Optional[str] = attr.ib(default="")
     file_path: Optional[str] = attr.ib(default="")
     query: Optional[str] = attr.ib(default=None)
@@ -154,6 +156,37 @@ class CardImage:
         finally:
             queue.put(self)
             download_bar.update()
+            download_bar.refresh()
+
+    def offset_slots(self, offset: int) -> "CardImage":
+        return CardImage(
+            drive_id=self.drive_id,
+            slots=[slot + offset for slot in self.slots],
+            name=self.name,
+            file_path=self.file_path,
+            query=self.query,
+        )
+
+    def split(self, splits: list[int]) -> list[Optional["CardImage"]]:
+        if not splits:
+            return [self]
+        split_cards: list[Optional["CardImage"]] = [None] * len(splits)
+        splits_with_ends = [0, *splits]
+        for i in range(0, len(splits_with_ends[:-1])):
+            slots_in_split = [
+                slot - splits_with_ends[i]
+                for slot in self.slots
+                if splits_with_ends[i] <= slot < splits_with_ends[i + 1]
+            ]
+            if slots_in_split:
+                split_cards[i] = CardImage(
+                    drive_id=self.drive_id,
+                    slots=slots_in_split,
+                    name=self.name,
+                    file_path=self.file_path,
+                    query=self.query,
+                )
+        return split_cards
 
     # endregion
 
@@ -164,10 +197,19 @@ class CardImageCollection:
     A collection of CardImages for one face of a CardOrder.
     """
 
-    cards: list[CardImage] = attr.ib(default=[])
+    cards: list[CardImage] = attr.ib(factory=list)
     queue: Queue[CardImage] = attr.ib(init=False, default=attr.Factory(Queue))
     num_slots: int = attr.ib(default=0)
     face: constants.Faces = attr.ib(default=constants.Faces.front)
+
+    def combine(self, other: "CardImageCollection") -> "CardImageCollection":
+        assert self.face == other.face
+        # TODO: identify identical cards and merge their slots.
+        return CardImageCollection(
+            cards=[*self.cards, *[card.offset_slots(self.num_slots) for card in other.cards]],
+            num_slots=self.num_slots + other.num_slots,
+            face=self.face,
+        )
 
     # region initialisation
 
@@ -175,7 +217,7 @@ class CardImageCollection:
         return set(range(0, self.num_slots))
 
     def slots(self) -> set[int]:
-        return {y for x in self.cards for y in x.slots}
+        return {slot for card in self.cards for slot in card.slots}
 
     def validate(self) -> None:
         if self.num_slots == 0 or not self.cards:
@@ -232,16 +274,17 @@ class CardImageCollection:
     # endregion
 
 
-@attr.s
+@attr.s(frozen=True)  # freezing so these can be hashed
 class Details:
     quantity: int = attr.ib(default=0)
     stock: str = attr.ib(default=constants.Cardstocks.S30.value)
     foil: bool = attr.ib(default=False)
+    allowed_to_exceed_project_max_size: bool = attr.ib(default=False)
 
     # region initialisation
 
     def validate(self) -> None:
-        if self.quantity > constants.PROJECT_MAX_SIZE:
+        if (not self.allowed_to_exceed_project_max_size) and self.quantity > constants.PROJECT_MAX_SIZE:
             raise ValidationException(
                 f"Order quantity {self.quantity} larger than maximum size of {bold(constants.PROJECT_MAX_SIZE)}!"
             )
@@ -270,7 +313,7 @@ class Details:
         stock = details_dict[constants.DetailsTags.stock].text or constants.Cardstocks.S30
         foil: bool = details_dict[constants.DetailsTags.foil].text == "true"
 
-        details = cls(quantity=quantity, stock=stock, foil=foil)
+        details = cls(quantity=quantity, stock=stock, foil=foil, allowed_to_exceed_project_max_size=True)
         return details
 
     # endregion
@@ -283,17 +326,122 @@ class CardOrder:
     fronts: CardImageCollection = attr.ib(default=None)
     backs: CardImageCollection = attr.ib(default=None)
 
-    # region logging
+    def is_combinable(self, other: "CardOrder") -> bool:
+        return self.details.foil == other.details.foil and self.details.stock == other.details.stock
 
-    def print_order_overview(self) -> None:
-        if self.name is not None:
-            print(f"Successfully parsed card order: {bold(self.name)}")
-        print(
-            f"Your order has a total of {bold(self.details.quantity)} cards."
-            f"\n{bold(self.details.stock)} cardstock ({bold('foil' if self.details.foil else 'nonfoil')}).\n "
+    def combine(self, other: "CardOrder") -> "CardOrder":
+        """
+        Combine `self` and `other` into a new `CardOrder`.
+        Orders must be "compatible" in order to be combined - i.e. they must share the same finish configuration.
+        Where both orders have the same single cardback, we continue to treat the cardback as a singleton
+        because this enables a large time saving optimisation when auto-filling the order into MakePlayingCards.
+        """
+
+        # users should never hit this assertion because we group by details before combining
+        assert self.is_combinable(other=other)
+        return CardOrder(
+            # assume that stock and foil finish are identical because the two orders are combinable
+            details=Details(
+                foil=self.details.foil,
+                stock=self.details.stock,
+                quantity=self.details.quantity + other.details.quantity,
+                allowed_to_exceed_project_max_size=True,
+            ),
+            fronts=self.fronts.combine(other.fronts),
+            backs=self.backs.combine(other.backs),
         )
 
-    # endregion
+    def get_project_sizes(self) -> list[int]:
+        naive_split = f"Split every {constants.PROJECT_MAX_SIZE} cards"
+        interactive_split = "Let me specify how to split the cards"
+        questions = {
+            "type": "list",
+            "name": "split_choices",
+            "message": (
+                f"Your project/s with cardstock {self.details.stock} ({'' if self.details.foil else 'non-'}foil)\n"
+                f"contain {self.details.quantity} cards, which exceeds the maximum project size of "
+                f"{constants.PROJECT_MAX_SIZE}.\n"
+                f"How should the project/s be split to fit within {constants.PROJECT_MAX_SIZE} cards at most?"
+            ),
+            "choices": [naive_split, interactive_split],
+        }
+        answers = prompt(questions)
+        split_method = answers["split_choices"]
+
+        # assume naive split
+        remainder = self.details.quantity % constants.PROJECT_MAX_SIZE
+        project_sizes = [constants.PROJECT_MAX_SIZE] * (
+            (self.details.quantity - remainder) // constants.PROJECT_MAX_SIZE
+        )
+        if remainder:
+            project_sizes.append(remainder)
+
+        if split_method == interactive_split:
+            # ask user to specify their desired splits
+            while True:
+                splits_text = input(
+                    f"Enter a comma-separated list of project sizes (each up to {bold(constants.PROJECT_MAX_SIZE)}) "
+                    f"that sum to {bold(self.details.quantity)} and press {bold('Enter')}. "
+                )
+                try:
+                    project_sizes = [int(split_text) for split_text in splits_text.replace(" ", "").split(",")]
+                    for raw_split in project_sizes:
+                        assert 0 < raw_split <= constants.PROJECT_MAX_SIZE
+                    assert sum(project_sizes) == self.details.quantity
+                    break
+                except (ValueError, AssertionError):
+                    print(
+                        f"There was a problem with your proposed splits (perhaps they didn't sum to "
+                        f"{bold(self.details.quantity)}); please try again."
+                    )
+                    pass
+        print(
+            f"The tool will produce {bold(len(project_sizes))} projects! They'll be sized as follows:\n"
+            f"{', '.join(['Project ' + bold(i) + ': ' + bold(project_size) + ' cards' for i, project_size in enumerate(project_sizes, start=1)])}"
+        )
+        return project_sizes
+
+    def split(self) -> list["CardOrder"]:
+        """
+        Split `self` into multiple orders which each meet the PROJECT_MAX_SIZE upper size bound constraint.
+        """
+
+        if self.details.quantity <= constants.PROJECT_MAX_SIZE:
+            return [self]
+
+        raw_splits = self.get_project_sizes()
+
+        # create the split orders
+        split_orders = [
+            CardOrder(
+                details=Details(
+                    quantity=raw_split,
+                    stock=self.details.stock,
+                    foil=self.details.foil,
+                    allowed_to_exceed_project_max_size=False,
+                ),
+                fronts=CardImageCollection(num_slots=raw_split, face=constants.Faces.front),
+                backs=CardImageCollection(num_slots=raw_split, face=constants.Faces.back),
+            )
+            for raw_split in raw_splits
+        ]
+
+        # this translates splits like [100, 150, 100] into splits like [100, 250, 350]
+        splits = [sum(raw_splits[: i + 1]) for i in range(len(raw_splits))]
+
+        # split each card and assign them to their corresponding order
+        for front_card in self.fronts.cards:
+            split_cards = front_card.split(splits)
+            for i, split_card in enumerate(split_cards):
+                if split_card:
+                    split_orders[i].fronts.cards.append(split_card)
+        for back_card in self.backs.cards:
+            split_cards = back_card.split(splits)
+            for i, split_card in enumerate(split_cards):
+                if split_card:
+                    split_orders[i].backs.cards.append(split_card)
+
+        return split_orders
 
     # region initialisation
 
@@ -352,23 +500,93 @@ class CardOrder:
     # region public
 
     @classmethod
-    def from_xml_in_folder(cls) -> "CardOrder":
+    def from_xmls_in_folder(cls) -> list["CardOrder"]:
         """
-        Reads an XML from the current directory, offering a choice if multiple are detected, and populates this
-        object with the contents of the file.
+        Reads some number of XMLs from the current directory, offering a choice if multiple are detected,
+        and populates them with the contents of the selected files.
+        The primary public entry point to this class.
         """
 
-        xml_glob = list(glob(os.path.join(CURRDIR, "*.xml")))
+        xml_glob = sorted(glob(os.path.join(CURRDIR, "*.xml")))
         if len(xml_glob) <= 0:
             input("No XML files found in this directory. Press enter to exit.")
             sys.exit(0)
         elif len(xml_glob) == 1:
-            file_name = xml_glob[0]
+            file_names = [xml_glob[0]]
         else:
-            xml_select_string = "Multiple XML files found. Please select one for this order: "
-            questions = {"type": "list", "name": "xml_choice", "message": xml_select_string, "choices": xml_glob}
-            answers = InquirerPy.prompt(questions)
-            file_name = answers["xml_choice"]
-        return cls.from_file_name(file_name)
+            xml_select_string = (
+                "Multiple XML files found. Please select any number of them to process.\n"
+                "Select a file by pressing Space, then confirm your selection by pressing Enter."
+            )
+            questions = {
+                "type": "list",
+                "name": "xml_choice",
+                "message": xml_select_string,
+                "choices": xml_glob,
+                "multiselect": True,
+            }
+            answers = prompt(questions)
+            file_names = answers["xml_choice"]
+        return [cls.from_file_name(file_name) for file_name in file_names]
+
+    @classmethod
+    def from_multiple_orders(cls, orders: list["CardOrder"]) -> "CardOrder":
+        """
+        Flatten some number of orders into a single `CardOrder`.
+        """
+
+        assert len(orders) > 0, "Attempted to produce a CardOrder from multiple CardOrders but none were given!"
+        return reduce(lambda a, b: a.combine(b), orders)
+
+    def print_order_overview(self) -> None:
+        if self.name is not None:
+            print(f"Successfully parsed project: {bold(self.name)}")
+        print(
+            f"This project has a total of {bold(self.details.quantity)} cards.\n"
+            f"{bold(self.details.stock)} cardstock ({bold('foil' if self.details.foil else 'nonfoil')}). "
+        )
 
     # endregion
+
+
+def aggregate_and_split_orders(
+    orders: list[CardOrder], target_site: constants.TargetSites, combine_orders: bool
+) -> list[CardOrder]:
+    """
+    Interactively aggregate multiple card orders into consolidated orders.
+
+    This occurs in two phases:
+    1. Combinable orders (orders that share the same finish settings) have their image collections merged.
+        * Note: the complexity here is handling different cardbacks between the orders
+        * This means that if any orders to be combined have different cardbacks,
+          we need to apply the cardback for each project to each slot rather than one slot.
+        * Combined orders can have their image collections spill over the max project size.
+    2. Split the combined orders back out into multiple orders such that they fit into brackets.
+        * For example, combining three 408 card projects will yield two 612 card projects.
+        * Note: the complexity here is optimising for cost across brackets in the target site.
+          I see users wanting to do this in three ways:
+            1. Naively split on max project size (612),
+            2. Read pricing data from the target site, perform some calculations, and suggest the optimal
+               splits for minimising costs,
+                 * Note: out of scope at the moment.
+            3. Allow users to type in their desired splits.
+    """
+
+    if len(orders) == 1:
+        return orders
+
+    def key(order: CardOrder) -> int:
+        return hash((order.details.foil, order.details.stock))
+
+    aggregated_orders = orders
+    if combine_orders:
+        aggregated_orders = [
+            CardOrder.from_multiple_orders(list(grouped_orders))
+            for _, grouped_orders in groupby(sorted(orders, key=key), key=key)
+        ]
+    aggregated_and_split_orders = [
+        aggregated_and_split_order
+        for aggregated_order in aggregated_orders
+        for aggregated_and_split_order in aggregated_order.split()
+    ]
+    return aggregated_and_split_orders

--- a/desktop-tool/src/order.py
+++ b/desktop-tool/src/order.py
@@ -109,6 +109,16 @@ class CardImage:
 
     # region public
 
+    def combine(self, other: "CardImage") -> "CardImage":
+        assert self.drive_id == other.drive_id
+        return CardImage(
+            drive_id=self.drive_id,
+            slots=self.slots | other.slots,
+            name=self.name,
+            file_path=self.file_path,
+            query=self.query,
+        )
+
     @classmethod
     def from_element(cls, element: Element) -> "CardImage":
         card_dict = unpack_element(element, [x.value for x in constants.DetailsTags])

--- a/desktop-tool/src/order.py
+++ b/desktop-tool/src/order.py
@@ -333,10 +333,6 @@ class CardOrder:
             backs = CardImageCollection.from_element(
                 element=root_dict[constants.BaseTags.backs], num_slots=details.quantity, face=constants.Faces.back
             )
-        # If the order has a single cardback, set its slots to [0], as it will only be uploaded and inserted into
-        # a single slot
-        if len(backs.cards) == 1:
-            backs.cards[0].slots = [0]
         order = cls(name=name, details=details, fronts=fronts, backs=backs)
         return order
 

--- a/desktop-tool/src/order.py
+++ b/desktop-tool/src/order.py
@@ -102,7 +102,8 @@ class CardImage:
         self.errored = any([self.errored, self.name is None, self.file_path is None])
 
     def __attrs_post_init__(self) -> None:
-        self.generate_file_path()
+        if not self.file_path:
+            self.generate_file_path()
         self.validate()
 
     # endregion

--- a/desktop-tool/src/order.py
+++ b/desktop-tool/src/order.py
@@ -305,7 +305,7 @@ class Details:
     # region public
 
     @classmethod
-    def from_element(cls, element: Element) -> "Details":
+    def from_element(cls, element: Element, allowed_to_exceed_project_max_size: bool) -> "Details":
         details_dict = unpack_element(element, [x.value for x in constants.DetailsTags])
         quantity = 0
         if (quantity_text := details_dict[constants.DetailsTags.quantity].text) is not None:
@@ -313,7 +313,12 @@ class Details:
         stock = details_dict[constants.DetailsTags.stock].text or constants.Cardstocks.S30
         foil: bool = details_dict[constants.DetailsTags.foil].text == "true"
 
-        details = cls(quantity=quantity, stock=stock, foil=foil, allowed_to_exceed_project_max_size=True)
+        details = cls(
+            quantity=quantity,
+            stock=stock,
+            foil=foil,
+            allowed_to_exceed_project_max_size=allowed_to_exceed_project_max_size,
+        )
         return details
 
     # endregion
@@ -462,9 +467,13 @@ class CardOrder:
             sys.exit(0)
 
     @classmethod
-    def from_element(cls, element: Element, name: Optional[str] = None) -> "CardOrder":
+    def from_element(
+        cls, element: Element, allowed_to_exceed_project_max_size: bool, name: Optional[str] = None
+    ) -> "CardOrder":
         root_dict = unpack_element(element, [x.value for x in constants.BaseTags])
-        details = Details.from_element(root_dict[constants.BaseTags.details])
+        details = Details.from_element(
+            root_dict[constants.BaseTags.details], allowed_to_exceed_project_max_size=allowed_to_exceed_project_max_size
+        )
         fronts = CardImageCollection.from_element(
             element=root_dict[constants.BaseTags.fronts], num_slots=details.quantity, face=constants.Faces.front
         )
@@ -492,7 +501,7 @@ class CardOrder:
             input("Your XML file contains a syntax error so it can't be processed. Press Enter to exit.")
             sys.exit(0)
         print(f"Parsing XML file {bold(file_name)}...")
-        order = cls.from_element(xml.getroot(), name=file_name)
+        order = cls.from_element(xml.getroot(), name=file_name, allowed_to_exceed_project_max_size=True)
         return order
 
     # endregion

--- a/desktop-tool/src/pdf_maker.py
+++ b/desktop-tool/src/pdf_maker.py
@@ -15,7 +15,7 @@ from src.utils import bold
 
 @attr.s
 class PdfExporter:
-    order: CardOrder = attr.ib(default=attr.Factory(CardOrder.from_xml_in_folder))
+    order: CardOrder = attr.ib(default=attr.Factory(lambda: CardOrder.from_xmls_in_folder()[0]))
     state: str = attr.ib(init=False, default=States.initialising)
     pdf: FPDF = attr.ib(default=None)
     card_width_in_inches: float = attr.ib(default=2.73)

--- a/desktop-tool/src/pdf_maker.py
+++ b/desktop-tool/src/pdf_maker.py
@@ -32,7 +32,7 @@ class PdfExporter:
     processed_bar: enlighten.Counter = attr.ib(init=False, default=None)
 
     def configure_bars(self) -> None:
-        num_images = len(self.order.fronts.cards) + len(self.order.backs.cards)
+        num_images = len(self.order.fronts.cards_by_id) + len(self.order.backs.cards_by_id)
         status_format = "State: {state}"
         self.status_bar = self.manager.status_bar(
             status_format=status_format,
@@ -117,12 +117,12 @@ class PdfExporter:
             self.order.backs.download_images(pool, self.download_bar, post_processing_config)
 
         backs_by_slots = {}
-        for card in self.order.backs.cards:
+        for card in self.order.backs.cards_by_id.values():
             for slot in card.slots:
                 backs_by_slots[slot] = card.file_path
 
         fronts_by_slots = {}
-        for card in self.order.fronts.cards:
+        for card in self.order.fronts.cards_by_id.values():
             for slot in card.slots:
                 fronts_by_slots[slot] = card.file_path
 

--- a/desktop-tool/src/utils.py
+++ b/desktop-tool/src/utils.py
@@ -27,14 +27,14 @@ def bold(text: Any) -> str:
     return f"{TEXT_BOLD}{text}{TEXT_END}"
 
 
-def text_to_list(input_text: str) -> list[int]:
+def text_to_set(input_text: str) -> set[int]:
     """
-    Helper function to translate strings like "[2, 4, 5, 6]" into sorted lists.
+    Helper function to translate strings like "[2, 4, 5, 6]" into sets.
     """
 
     if not input_text:
-        return []
-    return sorted([int(x) for x in input_text.strip("][").replace(" ", "").split(",")])
+        return set()
+    return set([int(x) for x in input_text.strip("][").replace(" ", "").split(",")])
 
 
 def unpack_element(element: ElementTree.Element, tags: list[str]) -> dict[str, ElementTree.Element]:

--- a/desktop-tool/tests/test_desktop_client.py
+++ b/desktop-tool/tests/test_desktop_client.py
@@ -585,9 +585,9 @@ def test_generate_google_drive_file_path(image_valid_google_drive):
     "image_a, image_b, expected_result",
     [
         (
-            CardImage(drive_id="1", name="a.jpg", slots={1, 2}),
-            CardImage(drive_id="1", name="a.jpg", slots={2, 3}),
-            CardImage(drive_id="1", name="a.jpg", slots={1, 2, 3}),
+            CardImage(drive_id="1", name="a.jpg", file_path=f"{FILE_PATH}/cards/a (1).jpg", slots={1, 2}),
+            CardImage(drive_id="1", name="a.jpg", file_path=f"{FILE_PATH}/cards/a (1).jpg", slots={2, 3}),
+            CardImage(drive_id="1", name="a.jpg", file_path=f"{FILE_PATH}/cards/a (1).jpg", slots={1, 2, 3}),
         )
     ],
 )
@@ -768,14 +768,14 @@ def test_card_order_valid_from_file():
                         drive_id="1OAw4l9RYbgYrmnyYeR1iVDoIS6_aus49",
                         slots=set(range(9)),
                         name="Island (Unsanctioned).png",
-                        file_path=f"{FILE_PATH}/cards/Island (Unsanctioned).png",
+                        file_path=f"{FILE_PATH}/cards/Island (Unsanctioned) (1OAw4l9RYbgYrmnyYeR1iVDoIS6_aus49).png",
                         query="island",
                     ),
                     "1wlrM7pNHQ5NqS9GY5LWH7Hd04TtNgHI4": CardImage(
                         drive_id="1wlrM7pNHQ5NqS9GY5LWH7Hd04TtNgHI4",
                         slots={9},
                         name="Rite of Flame.png",
-                        file_path=f"{FILE_PATH}/cards/Rite of Flame.png",
+                        file_path=f"{FILE_PATH}/cards/Rite of Flame (1wlrM7pNHQ5NqS9GY5LWH7Hd04TtNgHI4).png",
                         query="rite of flame",
                     ),
                 },
@@ -788,7 +788,7 @@ def test_card_order_valid_from_file():
                         drive_id="16g2UamJ2jzwNHovLesvsinvd6_qPkZfy",
                         slots=set(range(10)),
                         name="MTGA Lotus.png",
-                        file_path=f"{FILE_PATH}/cards/MTGA Lotus.png",
+                        file_path=f"{FILE_PATH}/cards/MTGA Lotus (16g2UamJ2jzwNHovLesvsinvd6_qPkZfy).png",
                         query=None,
                     )
                 },
@@ -818,12 +818,20 @@ def test_card_order_missing_slots(input_enter, card_order_element_invalid_quanti
                 CardOrder(
                     details=Details(quantity=2, stock=constants.Cardstocks.S30, foil=False),
                     fronts=CardImageCollection(
-                        cards_by_id={"1": CardImage(drive_id="1", name="1.png", slots={0, 1})},
+                        cards_by_id={
+                            "1": CardImage(
+                                drive_id="1", name="1.png", file_path=f"{FILE_PATH}/cards/1 (1).png", slots={0, 1}
+                            )
+                        },
                         num_slots=2,
                         face=constants.Faces.front,
                     ),
                     backs=CardImageCollection(
-                        cards_by_id={"2": CardImage(drive_id="2", name="2.png", slots={0, 1})},
+                        cards_by_id={
+                            "2": CardImage(
+                                drive_id="2", name="2.png", file_path=f"{FILE_PATH}/cards/2 (2).png", slots={0, 1}
+                            )
+                        },
                         num_slots=2,
                         face=constants.Faces.back,
                     ),
@@ -832,14 +840,22 @@ def test_card_order_missing_slots(input_enter, card_order_element_invalid_quanti
                     details=Details(quantity=2, stock=constants.Cardstocks.S30, foil=False),
                     fronts=CardImageCollection(
                         cards_by_id={
-                            "3": CardImage(drive_id="3", name="3.png", slots={0}),
-                            "4": CardImage(drive_id="4", name="4.png", slots={1}),
+                            "3": CardImage(
+                                drive_id="3", name="3.png", file_path=f"{FILE_PATH}/cards/3 (3).png", slots={0}
+                            ),
+                            "4": CardImage(
+                                drive_id="4", name="4.png", file_path=f"{FILE_PATH}/cards/4 (4).png", slots={1}
+                            ),
                         },
                         num_slots=2,
                         face=constants.Faces.front,
                     ),
                     backs=CardImageCollection(
-                        cards_by_id={"2": CardImage(drive_id="2", name="2.png", slots={0, 1})},
+                        cards_by_id={
+                            "2": CardImage(
+                                drive_id="2", name="2.png", file_path=f"{FILE_PATH}/cards/2 (2).png", slots={0, 1}
+                            )
+                        },
                         num_slots=2,
                         face=constants.Faces.back,
                     ),
@@ -850,16 +866,22 @@ def test_card_order_missing_slots(input_enter, card_order_element_invalid_quanti
                 details=Details(quantity=4, stock=constants.Cardstocks.S30, foil=False),
                 fronts=CardImageCollection(
                     cards_by_id={
-                        "1": CardImage(drive_id="1", name="1.png", slots={0, 1}),
-                        "3": CardImage(drive_id="3", name="3.png", slots={2}),
-                        "4": CardImage(drive_id="4", name="4.png", slots={3}),
+                        "1": CardImage(
+                            drive_id="1", name="1.png", file_path=f"{FILE_PATH}/cards/1 (1).png", slots={0, 1}
+                        ),
+                        "3": CardImage(drive_id="3", name="3.png", file_path=f"{FILE_PATH}/cards/3 (3).png", slots={2}),
+                        "4": CardImage(drive_id="4", name="4.png", file_path=f"{FILE_PATH}/cards/4 (4).png", slots={3}),
                     },
                     num_slots=4,
                     face=constants.Faces.front,
                 ),
                 backs=CardImageCollection(
                     # the slots for `2` across both orders will be merged as below
-                    cards_by_id={"2": CardImage(drive_id="2", name="2.png", slots={0, 1, 2, 3})},
+                    cards_by_id={
+                        "2": CardImage(
+                            drive_id="2", name="2.png", file_path=f"{FILE_PATH}/cards/2 (2).png", slots={0, 1, 2, 3}
+                        )
+                    },
                     num_slots=4,
                     face=constants.Faces.back,
                 ),
@@ -873,12 +895,20 @@ def test_card_order_missing_slots(input_enter, card_order_element_invalid_quanti
                 CardOrder(
                     details=Details(quantity=2, stock=constants.Cardstocks.S30, foil=False),
                     fronts=CardImageCollection(
-                        cards_by_id={"1": CardImage(drive_id="1", name="1.png", slots={0, 1})},
+                        cards_by_id={
+                            "1": CardImage(
+                                drive_id="1", name="1.png", file_path=f"{FILE_PATH}/cards/1 (1).png", slots={0, 1}
+                            )
+                        },
                         num_slots=2,
                         face=constants.Faces.front,
                     ),
                     backs=CardImageCollection(
-                        cards_by_id={"2": CardImage(drive_id="2", name="2.png", slots={0, 1})},
+                        cards_by_id={
+                            "2": CardImage(
+                                drive_id="2", name="2.png", file_path=f"{FILE_PATH}/cards/2 (2).png", slots={0, 1}
+                            )
+                        },
                         num_slots=2,
                         face=constants.Faces.back,
                     ),
@@ -887,14 +917,22 @@ def test_card_order_missing_slots(input_enter, card_order_element_invalid_quanti
                     details=Details(quantity=2, stock=constants.Cardstocks.S30, foil=False),
                     fronts=CardImageCollection(
                         cards_by_id={
-                            "3": CardImage(drive_id="3", name="3.png", slots={0}),
-                            "4": CardImage(drive_id="4", name="4.png", slots={1}),
+                            "3": CardImage(
+                                drive_id="3", name="3.png", file_path=f"{FILE_PATH}/cards/3 (3).png", slots={0}
+                            ),
+                            "4": CardImage(
+                                drive_id="4", name="4.png", file_path=f"{FILE_PATH}/cards/4 (4).png", slots={1}
+                            ),
                         },
                         num_slots=2,
                         face=constants.Faces.front,
                     ),
                     backs=CardImageCollection(
-                        cards_by_id={"5": CardImage(drive_id="5", name="5.png", slots={0, 1})},
+                        cards_by_id={
+                            "5": CardImage(
+                                drive_id="5", name="5.png", file_path=f"{FILE_PATH}/cards/5 (5).png", slots={0, 1}
+                            )
+                        },
                         num_slots=2,
                         face=constants.Faces.back,
                     ),
@@ -905,17 +943,23 @@ def test_card_order_missing_slots(input_enter, card_order_element_invalid_quanti
                 details=Details(quantity=4, stock=constants.Cardstocks.S30, foil=False),
                 fronts=CardImageCollection(
                     cards_by_id={
-                        "1": CardImage(drive_id="1", name="1.png", slots={0, 1}),
-                        "3": CardImage(drive_id="3", name="3.png", slots={2}),
-                        "4": CardImage(drive_id="4", name="4.png", slots={3}),
+                        "1": CardImage(
+                            drive_id="1", name="1.png", file_path=f"{FILE_PATH}/cards/1 (1).png", slots={0, 1}
+                        ),
+                        "3": CardImage(drive_id="3", name="3.png", file_path=f"{FILE_PATH}/cards/3 (3).png", slots={2}),
+                        "4": CardImage(drive_id="4", name="4.png", file_path=f"{FILE_PATH}/cards/4 (4).png", slots={3}),
                     },
                     num_slots=4,
                     face=constants.Faces.front,
                 ),
                 backs=CardImageCollection(
                     cards_by_id={
-                        "2": CardImage(drive_id="2", name="2.png", slots={0, 1}),
-                        "5": CardImage(drive_id="5", name="5.png", slots={2, 3}),
+                        "2": CardImage(
+                            drive_id="2", name="2.png", file_path=f"{FILE_PATH}/cards/2 (2).png", slots={0, 1}
+                        ),
+                        "5": CardImage(
+                            drive_id="5", name="5.png", file_path=f"{FILE_PATH}/cards/5 (5).png", slots={2, 3}
+                        ),
                     },
                     num_slots=4,
                     face=constants.Faces.back,
@@ -970,12 +1014,20 @@ def test_get_project_sizes_manually_specifying_sizes(
     order = CardOrder(
         details=Details(quantity=5, stock=constants.Cardstocks.S30, foil=False),
         fronts=CardImageCollection(
-            cards_by_id={"1": CardImage(drive_id="1", name="1.png", slots=set(range(5)))},
+            cards_by_id={
+                "1": CardImage(
+                    drive_id="1", name="1.png", file_path=f"{FILE_PATH}/cards/1 (1).png", slots=set(range(5))
+                )
+            },
             num_slots=5,
             face=constants.Faces.front,
         ),
         backs=CardImageCollection(
-            cards_by_id={"2": CardImage(drive_id="2", name="2.png", slots=set(range(5)))},
+            cards_by_id={
+                "2": CardImage(
+                    drive_id="2", name="2.png", file_path=f"{FILE_PATH}/cards/2 (2).png", slots=set(range(5))
+                )
+            },
             num_slots=5,
             face=constants.Faces.back,
         ),
@@ -994,12 +1046,20 @@ def test_get_project_sizes_manually_specifying_sizes_with_an_incorrect_attempt_f
     order = CardOrder(
         details=Details(quantity=5, stock=constants.Cardstocks.S30, foil=False),
         fronts=CardImageCollection(
-            cards_by_id={"1": CardImage(drive_id="1", name="1.png", slots=set(range(5)))},
+            cards_by_id={
+                "1": CardImage(
+                    drive_id="1", name="1.png", file_path=f"{FILE_PATH}/cards/1 (1).png", slots=set(range(5))
+                )
+            },
             num_slots=5,
             face=constants.Faces.front,
         ),
         backs=CardImageCollection(
-            cards_by_id={"2": CardImage(drive_id="2", name="2.png", slots=set(range(5)))},
+            cards_by_id={
+                "2": CardImage(
+                    drive_id="2", name="2.png", file_path=f"{FILE_PATH}/cards/2 (2).png", slots=set(range(5))
+                )
+            },
             num_slots=5,
             face=constants.Faces.back,
         ),
@@ -1017,12 +1077,20 @@ def test_get_project_sizes_automatically_breaking_on_max_size(
     order = CardOrder(
         details=Details(quantity=5, stock=constants.Cardstocks.S30, foil=False),
         fronts=CardImageCollection(
-            cards_by_id={"1": CardImage(drive_id="1", name="1.png", slots=set(range(5)))},
+            cards_by_id={
+                "1": CardImage(
+                    drive_id="1", name="1.png", file_path=f"{FILE_PATH}/cards/1 (1).png", slots=set(range(5))
+                )
+            },
             num_slots=5,
             face=constants.Faces.front,
         ),
         backs=CardImageCollection(
-            cards_by_id={"2": CardImage(drive_id="2", name="2.png", slots=set(range(5)))},
+            cards_by_id={
+                "2": CardImage(
+                    drive_id="2", name="2.png", file_path=f"{FILE_PATH}/cards/2 (2).png", slots=set(range(5))
+                )
+            },
             num_slots=5,
             face=constants.Faces.back,
         ),
@@ -1040,12 +1108,26 @@ def test_get_project_sizes_automatically_breaking_on_max_size(
                 CardOrder(
                     details=Details(quantity=5, stock=constants.Cardstocks.S30, foil=False),
                     fronts=CardImageCollection(
-                        cards_by_id={"1": CardImage(drive_id="1", name="1.png", slots=set(range(5)))},
+                        cards_by_id={
+                            "1": CardImage(
+                                drive_id="1",
+                                name="1.png",
+                                file_path=f"{FILE_PATH}/cards/1 (1).png",
+                                slots=set(range(5)),
+                            )
+                        },
                         num_slots=5,
                         face=constants.Faces.front,
                     ),
                     backs=CardImageCollection(
-                        cards_by_id={"2": CardImage(drive_id="2", name="2.png", slots=set(range(5)))},
+                        cards_by_id={
+                            "2": CardImage(
+                                drive_id="2",
+                                name="2.png",
+                                file_path=f"{FILE_PATH}/cards/2 (2).png",
+                                slots=set(range(5)),
+                            )
+                        },
                         num_slots=5,
                         face=constants.Faces.back,
                     ),
@@ -1053,12 +1135,26 @@ def test_get_project_sizes_automatically_breaking_on_max_size(
                 CardOrder(
                     details=Details(quantity=2, stock=constants.Cardstocks.S30, foil=False),
                     fronts=CardImageCollection(
-                        cards_by_id={"1": CardImage(drive_id="1", name="1.png", slots=set(range(2)))},
+                        cards_by_id={
+                            "1": CardImage(
+                                drive_id="1",
+                                name="1.png",
+                                file_path=f"{FILE_PATH}/cards/1 (1).png",
+                                slots=set(range(2)),
+                            )
+                        },
                         num_slots=2,
                         face=constants.Faces.front,
                     ),
                     backs=CardImageCollection(
-                        cards_by_id={"2": CardImage(drive_id="2", name="2.png", slots=set(range(2)))},
+                        cards_by_id={
+                            "2": CardImage(
+                                drive_id="2",
+                                name="2.png",
+                                file_path=f"{FILE_PATH}/cards/2 (2).png",
+                                slots=set(range(2)),
+                            )
+                        },
                         num_slots=2,
                         face=constants.Faces.back,
                     ),
@@ -1068,12 +1164,26 @@ def test_get_project_sizes_automatically_breaking_on_max_size(
                 CardOrder(
                     details=Details(quantity=4, stock=constants.Cardstocks.S30, foil=False),
                     fronts=CardImageCollection(
-                        cards_by_id={"1": CardImage(drive_id="1", name="1.png", slots=set(range(4)))},
+                        cards_by_id={
+                            "1": CardImage(
+                                drive_id="1",
+                                name="1.png",
+                                file_path=f"{FILE_PATH}/cards/1 (1).png",
+                                slots=set(range(4)),
+                            )
+                        },
                         num_slots=4,
                         face=constants.Faces.front,
                     ),
                     backs=CardImageCollection(
-                        cards_by_id={"2": CardImage(drive_id="2", name="2.png", slots=set(range(4)))},
+                        cards_by_id={
+                            "2": CardImage(
+                                drive_id="2",
+                                name="2.png",
+                                file_path=f"{FILE_PATH}/cards/2 (2).png",
+                                slots=set(range(4)),
+                            )
+                        },
                         num_slots=4,
                         face=constants.Faces.back,
                     ),
@@ -1081,12 +1191,26 @@ def test_get_project_sizes_automatically_breaking_on_max_size(
                 CardOrder(
                     details=Details(quantity=3, stock=constants.Cardstocks.S30, foil=False),
                     fronts=CardImageCollection(
-                        cards_by_id={"1": CardImage(drive_id="1", name="1.png", slots=set(range(3)))},
+                        cards_by_id={
+                            "1": CardImage(
+                                drive_id="1",
+                                name="1.png",
+                                file_path=f"{FILE_PATH}/cards/1 (1).png",
+                                slots=set(range(3)),
+                            )
+                        },
                         num_slots=3,
                         face=constants.Faces.front,
                     ),
                     backs=CardImageCollection(
-                        cards_by_id={"2": CardImage(drive_id="2", name="2.png", slots=set(range(3)))},
+                        cards_by_id={
+                            "2": CardImage(
+                                drive_id="2",
+                                name="2.png",
+                                file_path=f"{FILE_PATH}/cards/2 (2).png",
+                                slots=set(range(3)),
+                            )
+                        },
                         num_slots=3,
                         face=constants.Faces.back,
                     ),

--- a/desktop-tool/tests/test_desktop_client.py
+++ b/desktop-tool/tests/test_desktop_client.py
@@ -73,6 +73,7 @@ def assert_file_size(file_path: str, size: int) -> None:
 # region constants
 
 FILE_PATH = os.path.abspath(os.path.dirname(__file__))
+CARDS_FILE_PATH = os.path.join(FILE_PATH, "cards")
 SIMPLE_CUBE = "Simple Cube"
 SIMPLE_CUBE_ID = "1JtXL6Ca9nQkvhwZZRR9ZuKA9_DzsFf1V"
 SIMPLE_LOTUS = "Simple Lotus"
@@ -118,7 +119,7 @@ def image_element_local_file() -> Generator[ElementTree.Element, None, None]:
         textwrap.dedent(  # file exists in /src/cards
             f"""
             <card>
-                <id>{FILE_PATH}/cards/{TEST_IMAGE}.png</id>
+                <id>{os.path.join(CARDS_FILE_PATH, TEST_IMAGE)}.png</id>
                 <slots>0</slots>
                 <name>{TEST_IMAGE}.png</name>
                 <query>test image</query>
@@ -366,7 +367,7 @@ def card_order_element_valid() -> Generator[ElementTree.Element, None, None]:
                         <query>simple lotus</query>
                     </card>
                 </fronts>
-                <cardback>{FILE_PATH}/cards/{TEST_IMAGE}.png</cardback>
+                <cardback>{os.path.join(CARDS_FILE_PATH, TEST_IMAGE)}.png</cardback>
             </order>
             """
         )
@@ -391,7 +392,7 @@ def card_order_element_multiple_cardbacks() -> Generator[ElementTree.Element, No
                 </details>
                 <fronts>
                     <card>
-                        <id>{FILE_PATH}/cards/{TEST_IMAGE}.png</id>
+                        <id>{os.path.join(CARDS_FILE_PATH, TEST_IMAGE)}.png</id>
                         <slots>0,3</slots>
                         <name></name>
                         <query></query>
@@ -450,7 +451,7 @@ def card_order_element_invalid_quantity() -> Generator[ElementTree.Element, None
                         <query>simple lotus</query>
                     </card>
                 </fronts>
-                <cardback>{FILE_PATH}/cards/{TEST_IMAGE}.png</cardback>
+                <cardback>{os.path.join(CARDS_FILE_PATH, TEST_IMAGE)}.png</cardback>
             </order>
             """
         )
@@ -482,7 +483,7 @@ def card_order_element_missing_front_image() -> Generator[ElementTree.Element, N
                         <query>simple lotus</query>
                     </card>
                 </fronts>
-                <cardback>{FILE_PATH}/cards/{TEST_IMAGE}.png</cardback>
+                <cardback>{os.path.join(CARDS_FILE_PATH, TEST_IMAGE)}.png</cardback>
             </order>
             """
         )
@@ -585,9 +586,11 @@ def test_generate_google_drive_file_path(image_valid_google_drive):
     "image_a, image_b, expected_result",
     [
         (
-            CardImage(drive_id="1", name="a.jpg", file_path=f"{FILE_PATH}/cards/a (1).jpg", slots={1, 2}),
-            CardImage(drive_id="1", name="a.jpg", file_path=f"{FILE_PATH}/cards/a (1).jpg", slots={2, 3}),
-            CardImage(drive_id="1", name="a.jpg", file_path=f"{FILE_PATH}/cards/a (1).jpg", slots={1, 2, 3}),
+            CardImage(drive_id="1", name="a.jpg", file_path=os.path.join(CARDS_FILE_PATH, "a (1).jpg"), slots={1, 2}),
+            CardImage(drive_id="1", name="a.jpg", file_path=os.path.join(CARDS_FILE_PATH, "a (1).jpg"), slots={2, 3}),
+            CardImage(
+                drive_id="1", name="a.jpg", file_path=os.path.join(CARDS_FILE_PATH, "a (1).jpg"), slots={1, 2, 3}
+            ),
         )
     ],
 )
@@ -666,14 +669,14 @@ def test_card_order_valid(card_order_valid):
                         drive_id=SIMPLE_CUBE_ID,
                         slots={0},
                         name=f"{SIMPLE_CUBE}.png",
-                        file_path=f"{FILE_PATH}/cards/{SIMPLE_CUBE} ({SIMPLE_CUBE_ID}).png",  # not on disk
+                        file_path=os.path.join(CARDS_FILE_PATH, f"{SIMPLE_CUBE} ({SIMPLE_CUBE_ID}).png"),  # not on disk
                         query="simple cube",
                     ),
                     SIMPLE_LOTUS_ID: CardImage(
                         drive_id=SIMPLE_LOTUS_ID,
                         slots={1, 2},
                         name=f"{SIMPLE_LOTUS}.png",
-                        file_path=f"{FILE_PATH}/cards/{SIMPLE_LOTUS}.png",  # already exists on disk
+                        file_path=os.path.join(CARDS_FILE_PATH, f"{SIMPLE_LOTUS}.png"),  # already exists on disk
                         query="simple lotus",
                     ),
                 },
@@ -682,11 +685,11 @@ def test_card_order_valid(card_order_valid):
                 face=constants.Faces.back,
                 num_slots=3,
                 cards_by_id={
-                    f"{FILE_PATH}/cards/{TEST_IMAGE}.png": CardImage(
-                        drive_id=f"{FILE_PATH}/cards/{TEST_IMAGE}.png",
+                    os.path.join(CARDS_FILE_PATH, f"{TEST_IMAGE}.png"): CardImage(
+                        drive_id=os.path.join(CARDS_FILE_PATH, f"{TEST_IMAGE}.png"),
                         slots={0, 1, 2},
                         name=f"{TEST_IMAGE}.png",  # name retrieved from file on disk
-                        file_path=f"{FILE_PATH}/cards/{TEST_IMAGE}.png",
+                        file_path=os.path.join(CARDS_FILE_PATH, f"{TEST_IMAGE}.png"),
                         query=None,
                     )
                 },
@@ -708,18 +711,18 @@ def test_card_order_multiple_cardbacks(card_order_multiple_cardbacks):
                 face=constants.Faces.front,
                 num_slots=4,
                 cards_by_id={
-                    f"{FILE_PATH}/cards/{TEST_IMAGE}.png": CardImage(
-                        drive_id=f"{FILE_PATH}/cards/{TEST_IMAGE}.png",
+                    os.path.join(CARDS_FILE_PATH, "{TEST_IMAGE}.png"): CardImage(
+                        drive_id=os.path.join(CARDS_FILE_PATH, f"{TEST_IMAGE}.png"),
                         slots={0, 3},
                         name=f"{TEST_IMAGE}.png",  # name retrieved from file on disk
-                        file_path=f"{FILE_PATH}/cards/{TEST_IMAGE}.png",
+                        file_path=os.path.join(CARDS_FILE_PATH, f"{TEST_IMAGE}.png"),
                         query=None,
                     ),
                     SIMPLE_LOTUS_ID: CardImage(
                         drive_id=SIMPLE_LOTUS_ID,
                         slots={1, 2},
                         name=f"{SIMPLE_LOTUS}.png",
-                        file_path=f"{FILE_PATH}/cards/{SIMPLE_LOTUS}.png",  # already exists on disk
+                        file_path=os.path.join(CARDS_FILE_PATH, f"{SIMPLE_LOTUS}.png"),  # already exists on disk
                         query="simple lotus",
                     ),
                 },
@@ -732,14 +735,14 @@ def test_card_order_multiple_cardbacks(card_order_multiple_cardbacks):
                         drive_id=SIMPLE_LOTUS_ID,
                         slots={1},
                         name=f"{SIMPLE_LOTUS}.png",
-                        file_path=f"{FILE_PATH}/cards/{SIMPLE_LOTUS}.png",  # already exists on disk
+                        file_path=os.path.join(CARDS_FILE_PATH, f"{SIMPLE_LOTUS}.png"),  # already exists on disk
                         query="simple lotus",
                     ),
                     SIMPLE_CUBE_ID: CardImage(
                         drive_id=SIMPLE_CUBE_ID,
                         slots={0, 2, 3},
                         name=f"{SIMPLE_CUBE}.png",
-                        file_path=f"{FILE_PATH}/cards/{SIMPLE_CUBE} ({SIMPLE_CUBE_ID}).png",  # not on disk
+                        file_path=os.path.join(CARDS_FILE_PATH, f"{SIMPLE_CUBE} ({SIMPLE_CUBE_ID}).png"),  # not on disk
                         query=None,
                     ),
                 },
@@ -768,14 +771,18 @@ def test_card_order_valid_from_file():
                         drive_id="1OAw4l9RYbgYrmnyYeR1iVDoIS6_aus49",
                         slots=set(range(9)),
                         name="Island (Unsanctioned).png",
-                        file_path=f"{FILE_PATH}/cards/Island (Unsanctioned) (1OAw4l9RYbgYrmnyYeR1iVDoIS6_aus49).png",
+                        file_path=os.path.join(
+                            CARDS_FILE_PATH, "Island (Unsanctioned) (1OAw4l9RYbgYrmnyYeR1iVDoIS6_aus49).png"
+                        ),
                         query="island",
                     ),
                     "1wlrM7pNHQ5NqS9GY5LWH7Hd04TtNgHI4": CardImage(
                         drive_id="1wlrM7pNHQ5NqS9GY5LWH7Hd04TtNgHI4",
                         slots={9},
                         name="Rite of Flame.png",
-                        file_path=f"{FILE_PATH}/cards/Rite of Flame (1wlrM7pNHQ5NqS9GY5LWH7Hd04TtNgHI4).png",
+                        file_path=os.path.join(
+                            CARDS_FILE_PATH, "Rite of Flame (1wlrM7pNHQ5NqS9GY5LWH7Hd04TtNgHI4).png"
+                        ),
                         query="rite of flame",
                     ),
                 },
@@ -788,7 +795,7 @@ def test_card_order_valid_from_file():
                         drive_id="16g2UamJ2jzwNHovLesvsinvd6_qPkZfy",
                         slots=set(range(10)),
                         name="MTGA Lotus.png",
-                        file_path=f"{FILE_PATH}/cards/MTGA Lotus (16g2UamJ2jzwNHovLesvsinvd6_qPkZfy).png",
+                        file_path=os.path.join(CARDS_FILE_PATH, "MTGA Lotus (16g2UamJ2jzwNHovLesvsinvd6_qPkZfy).png"),
                         query=None,
                     )
                 },
@@ -820,7 +827,10 @@ def test_card_order_missing_slots(input_enter, card_order_element_invalid_quanti
                     fronts=CardImageCollection(
                         cards_by_id={
                             "1": CardImage(
-                                drive_id="1", name="1.png", file_path=f"{FILE_PATH}/cards/1 (1).png", slots={0, 1}
+                                drive_id="1",
+                                name="1.png",
+                                file_path=os.path.join(CARDS_FILE_PATH, "1 (1).png"),
+                                slots={0, 1},
                             )
                         },
                         num_slots=2,
@@ -829,7 +839,10 @@ def test_card_order_missing_slots(input_enter, card_order_element_invalid_quanti
                     backs=CardImageCollection(
                         cards_by_id={
                             "2": CardImage(
-                                drive_id="2", name="2.png", file_path=f"{FILE_PATH}/cards/2 (2).png", slots={0, 1}
+                                drive_id="2",
+                                name="2.png",
+                                file_path=os.path.join(CARDS_FILE_PATH, "2 (2).png"),
+                                slots={0, 1},
                             )
                         },
                         num_slots=2,
@@ -841,10 +854,16 @@ def test_card_order_missing_slots(input_enter, card_order_element_invalid_quanti
                     fronts=CardImageCollection(
                         cards_by_id={
                             "3": CardImage(
-                                drive_id="3", name="3.png", file_path=f"{FILE_PATH}/cards/3 (3).png", slots={0}
+                                drive_id="3",
+                                name="3.png",
+                                file_path=os.path.join(CARDS_FILE_PATH, "3 (3).png"),
+                                slots={0},
                             ),
                             "4": CardImage(
-                                drive_id="4", name="4.png", file_path=f"{FILE_PATH}/cards/4 (4).png", slots={1}
+                                drive_id="4",
+                                name="4.png",
+                                file_path=os.path.join(CARDS_FILE_PATH, "4 (4).png"),
+                                slots={1},
                             ),
                         },
                         num_slots=2,
@@ -853,7 +872,10 @@ def test_card_order_missing_slots(input_enter, card_order_element_invalid_quanti
                     backs=CardImageCollection(
                         cards_by_id={
                             "2": CardImage(
-                                drive_id="2", name="2.png", file_path=f"{FILE_PATH}/cards/2 (2).png", slots={0, 1}
+                                drive_id="2",
+                                name="2.png",
+                                file_path=os.path.join(CARDS_FILE_PATH, "2 (2).png"),
+                                slots={0, 1},
                             )
                         },
                         num_slots=2,
@@ -867,10 +889,17 @@ def test_card_order_missing_slots(input_enter, card_order_element_invalid_quanti
                 fronts=CardImageCollection(
                     cards_by_id={
                         "1": CardImage(
-                            drive_id="1", name="1.png", file_path=f"{FILE_PATH}/cards/1 (1).png", slots={0, 1}
+                            drive_id="1",
+                            name="1.png",
+                            file_path=os.path.join(CARDS_FILE_PATH, "1 (1).png"),
+                            slots={0, 1},
                         ),
-                        "3": CardImage(drive_id="3", name="3.png", file_path=f"{FILE_PATH}/cards/3 (3).png", slots={2}),
-                        "4": CardImage(drive_id="4", name="4.png", file_path=f"{FILE_PATH}/cards/4 (4).png", slots={3}),
+                        "3": CardImage(
+                            drive_id="3", name="3.png", file_path=os.path.join(CARDS_FILE_PATH, "3 (3).png"), slots={2}
+                        ),
+                        "4": CardImage(
+                            drive_id="4", name="4.png", file_path=os.path.join(CARDS_FILE_PATH, "4 (4).png"), slots={3}
+                        ),
                     },
                     num_slots=4,
                     face=constants.Faces.front,
@@ -879,7 +908,10 @@ def test_card_order_missing_slots(input_enter, card_order_element_invalid_quanti
                     # the slots for `2` across both orders will be merged as below
                     cards_by_id={
                         "2": CardImage(
-                            drive_id="2", name="2.png", file_path=f"{FILE_PATH}/cards/2 (2).png", slots={0, 1, 2, 3}
+                            drive_id="2",
+                            name="2.png",
+                            file_path=os.path.join(CARDS_FILE_PATH, "2 (2).png"),
+                            slots={0, 1, 2, 3},
                         )
                     },
                     num_slots=4,
@@ -897,7 +929,10 @@ def test_card_order_missing_slots(input_enter, card_order_element_invalid_quanti
                     fronts=CardImageCollection(
                         cards_by_id={
                             "1": CardImage(
-                                drive_id="1", name="1.png", file_path=f"{FILE_PATH}/cards/1 (1).png", slots={0, 1}
+                                drive_id="1",
+                                name="1.png",
+                                file_path=os.path.join(CARDS_FILE_PATH, "1 (1).png"),
+                                slots={0, 1},
                             )
                         },
                         num_slots=2,
@@ -906,7 +941,10 @@ def test_card_order_missing_slots(input_enter, card_order_element_invalid_quanti
                     backs=CardImageCollection(
                         cards_by_id={
                             "2": CardImage(
-                                drive_id="2", name="2.png", file_path=f"{FILE_PATH}/cards/2 (2).png", slots={0, 1}
+                                drive_id="2",
+                                name="2.png",
+                                file_path=os.path.join(CARDS_FILE_PATH, "2 (2).png"),
+                                slots={0, 1},
                             )
                         },
                         num_slots=2,
@@ -918,10 +956,16 @@ def test_card_order_missing_slots(input_enter, card_order_element_invalid_quanti
                     fronts=CardImageCollection(
                         cards_by_id={
                             "3": CardImage(
-                                drive_id="3", name="3.png", file_path=f"{FILE_PATH}/cards/3 (3).png", slots={0}
+                                drive_id="3",
+                                name="3.png",
+                                file_path=os.path.join(CARDS_FILE_PATH, "3 (3).png"),
+                                slots={0},
                             ),
                             "4": CardImage(
-                                drive_id="4", name="4.png", file_path=f"{FILE_PATH}/cards/4 (4).png", slots={1}
+                                drive_id="4",
+                                name="4.png",
+                                file_path=os.path.join(CARDS_FILE_PATH, "4 (4).png"),
+                                slots={1},
                             ),
                         },
                         num_slots=2,
@@ -930,7 +974,10 @@ def test_card_order_missing_slots(input_enter, card_order_element_invalid_quanti
                     backs=CardImageCollection(
                         cards_by_id={
                             "5": CardImage(
-                                drive_id="5", name="5.png", file_path=f"{FILE_PATH}/cards/5 (5).png", slots={0, 1}
+                                drive_id="5",
+                                name="5.png",
+                                file_path=os.path.join(CARDS_FILE_PATH, "5 (5).png"),
+                                slots={0, 1},
                             )
                         },
                         num_slots=2,
@@ -944,10 +991,17 @@ def test_card_order_missing_slots(input_enter, card_order_element_invalid_quanti
                 fronts=CardImageCollection(
                     cards_by_id={
                         "1": CardImage(
-                            drive_id="1", name="1.png", file_path=f"{FILE_PATH}/cards/1 (1).png", slots={0, 1}
+                            drive_id="1",
+                            name="1.png",
+                            file_path=os.path.join(CARDS_FILE_PATH, "1 (1).png"),
+                            slots={0, 1},
                         ),
-                        "3": CardImage(drive_id="3", name="3.png", file_path=f"{FILE_PATH}/cards/3 (3).png", slots={2}),
-                        "4": CardImage(drive_id="4", name="4.png", file_path=f"{FILE_PATH}/cards/4 (4).png", slots={3}),
+                        "3": CardImage(
+                            drive_id="3", name="3.png", file_path=os.path.join(CARDS_FILE_PATH, "3 (3).png"), slots={2}
+                        ),
+                        "4": CardImage(
+                            drive_id="4", name="4.png", file_path=os.path.join(CARDS_FILE_PATH, "4 (4).png"), slots={3}
+                        ),
                     },
                     num_slots=4,
                     face=constants.Faces.front,
@@ -955,10 +1009,16 @@ def test_card_order_missing_slots(input_enter, card_order_element_invalid_quanti
                 backs=CardImageCollection(
                     cards_by_id={
                         "2": CardImage(
-                            drive_id="2", name="2.png", file_path=f"{FILE_PATH}/cards/2 (2).png", slots={0, 1}
+                            drive_id="2",
+                            name="2.png",
+                            file_path=os.path.join(CARDS_FILE_PATH, "2 (2).png"),
+                            slots={0, 1},
                         ),
                         "5": CardImage(
-                            drive_id="5", name="5.png", file_path=f"{FILE_PATH}/cards/5 (5).png", slots={2, 3}
+                            drive_id="5",
+                            name="5.png",
+                            file_path=os.path.join(CARDS_FILE_PATH, "5 (5).png"),
+                            slots={2, 3},
                         ),
                     },
                     num_slots=4,
@@ -1016,7 +1076,10 @@ def test_get_project_sizes_manually_specifying_sizes(
         fronts=CardImageCollection(
             cards_by_id={
                 "1": CardImage(
-                    drive_id="1", name="1.png", file_path=f"{FILE_PATH}/cards/1 (1).png", slots=set(range(5))
+                    drive_id="1",
+                    name="1.png",
+                    file_path=os.path.join(CARDS_FILE_PATH, "1 (1).png"),
+                    slots=set(range(5)),
                 )
             },
             num_slots=5,
@@ -1025,7 +1088,10 @@ def test_get_project_sizes_manually_specifying_sizes(
         backs=CardImageCollection(
             cards_by_id={
                 "2": CardImage(
-                    drive_id="2", name="2.png", file_path=f"{FILE_PATH}/cards/2 (2).png", slots=set(range(5))
+                    drive_id="2",
+                    name="2.png",
+                    file_path=os.path.join(CARDS_FILE_PATH, "2 (2).png"),
+                    slots=set(range(5)),
                 )
             },
             num_slots=5,
@@ -1048,7 +1114,10 @@ def test_get_project_sizes_manually_specifying_sizes_with_an_incorrect_attempt_f
         fronts=CardImageCollection(
             cards_by_id={
                 "1": CardImage(
-                    drive_id="1", name="1.png", file_path=f"{FILE_PATH}/cards/1 (1).png", slots=set(range(5))
+                    drive_id="1",
+                    name="1.png",
+                    file_path=os.path.join(CARDS_FILE_PATH, "1 (1).png"),
+                    slots=set(range(5)),
                 )
             },
             num_slots=5,
@@ -1057,7 +1126,10 @@ def test_get_project_sizes_manually_specifying_sizes_with_an_incorrect_attempt_f
         backs=CardImageCollection(
             cards_by_id={
                 "2": CardImage(
-                    drive_id="2", name="2.png", file_path=f"{FILE_PATH}/cards/2 (2).png", slots=set(range(5))
+                    drive_id="2",
+                    name="2.png",
+                    file_path=os.path.join(CARDS_FILE_PATH, "2 (2).png"),
+                    slots=set(range(5)),
                 )
             },
             num_slots=5,
@@ -1079,7 +1151,10 @@ def test_get_project_sizes_automatically_breaking_on_max_size(
         fronts=CardImageCollection(
             cards_by_id={
                 "1": CardImage(
-                    drive_id="1", name="1.png", file_path=f"{FILE_PATH}/cards/1 (1).png", slots=set(range(5))
+                    drive_id="1",
+                    name="1.png",
+                    file_path=os.path.join(CARDS_FILE_PATH, "1 (1).png"),
+                    slots=set(range(5)),
                 )
             },
             num_slots=5,
@@ -1088,7 +1163,10 @@ def test_get_project_sizes_automatically_breaking_on_max_size(
         backs=CardImageCollection(
             cards_by_id={
                 "2": CardImage(
-                    drive_id="2", name="2.png", file_path=f"{FILE_PATH}/cards/2 (2).png", slots=set(range(5))
+                    drive_id="2",
+                    name="2.png",
+                    file_path=os.path.join(CARDS_FILE_PATH, "2 (2).png"),
+                    slots=set(range(5)),
                 )
             },
             num_slots=5,
@@ -1112,7 +1190,7 @@ def test_get_project_sizes_automatically_breaking_on_max_size(
                             "1": CardImage(
                                 drive_id="1",
                                 name="1.png",
-                                file_path=f"{FILE_PATH}/cards/1 (1).png",
+                                file_path=os.path.join(CARDS_FILE_PATH, "1 (1).png"),
                                 slots=set(range(5)),
                             )
                         },
@@ -1124,7 +1202,7 @@ def test_get_project_sizes_automatically_breaking_on_max_size(
                             "2": CardImage(
                                 drive_id="2",
                                 name="2.png",
-                                file_path=f"{FILE_PATH}/cards/2 (2).png",
+                                file_path=os.path.join(CARDS_FILE_PATH, "2 (2).png"),
                                 slots=set(range(5)),
                             )
                         },
@@ -1139,7 +1217,7 @@ def test_get_project_sizes_automatically_breaking_on_max_size(
                             "1": CardImage(
                                 drive_id="1",
                                 name="1.png",
-                                file_path=f"{FILE_PATH}/cards/1 (1).png",
+                                file_path=os.path.join(CARDS_FILE_PATH, "1 (1).png"),
                                 slots=set(range(2)),
                             )
                         },
@@ -1151,7 +1229,7 @@ def test_get_project_sizes_automatically_breaking_on_max_size(
                             "2": CardImage(
                                 drive_id="2",
                                 name="2.png",
-                                file_path=f"{FILE_PATH}/cards/2 (2).png",
+                                file_path=os.path.join(CARDS_FILE_PATH, "2 (2).png"),
                                 slots=set(range(2)),
                             )
                         },
@@ -1168,7 +1246,7 @@ def test_get_project_sizes_automatically_breaking_on_max_size(
                             "1": CardImage(
                                 drive_id="1",
                                 name="1.png",
-                                file_path=f"{FILE_PATH}/cards/1 (1).png",
+                                file_path=os.path.join(CARDS_FILE_PATH, "1 (1).png"),
                                 slots=set(range(4)),
                             )
                         },
@@ -1180,7 +1258,7 @@ def test_get_project_sizes_automatically_breaking_on_max_size(
                             "2": CardImage(
                                 drive_id="2",
                                 name="2.png",
-                                file_path=f"{FILE_PATH}/cards/2 (2).png",
+                                file_path=os.path.join(CARDS_FILE_PATH, "2 (2).png"),
                                 slots=set(range(4)),
                             )
                         },
@@ -1195,7 +1273,7 @@ def test_get_project_sizes_automatically_breaking_on_max_size(
                             "1": CardImage(
                                 drive_id="1",
                                 name="1.png",
-                                file_path=f"{FILE_PATH}/cards/1 (1).png",
+                                file_path=os.path.join(CARDS_FILE_PATH, "1 (1).png"),
                                 slots=set(range(3)),
                             )
                         },
@@ -1207,7 +1285,7 @@ def test_get_project_sizes_automatically_breaking_on_max_size(
                             "2": CardImage(
                                 drive_id="2",
                                 name="2.png",
-                                file_path=f"{FILE_PATH}/cards/2 (2).png",
+                                file_path=os.path.join(CARDS_FILE_PATH, "2 (2).png"),
                                 slots=set(range(3)),
                             )
                         },

--- a/desktop-tool/tests/test_desktop_client.py
+++ b/desktop-tool/tests/test_desktop_client.py
@@ -45,12 +45,11 @@ def assert_card_images_identical(a: CardImage, b: CardImage) -> None:
 def assert_card_image_collections_identical(a: CardImageCollection, b: CardImageCollection) -> None:
     assert a.face == b.face, f"Face {a.face} does not match {b.face}"
     assert a.num_slots == b.num_slots, f"Number of slots {a.num_slots} does not match {b.num_slots}"
-    assert len(a.cards) == len(b.cards), f"Number of cards {len(a.cards)} does not match {len(b.cards)}"
-    for card_image_a, card_image_b in zip(
-        sorted(a.cards, key=lambda x: x.drive_id),
-        sorted(b.cards, key=lambda x: x.drive_id),
-    ):
-        assert_card_images_identical(card_image_a, card_image_b)
+    assert len(a.cards_by_id) == len(
+        b.cards_by_id
+    ), f"Number of cards {len(a.cards_by_id)} does not match {len(b.cards_by_id)}"
+    for card_image_id_a, card_image_id_b in zip(sorted(a.cards_by_id.keys()), sorted(b.cards_by_id.keys())):
+        assert_card_images_identical(a.cards_by_id[card_image_id_a], b.cards_by_id[card_image_id_b])
 
 
 def assert_details_identical(a: Details, b: Details) -> None:
@@ -603,13 +602,13 @@ def test_combine_images(image_a, image_b, expected_result):
 
 def test_card_image_collection_download(card_image_collection_valid, counter, image_google_valid_drive_no_name, pool):
     assert card_image_collection_valid.slots() == {0, 1, 2}
-    assert [x.file_exists() for x in card_image_collection_valid.cards] == [False, True]
+    assert [x.file_exists() for x in card_image_collection_valid.cards_by_id.values()] == [False, True]
     card_image_collection_valid.download_images(
         pool=pool, download_bar=counter, post_processing_config=DEFAULT_POST_PROCESSING
     )
     time.sleep(3)
     pool.shutdown(wait=True, cancel_futures=False)
-    assert all([x.file_exists() for x in card_image_collection_valid.cards])
+    assert all([x.file_exists() for x in card_image_collection_valid.cards_by_id.values()])
 
 
 def test_card_image_collection_no_cards(input_enter, card_image_collection_element_no_cards):
@@ -662,35 +661,35 @@ def test_card_order_valid(card_order_valid):
             fronts=CardImageCollection(
                 face=constants.Faces.front,
                 num_slots=3,
-                cards=[
-                    CardImage(
+                cards_by_id={
+                    SIMPLE_CUBE_ID: CardImage(
                         drive_id=SIMPLE_CUBE_ID,
                         slots={0},
                         name=f"{SIMPLE_CUBE}.png",
                         file_path=f"{FILE_PATH}/cards/{SIMPLE_CUBE} ({SIMPLE_CUBE_ID}).png",  # not on disk
                         query="simple cube",
                     ),
-                    CardImage(
+                    SIMPLE_LOTUS_ID: CardImage(
                         drive_id=SIMPLE_LOTUS_ID,
                         slots={1, 2},
                         name=f"{SIMPLE_LOTUS}.png",
                         file_path=f"{FILE_PATH}/cards/{SIMPLE_LOTUS}.png",  # already exists on disk
                         query="simple lotus",
                     ),
-                ],
+                },
             ),
             backs=CardImageCollection(
                 face=constants.Faces.back,
                 num_slots=3,
-                cards=[
-                    CardImage(
+                cards_by_id={
+                    f"{FILE_PATH}/cards/{TEST_IMAGE}.png": CardImage(
                         drive_id=f"{FILE_PATH}/cards/{TEST_IMAGE}.png",
                         slots={0, 1, 2},
                         name=f"{TEST_IMAGE}.png",  # name retrieved from file on disk
                         file_path=f"{FILE_PATH}/cards/{TEST_IMAGE}.png",
                         query=None,
                     )
-                ],
+                },
             ),
         ),
     )
@@ -708,42 +707,42 @@ def test_card_order_multiple_cardbacks(card_order_multiple_cardbacks):
             fronts=CardImageCollection(
                 face=constants.Faces.front,
                 num_slots=4,
-                cards=[
-                    CardImage(
+                cards_by_id={
+                    f"{FILE_PATH}/cards/{TEST_IMAGE}.png": CardImage(
                         drive_id=f"{FILE_PATH}/cards/{TEST_IMAGE}.png",
                         slots={0, 3},
                         name=f"{TEST_IMAGE}.png",  # name retrieved from file on disk
                         file_path=f"{FILE_PATH}/cards/{TEST_IMAGE}.png",
                         query=None,
                     ),
-                    CardImage(
+                    SIMPLE_LOTUS_ID: CardImage(
                         drive_id=SIMPLE_LOTUS_ID,
                         slots={1, 2},
                         name=f"{SIMPLE_LOTUS}.png",
                         file_path=f"{FILE_PATH}/cards/{SIMPLE_LOTUS}.png",  # already exists on disk
                         query="simple lotus",
                     ),
-                ],
+                },
             ),
             backs=CardImageCollection(
                 face=constants.Faces.back,
                 num_slots=4,
-                cards=[
-                    CardImage(
+                cards_by_id={
+                    SIMPLE_LOTUS_ID: CardImage(
                         drive_id=SIMPLE_LOTUS_ID,
                         slots={1},
                         name=f"{SIMPLE_LOTUS}.png",
                         file_path=f"{FILE_PATH}/cards/{SIMPLE_LOTUS}.png",  # already exists on disk
                         query="simple lotus",
                     ),
-                    CardImage(
+                    SIMPLE_CUBE_ID: CardImage(
                         drive_id=SIMPLE_CUBE_ID,
                         slots={0, 2, 3},
                         name=f"{SIMPLE_CUBE}.png",
                         file_path=f"{FILE_PATH}/cards/{SIMPLE_CUBE} ({SIMPLE_CUBE_ID}).png",  # not on disk
                         query=None,
                     ),
-                ],
+                },
             ),
         ),
     )
@@ -751,7 +750,7 @@ def test_card_order_multiple_cardbacks(card_order_multiple_cardbacks):
 
 def test_card_order_valid_from_file():
     card_order = CardOrder.from_file_name("test_order.xml")
-    for card in [*card_order.fronts.cards, *card_order.backs.cards]:
+    for card in (card_order.fronts.cards_by_id | card_order.backs.cards_by_id).values():
         assert not card.file_exists()
     assert_orders_identical(
         card_order,
@@ -764,35 +763,35 @@ def test_card_order_valid_from_file():
             fronts=CardImageCollection(
                 face=constants.Faces.front,
                 num_slots=10,
-                cards=[
-                    CardImage(
+                cards_by_id={
+                    "1OAw4l9RYbgYrmnyYeR1iVDoIS6_aus49": CardImage(
                         drive_id="1OAw4l9RYbgYrmnyYeR1iVDoIS6_aus49",
                         slots=set(range(9)),
                         name="Island (Unsanctioned).png",
                         file_path=f"{FILE_PATH}/cards/Island (Unsanctioned).png",
                         query="island",
                     ),
-                    CardImage(
+                    "1wlrM7pNHQ5NqS9GY5LWH7Hd04TtNgHI4": CardImage(
                         drive_id="1wlrM7pNHQ5NqS9GY5LWH7Hd04TtNgHI4",
                         slots={9},
                         name="Rite of Flame.png",
                         file_path=f"{FILE_PATH}/cards/Rite of Flame.png",
                         query="rite of flame",
                     ),
-                ],
+                },
             ),
             backs=CardImageCollection(
                 face=constants.Faces.back,
                 num_slots=10,
-                cards=[
-                    CardImage(
+                cards_by_id={
+                    "16g2UamJ2jzwNHovLesvsinvd6_qPkZfy": CardImage(
                         drive_id="16g2UamJ2jzwNHovLesvsinvd6_qPkZfy",
                         slots=set(range(10)),
                         name="MTGA Lotus.png",
                         file_path=f"{FILE_PATH}/cards/MTGA Lotus.png",
                         query=None,
                     )
-                ],
+                },
             ),
         ),
     )
@@ -819,12 +818,12 @@ def test_card_order_missing_slots(input_enter, card_order_element_invalid_quanti
                 CardOrder(
                     details=Details(quantity=2, stock=constants.Cardstocks.S30, foil=False),
                     fronts=CardImageCollection(
-                        cards=[CardImage(drive_id="1", name="1.png", slots={0, 1})],
+                        cards_by_id={"1": CardImage(drive_id="1", name="1.png", slots={0, 1})},
                         num_slots=2,
                         face=constants.Faces.front,
                     ),
                     backs=CardImageCollection(
-                        cards=[CardImage(drive_id="2", name="2.png", slots={0, 1})],
+                        cards_by_id={"2": CardImage(drive_id="2", name="2.png", slots={0, 1})},
                         num_slots=2,
                         face=constants.Faces.back,
                     ),
@@ -832,15 +831,15 @@ def test_card_order_missing_slots(input_enter, card_order_element_invalid_quanti
                 CardOrder(
                     details=Details(quantity=2, stock=constants.Cardstocks.S30, foil=False),
                     fronts=CardImageCollection(
-                        cards=[
-                            CardImage(drive_id="3", name="3.png", slots={0}),
-                            CardImage(drive_id="4", name="4.png", slots={1}),
-                        ],
+                        cards_by_id={
+                            "3": CardImage(drive_id="3", name="3.png", slots={0}),
+                            "4": CardImage(drive_id="4", name="4.png", slots={1}),
+                        },
                         num_slots=2,
                         face=constants.Faces.front,
                     ),
                     backs=CardImageCollection(
-                        cards=[CardImage(drive_id="2", name="2.png", slots={0, 1})],
+                        cards_by_id={"2": CardImage(drive_id="2", name="2.png", slots={0, 1})},
                         num_slots=2,
                         face=constants.Faces.back,
                     ),
@@ -850,19 +849,17 @@ def test_card_order_missing_slots(input_enter, card_order_element_invalid_quanti
             CardOrder(
                 details=Details(quantity=4, stock=constants.Cardstocks.S30, foil=False),
                 fronts=CardImageCollection(
-                    cards=[
-                        CardImage(drive_id="1", name="1.png", slots={0, 1}),
-                        CardImage(drive_id="3", name="3.png", slots={2}),
-                        CardImage(drive_id="4", name="4.png", slots={3}),
-                    ],
+                    cards_by_id={
+                        "1": CardImage(drive_id="1", name="1.png", slots={0, 1}),
+                        "3": CardImage(drive_id="3", name="3.png", slots={2}),
+                        "4": CardImage(drive_id="4", name="4.png", slots={3}),
+                    },
                     num_slots=4,
                     face=constants.Faces.front,
                 ),
                 backs=CardImageCollection(
-                    cards=[
-                        CardImage(drive_id="2", name="2.png", slots={0, 1}),
-                        CardImage(drive_id="2", name="2.png", slots={2, 3}),
-                    ],
+                    # the slots for `2` across both orders will be merged as below
+                    cards_by_id={"2": CardImage(drive_id="2", name="2.png", slots={0, 1, 2, 3})},
                     num_slots=4,
                     face=constants.Faces.back,
                 ),
@@ -876,12 +873,12 @@ def test_card_order_missing_slots(input_enter, card_order_element_invalid_quanti
                 CardOrder(
                     details=Details(quantity=2, stock=constants.Cardstocks.S30, foil=False),
                     fronts=CardImageCollection(
-                        cards=[CardImage(drive_id="1", name="1.png", slots={0, 1})],
+                        cards_by_id={"1": CardImage(drive_id="1", name="1.png", slots={0, 1})},
                         num_slots=2,
                         face=constants.Faces.front,
                     ),
                     backs=CardImageCollection(
-                        cards=[CardImage(drive_id="2", name="2.png", slots={0, 1})],
+                        cards_by_id={"2": CardImage(drive_id="2", name="2.png", slots={0, 1})},
                         num_slots=2,
                         face=constants.Faces.back,
                     ),
@@ -889,15 +886,15 @@ def test_card_order_missing_slots(input_enter, card_order_element_invalid_quanti
                 CardOrder(
                     details=Details(quantity=2, stock=constants.Cardstocks.S30, foil=False),
                     fronts=CardImageCollection(
-                        cards=[
-                            CardImage(drive_id="3", name="3.png", slots={0}),
-                            CardImage(drive_id="4", name="4.png", slots={1}),
-                        ],
+                        cards_by_id={
+                            "3": CardImage(drive_id="3", name="3.png", slots={0}),
+                            "4": CardImage(drive_id="4", name="4.png", slots={1}),
+                        },
                         num_slots=2,
                         face=constants.Faces.front,
                     ),
                     backs=CardImageCollection(
-                        cards=[CardImage(drive_id="5", name="5.png", slots={0, 1})],
+                        cards_by_id={"5": CardImage(drive_id="5", name="5.png", slots={0, 1})},
                         num_slots=2,
                         face=constants.Faces.back,
                     ),
@@ -907,19 +904,19 @@ def test_card_order_missing_slots(input_enter, card_order_element_invalid_quanti
             CardOrder(
                 details=Details(quantity=4, stock=constants.Cardstocks.S30, foil=False),
                 fronts=CardImageCollection(
-                    cards=[
-                        CardImage(drive_id="1", name="1.png", slots={0, 1}),
-                        CardImage(drive_id="3", name="3.png", slots={2}),
-                        CardImage(drive_id="4", name="4.png", slots={3}),
-                    ],
+                    cards_by_id={
+                        "1": CardImage(drive_id="1", name="1.png", slots={0, 1}),
+                        "3": CardImage(drive_id="3", name="3.png", slots={2}),
+                        "4": CardImage(drive_id="4", name="4.png", slots={3}),
+                    },
                     num_slots=4,
                     face=constants.Faces.front,
                 ),
                 backs=CardImageCollection(
-                    cards=[
-                        CardImage(drive_id="2", name="2.png", slots={0, 1}),
-                        CardImage(drive_id="5", name="5.png", slots={2, 3}),
-                    ],
+                    cards_by_id={
+                        "2": CardImage(drive_id="2", name="2.png", slots={0, 1}),
+                        "5": CardImage(drive_id="5", name="5.png", slots={2, 3}),
+                    },
                     num_slots=4,
                     face=constants.Faces.back,
                 ),
@@ -973,12 +970,12 @@ def test_get_project_sizes_manually_specifying_sizes(
     order = CardOrder(
         details=Details(quantity=5, stock=constants.Cardstocks.S30, foil=False),
         fronts=CardImageCollection(
-            cards=[CardImage(drive_id="1", name="1.png", slots=set(range(5)))],
+            cards_by_id={"1": CardImage(drive_id="1", name="1.png", slots=set(range(5)))},
             num_slots=5,
             face=constants.Faces.front,
         ),
         backs=CardImageCollection(
-            cards=[CardImage(drive_id="2", name="2.png", slots=set(range(5)))],
+            cards_by_id={"2": CardImage(drive_id="2", name="2.png", slots=set(range(5)))},
             num_slots=5,
             face=constants.Faces.back,
         ),
@@ -997,12 +994,12 @@ def test_get_project_sizes_manually_specifying_sizes_with_an_incorrect_attempt_f
     order = CardOrder(
         details=Details(quantity=5, stock=constants.Cardstocks.S30, foil=False),
         fronts=CardImageCollection(
-            cards=[CardImage(drive_id="1", name="1.png", slots=set(range(5)))],
+            cards_by_id={"1": CardImage(drive_id="1", name="1.png", slots=set(range(5)))},
             num_slots=5,
             face=constants.Faces.front,
         ),
         backs=CardImageCollection(
-            cards=[CardImage(drive_id="2", name="2.png", slots=set(range(5)))],
+            cards_by_id={"2": CardImage(drive_id="2", name="2.png", slots=set(range(5)))},
             num_slots=5,
             face=constants.Faces.back,
         ),
@@ -1020,12 +1017,12 @@ def test_get_project_sizes_automatically_breaking_on_max_size(
     order = CardOrder(
         details=Details(quantity=5, stock=constants.Cardstocks.S30, foil=False),
         fronts=CardImageCollection(
-            cards=[CardImage(drive_id="1", name="1.png", slots=set(range(5)))],
+            cards_by_id={"1": CardImage(drive_id="1", name="1.png", slots=set(range(5)))},
             num_slots=5,
             face=constants.Faces.front,
         ),
         backs=CardImageCollection(
-            cards=[CardImage(drive_id="2", name="2.png", slots=set(range(5)))],
+            cards_by_id={"2": CardImage(drive_id="2", name="2.png", slots=set(range(5)))},
             num_slots=5,
             face=constants.Faces.back,
         ),
@@ -1043,12 +1040,12 @@ def test_get_project_sizes_automatically_breaking_on_max_size(
                 CardOrder(
                     details=Details(quantity=5, stock=constants.Cardstocks.S30, foil=False),
                     fronts=CardImageCollection(
-                        cards=[CardImage(drive_id="1", name="1.png", slots=set(range(5)))],
+                        cards_by_id={"1": CardImage(drive_id="1", name="1.png", slots=set(range(5)))},
                         num_slots=5,
                         face=constants.Faces.front,
                     ),
                     backs=CardImageCollection(
-                        cards=[CardImage(drive_id="2", name="2.png", slots=set(range(5)))],
+                        cards_by_id={"2": CardImage(drive_id="2", name="2.png", slots=set(range(5)))},
                         num_slots=5,
                         face=constants.Faces.back,
                     ),
@@ -1056,12 +1053,12 @@ def test_get_project_sizes_automatically_breaking_on_max_size(
                 CardOrder(
                     details=Details(quantity=2, stock=constants.Cardstocks.S30, foil=False),
                     fronts=CardImageCollection(
-                        cards=[CardImage(drive_id="1", name="1.png", slots=set(range(2)))],
+                        cards_by_id={"1": CardImage(drive_id="1", name="1.png", slots=set(range(2)))},
                         num_slots=2,
                         face=constants.Faces.front,
                     ),
                     backs=CardImageCollection(
-                        cards=[CardImage(drive_id="2", name="2.png", slots=set(range(2)))],
+                        cards_by_id={"2": CardImage(drive_id="2", name="2.png", slots=set(range(2)))},
                         num_slots=2,
                         face=constants.Faces.back,
                     ),
@@ -1071,12 +1068,12 @@ def test_get_project_sizes_automatically_breaking_on_max_size(
                 CardOrder(
                     details=Details(quantity=4, stock=constants.Cardstocks.S30, foil=False),
                     fronts=CardImageCollection(
-                        cards=[CardImage(drive_id="1", name="1.png", slots=set(range(4)))],
+                        cards_by_id={"1": CardImage(drive_id="1", name="1.png", slots=set(range(4)))},
                         num_slots=4,
                         face=constants.Faces.front,
                     ),
                     backs=CardImageCollection(
-                        cards=[CardImage(drive_id="2", name="2.png", slots=set(range(4)))],
+                        cards_by_id={"2": CardImage(drive_id="2", name="2.png", slots=set(range(4)))},
                         num_slots=4,
                         face=constants.Faces.back,
                     ),
@@ -1084,12 +1081,12 @@ def test_get_project_sizes_automatically_breaking_on_max_size(
                 CardOrder(
                     details=Details(quantity=3, stock=constants.Cardstocks.S30, foil=False),
                     fronts=CardImageCollection(
-                        cards=[CardImage(drive_id="1", name="1.png", slots=set(range(3)))],
+                        cards_by_id={"1": CardImage(drive_id="1", name="1.png", slots=set(range(3)))},
                         num_slots=3,
                         face=constants.Faces.front,
                     ),
                     backs=CardImageCollection(
-                        cards=[CardImage(drive_id="2", name="2.png", slots=set(range(3)))],
+                        cards_by_id={"2": CardImage(drive_id="2", name="2.png", slots=set(range(3)))},
                         num_slots=3,
                         face=constants.Faces.back,
                     ),

--- a/desktop-tool/tests/test_desktop_client.py
+++ b/desktop-tool/tests/test_desktop_client.py
@@ -663,7 +663,7 @@ def test_card_order_valid(card_order_valid):
                 cards=[
                     CardImage(
                         drive_id=f"{FILE_PATH}/cards/{TEST_IMAGE}.png",
-                        slots=[0],  # for orders with a single back image, the back image is only assigned to slot 0
+                        slots=[0, 1, 2],
                         name=f"{TEST_IMAGE}.png",  # name retrieved from file on disk
                         file_path=f"{FILE_PATH}/cards/{TEST_IMAGE}.png",
                         query=None,
@@ -765,7 +765,7 @@ def test_card_order_valid_from_file():
                 cards=[
                     CardImage(
                         drive_id="16g2UamJ2jzwNHovLesvsinvd6_qPkZfy",
-                        slots=[0],  # for orders with a single back image, the back image is only assigned to slot 0
+                        slots=list(range(10)),
                         name="MTGA Lotus.png",
                         file_path=f"{FILE_PATH}/cards/MTGA Lotus.png",
                         query=None,

--- a/desktop-tool/tests/test_desktop_client.py
+++ b/desktop-tool/tests/test_desktop_client.py
@@ -582,6 +582,20 @@ def test_generate_google_drive_file_path(image_valid_google_drive):
     assert not image_valid_google_drive.file_exists()
 
 
+@pytest.mark.parametrize(
+    "image_a, image_b, expected_result",
+    [
+        (
+            CardImage(drive_id="1", name="a.jpg", slots={1, 2}),
+            CardImage(drive_id="1", name="a.jpg", slots={2, 3}),
+            CardImage(drive_id="1", name="a.jpg", slots={1, 2, 3}),
+        )
+    ],
+)
+def test_combine_images(image_a, image_b, expected_result):
+    assert_card_images_identical(image_a.combine(image_b), expected_result)
+
+
 # endregion
 
 # region test CardImageCollection

--- a/desktop-tool/tests/test_desktop_client.py
+++ b/desktop-tool/tests/test_desktop_client.py
@@ -1320,7 +1320,6 @@ def test_pdf_export_complete_separate_faces(monkeypatch, card_order_valid):
 # region test driver.py
 
 
-@pytest.mark.skip()
 @pytest.mark.flaky(retries=3, delay=1)
 @pytest.mark.parametrize("browser", [constants.Browsers.chrome, constants.Browsers.edge])
 @pytest.mark.parametrize(
@@ -1350,7 +1349,6 @@ def test_card_order_complete_run_single_cardback(browser, site, input_enter, car
     )
 
 
-@pytest.mark.skip()
 @pytest.mark.flaky(retries=3, delay=1)
 @pytest.mark.parametrize("browser", [constants.Browsers.chrome, constants.Browsers.edge])
 @pytest.mark.parametrize(

--- a/desktop-tool/tests/test_desktop_client.py
+++ b/desktop-tool/tests/test_desktop_client.py
@@ -26,7 +26,7 @@ from src.order import (
 )
 from src.pdf_maker import PdfExporter
 from src.processing import ImagePostProcessingConfig
-from src.utils import text_to_list
+from src.utils import text_to_set
 
 DEFAULT_POST_PROCESSING = ImagePostProcessingConfig(max_dpi=800, downscale_alg=constants.ImageResizeMethods.LANCZOS)
 
@@ -504,11 +504,11 @@ def test_get_google_drive_file_name():
     assert get_google_drive_file_name("") is None
 
 
-def test_text_to_list():
-    assert text_to_list("[1, 2, 3]") == [1, 2, 3]
-    assert text_to_list("[1,2,3]") == [1, 2, 3]
-    assert text_to_list("1, 2, 3") == [1, 2, 3]
-    assert text_to_list("") == []
+def test_text_to_set():
+    assert text_to_set("[1, 2, 3]") == {1, 2, 3}
+    assert text_to_set("[1,2,3]") == {1, 2, 3}
+    assert text_to_set("1, 2, 3") == {1, 2, 3}
+    assert text_to_set("") == set()
 
 
 # endregion
@@ -651,14 +651,14 @@ def test_card_order_valid(card_order_valid):
                 cards=[
                     CardImage(
                         drive_id=SIMPLE_CUBE_ID,
-                        slots=[0],
+                        slots={0},
                         name=f"{SIMPLE_CUBE}.png",
                         file_path=f"{FILE_PATH}/cards/{SIMPLE_CUBE} ({SIMPLE_CUBE_ID}).png",  # not on disk
                         query="simple cube",
                     ),
                     CardImage(
                         drive_id=SIMPLE_LOTUS_ID,
-                        slots=[1, 2],
+                        slots={1, 2},
                         name=f"{SIMPLE_LOTUS}.png",
                         file_path=f"{FILE_PATH}/cards/{SIMPLE_LOTUS}.png",  # already exists on disk
                         query="simple lotus",
@@ -671,7 +671,7 @@ def test_card_order_valid(card_order_valid):
                 cards=[
                     CardImage(
                         drive_id=f"{FILE_PATH}/cards/{TEST_IMAGE}.png",
-                        slots=[0, 1, 2],
+                        slots={0, 1, 2},
                         name=f"{TEST_IMAGE}.png",  # name retrieved from file on disk
                         file_path=f"{FILE_PATH}/cards/{TEST_IMAGE}.png",
                         query=None,
@@ -697,14 +697,14 @@ def test_card_order_multiple_cardbacks(card_order_multiple_cardbacks):
                 cards=[
                     CardImage(
                         drive_id=f"{FILE_PATH}/cards/{TEST_IMAGE}.png",
-                        slots=[0, 3],
+                        slots={0, 3},
                         name=f"{TEST_IMAGE}.png",  # name retrieved from file on disk
                         file_path=f"{FILE_PATH}/cards/{TEST_IMAGE}.png",
                         query=None,
                     ),
                     CardImage(
                         drive_id=SIMPLE_LOTUS_ID,
-                        slots=[1, 2],
+                        slots={1, 2},
                         name=f"{SIMPLE_LOTUS}.png",
                         file_path=f"{FILE_PATH}/cards/{SIMPLE_LOTUS}.png",  # already exists on disk
                         query="simple lotus",
@@ -717,14 +717,14 @@ def test_card_order_multiple_cardbacks(card_order_multiple_cardbacks):
                 cards=[
                     CardImage(
                         drive_id=SIMPLE_LOTUS_ID,
-                        slots=[1],
+                        slots={1},
                         name=f"{SIMPLE_LOTUS}.png",
                         file_path=f"{FILE_PATH}/cards/{SIMPLE_LOTUS}.png",  # already exists on disk
                         query="simple lotus",
                     ),
                     CardImage(
                         drive_id=SIMPLE_CUBE_ID,
-                        slots=[0, 2, 3],
+                        slots={0, 2, 3},
                         name=f"{SIMPLE_CUBE}.png",
                         file_path=f"{FILE_PATH}/cards/{SIMPLE_CUBE} ({SIMPLE_CUBE_ID}).png",  # not on disk
                         query=None,
@@ -753,14 +753,14 @@ def test_card_order_valid_from_file():
                 cards=[
                     CardImage(
                         drive_id="1OAw4l9RYbgYrmnyYeR1iVDoIS6_aus49",
-                        slots=list(range(9)),
+                        slots=set(range(9)),
                         name="Island (Unsanctioned).png",
                         file_path=f"{FILE_PATH}/cards/Island (Unsanctioned).png",
                         query="island",
                     ),
                     CardImage(
                         drive_id="1wlrM7pNHQ5NqS9GY5LWH7Hd04TtNgHI4",
-                        slots=[9],
+                        slots={9},
                         name="Rite of Flame.png",
                         file_path=f"{FILE_PATH}/cards/Rite of Flame.png",
                         query="rite of flame",
@@ -773,7 +773,7 @@ def test_card_order_valid_from_file():
                 cards=[
                     CardImage(
                         drive_id="16g2UamJ2jzwNHovLesvsinvd6_qPkZfy",
-                        slots=list(range(10)),
+                        slots=set(range(10)),
                         name="MTGA Lotus.png",
                         file_path=f"{FILE_PATH}/cards/MTGA Lotus.png",
                         query=None,
@@ -805,12 +805,12 @@ def test_card_order_missing_slots(input_enter, card_order_element_invalid_quanti
                 CardOrder(
                     details=Details(quantity=2, stock=constants.Cardstocks.S30, foil=False),
                     fronts=CardImageCollection(
-                        cards=[CardImage(drive_id="1", name="1.png", slots=[0, 1])],
+                        cards=[CardImage(drive_id="1", name="1.png", slots={0, 1})],
                         num_slots=2,
                         face=constants.Faces.front,
                     ),
                     backs=CardImageCollection(
-                        cards=[CardImage(drive_id="2", name="2.png", slots=[0, 1])],
+                        cards=[CardImage(drive_id="2", name="2.png", slots={0, 1})],
                         num_slots=2,
                         face=constants.Faces.back,
                     ),
@@ -819,14 +819,14 @@ def test_card_order_missing_slots(input_enter, card_order_element_invalid_quanti
                     details=Details(quantity=2, stock=constants.Cardstocks.S30, foil=False),
                     fronts=CardImageCollection(
                         cards=[
-                            CardImage(drive_id="3", name="3.png", slots=[0]),
-                            CardImage(drive_id="4", name="4.png", slots=[1]),
+                            CardImage(drive_id="3", name="3.png", slots={0}),
+                            CardImage(drive_id="4", name="4.png", slots={1}),
                         ],
                         num_slots=2,
                         face=constants.Faces.front,
                     ),
                     backs=CardImageCollection(
-                        cards=[CardImage(drive_id="2", name="2.png", slots=[0, 1])],
+                        cards=[CardImage(drive_id="2", name="2.png", slots={0, 1})],
                         num_slots=2,
                         face=constants.Faces.back,
                     ),
@@ -837,17 +837,17 @@ def test_card_order_missing_slots(input_enter, card_order_element_invalid_quanti
                 details=Details(quantity=4, stock=constants.Cardstocks.S30, foil=False),
                 fronts=CardImageCollection(
                     cards=[
-                        CardImage(drive_id="1", name="1.png", slots=[0, 1]),
-                        CardImage(drive_id="3", name="3.png", slots=[2]),
-                        CardImage(drive_id="4", name="4.png", slots=[3]),
+                        CardImage(drive_id="1", name="1.png", slots={0, 1}),
+                        CardImage(drive_id="3", name="3.png", slots={2}),
+                        CardImage(drive_id="4", name="4.png", slots={3}),
                     ],
                     num_slots=4,
                     face=constants.Faces.front,
                 ),
                 backs=CardImageCollection(
                     cards=[
-                        CardImage(drive_id="2", name="2.png", slots=[0, 1]),
-                        CardImage(drive_id="2", name="2.png", slots=[2, 3]),
+                        CardImage(drive_id="2", name="2.png", slots={0, 1}),
+                        CardImage(drive_id="2", name="2.png", slots={2, 3}),
                     ],
                     num_slots=4,
                     face=constants.Faces.back,
@@ -862,12 +862,12 @@ def test_card_order_missing_slots(input_enter, card_order_element_invalid_quanti
                 CardOrder(
                     details=Details(quantity=2, stock=constants.Cardstocks.S30, foil=False),
                     fronts=CardImageCollection(
-                        cards=[CardImage(drive_id="1", name="1.png", slots=[0, 1])],
+                        cards=[CardImage(drive_id="1", name="1.png", slots={0, 1})],
                         num_slots=2,
                         face=constants.Faces.front,
                     ),
                     backs=CardImageCollection(
-                        cards=[CardImage(drive_id="2", name="2.png", slots=[0, 1])],
+                        cards=[CardImage(drive_id="2", name="2.png", slots={0, 1})],
                         num_slots=2,
                         face=constants.Faces.back,
                     ),
@@ -876,14 +876,14 @@ def test_card_order_missing_slots(input_enter, card_order_element_invalid_quanti
                     details=Details(quantity=2, stock=constants.Cardstocks.S30, foil=False),
                     fronts=CardImageCollection(
                         cards=[
-                            CardImage(drive_id="3", name="3.png", slots=[0]),
-                            CardImage(drive_id="4", name="4.png", slots=[1]),
+                            CardImage(drive_id="3", name="3.png", slots={0}),
+                            CardImage(drive_id="4", name="4.png", slots={1}),
                         ],
                         num_slots=2,
                         face=constants.Faces.front,
                     ),
                     backs=CardImageCollection(
-                        cards=[CardImage(drive_id="5", name="5.png", slots=[0, 1])],
+                        cards=[CardImage(drive_id="5", name="5.png", slots={0, 1})],
                         num_slots=2,
                         face=constants.Faces.back,
                     ),
@@ -894,17 +894,17 @@ def test_card_order_missing_slots(input_enter, card_order_element_invalid_quanti
                 details=Details(quantity=4, stock=constants.Cardstocks.S30, foil=False),
                 fronts=CardImageCollection(
                     cards=[
-                        CardImage(drive_id="1", name="1.png", slots=[0, 1]),
-                        CardImage(drive_id="3", name="3.png", slots=[2]),
-                        CardImage(drive_id="4", name="4.png", slots=[3]),
+                        CardImage(drive_id="1", name="1.png", slots={0, 1}),
+                        CardImage(drive_id="3", name="3.png", slots={2}),
+                        CardImage(drive_id="4", name="4.png", slots={3}),
                     ],
                     num_slots=4,
                     face=constants.Faces.front,
                 ),
                 backs=CardImageCollection(
                     cards=[
-                        CardImage(drive_id="2", name="2.png", slots=[0, 1]),
-                        CardImage(drive_id="5", name="5.png", slots=[2, 3]),
+                        CardImage(drive_id="2", name="2.png", slots={0, 1}),
+                        CardImage(drive_id="5", name="5.png", slots={2, 3}),
                     ],
                     num_slots=4,
                     face=constants.Faces.back,
@@ -959,12 +959,12 @@ def test_get_project_sizes_manually_specifying_sizes(
     order = CardOrder(
         details=Details(quantity=5, stock=constants.Cardstocks.S30, foil=False),
         fronts=CardImageCollection(
-            cards=[CardImage(drive_id="1", name="1.png", slots=list(range(5)))],
+            cards=[CardImage(drive_id="1", name="1.png", slots=set(range(5)))],
             num_slots=5,
             face=constants.Faces.front,
         ),
         backs=CardImageCollection(
-            cards=[CardImage(drive_id="2", name="2.png", slots=list(range(5)))],
+            cards=[CardImage(drive_id="2", name="2.png", slots=set(range(5)))],
             num_slots=5,
             face=constants.Faces.back,
         ),
@@ -983,12 +983,12 @@ def test_get_project_sizes_manually_specifying_sizes_with_an_incorrect_attempt_f
     order = CardOrder(
         details=Details(quantity=5, stock=constants.Cardstocks.S30, foil=False),
         fronts=CardImageCollection(
-            cards=[CardImage(drive_id="1", name="1.png", slots=list(range(5)))],
+            cards=[CardImage(drive_id="1", name="1.png", slots=set(range(5)))],
             num_slots=5,
             face=constants.Faces.front,
         ),
         backs=CardImageCollection(
-            cards=[CardImage(drive_id="2", name="2.png", slots=list(range(5)))],
+            cards=[CardImage(drive_id="2", name="2.png", slots=set(range(5)))],
             num_slots=5,
             face=constants.Faces.back,
         ),
@@ -1006,12 +1006,12 @@ def test_get_project_sizes_automatically_breaking_on_max_size(
     order = CardOrder(
         details=Details(quantity=5, stock=constants.Cardstocks.S30, foil=False),
         fronts=CardImageCollection(
-            cards=[CardImage(drive_id="1", name="1.png", slots=list(range(5)))],
+            cards=[CardImage(drive_id="1", name="1.png", slots=set(range(5)))],
             num_slots=5,
             face=constants.Faces.front,
         ),
         backs=CardImageCollection(
-            cards=[CardImage(drive_id="2", name="2.png", slots=list(range(5)))],
+            cards=[CardImage(drive_id="2", name="2.png", slots=set(range(5)))],
             num_slots=5,
             face=constants.Faces.back,
         ),
@@ -1029,12 +1029,12 @@ def test_get_project_sizes_automatically_breaking_on_max_size(
                 CardOrder(
                     details=Details(quantity=5, stock=constants.Cardstocks.S30, foil=False),
                     fronts=CardImageCollection(
-                        cards=[CardImage(drive_id="1", name="1.png", slots=list(range(5)))],
+                        cards=[CardImage(drive_id="1", name="1.png", slots=set(range(5)))],
                         num_slots=5,
                         face=constants.Faces.front,
                     ),
                     backs=CardImageCollection(
-                        cards=[CardImage(drive_id="2", name="2.png", slots=list(range(5)))],
+                        cards=[CardImage(drive_id="2", name="2.png", slots=set(range(5)))],
                         num_slots=5,
                         face=constants.Faces.back,
                     ),
@@ -1042,12 +1042,12 @@ def test_get_project_sizes_automatically_breaking_on_max_size(
                 CardOrder(
                     details=Details(quantity=2, stock=constants.Cardstocks.S30, foil=False),
                     fronts=CardImageCollection(
-                        cards=[CardImage(drive_id="1", name="1.png", slots=list(range(2)))],
+                        cards=[CardImage(drive_id="1", name="1.png", slots=set(range(2)))],
                         num_slots=2,
                         face=constants.Faces.front,
                     ),
                     backs=CardImageCollection(
-                        cards=[CardImage(drive_id="2", name="2.png", slots=list(range(2)))],
+                        cards=[CardImage(drive_id="2", name="2.png", slots=set(range(2)))],
                         num_slots=2,
                         face=constants.Faces.back,
                     ),
@@ -1057,12 +1057,12 @@ def test_get_project_sizes_automatically_breaking_on_max_size(
                 CardOrder(
                     details=Details(quantity=4, stock=constants.Cardstocks.S30, foil=False),
                     fronts=CardImageCollection(
-                        cards=[CardImage(drive_id="1", name="1.png", slots=list(range(4)))],
+                        cards=[CardImage(drive_id="1", name="1.png", slots=set(range(4)))],
                         num_slots=4,
                         face=constants.Faces.front,
                     ),
                     backs=CardImageCollection(
-                        cards=[CardImage(drive_id="2", name="2.png", slots=list(range(4)))],
+                        cards=[CardImage(drive_id="2", name="2.png", slots=set(range(4)))],
                         num_slots=4,
                         face=constants.Faces.back,
                     ),
@@ -1070,12 +1070,12 @@ def test_get_project_sizes_automatically_breaking_on_max_size(
                 CardOrder(
                     details=Details(quantity=3, stock=constants.Cardstocks.S30, foil=False),
                     fronts=CardImageCollection(
-                        cards=[CardImage(drive_id="1", name="1.png", slots=list(range(3)))],
+                        cards=[CardImage(drive_id="1", name="1.png", slots=set(range(3)))],
                         num_slots=3,
                         face=constants.Faces.front,
                     ),
                     backs=CardImageCollection(
-                        cards=[CardImage(drive_id="2", name="2.png", slots=list(range(3)))],
+                        cards=[CardImage(drive_id="2", name="2.png", slots=set(range(3)))],
                         num_slots=3,
                         face=constants.Faces.back,
                     ),

--- a/desktop-tool/tests/test_desktop_client.py
+++ b/desktop-tool/tests/test_desktop_client.py
@@ -869,8 +869,13 @@ def test_pdf_export_complete_separate_faces(monkeypatch, card_order_valid):
     ],
 )
 def test_card_order_complete_run_single_cardback(browser, site, input_enter, card_order_valid):
-    autofill_driver = AutofillDriver(order=card_order_valid, browser=browser, target_site=site, headless=True)
-    autofill_driver.execute(skip_setup=False, auto_save_threshold=None, post_processing_config=DEFAULT_POST_PROCESSING)
+    autofill_driver = AutofillDriver(browser=browser, target_site=site, headless=True)
+    autofill_driver.execute_order(
+        order=card_order_valid,
+        skip_setup=False,
+        auto_save_threshold=None,
+        post_processing_config=DEFAULT_POST_PROCESSING,
+    )
     assert (
         len(
             WebDriverWait(autofill_driver.driver, 30).until(
@@ -893,10 +898,13 @@ def test_card_order_complete_run_single_cardback(browser, site, input_enter, car
     ],
 )
 def test_card_order_complete_run_multiple_cardbacks(browser, site, input_enter, card_order_multiple_cardbacks):
-    autofill_driver = AutofillDriver(
-        order=card_order_multiple_cardbacks, browser=browser, target_site=site, headless=True
+    autofill_driver = AutofillDriver(browser=browser, target_site=site, headless=True)
+    autofill_driver.execute_order(
+        order=card_order_multiple_cardbacks,
+        skip_setup=False,
+        auto_save_threshold=None,
+        post_processing_config=DEFAULT_POST_PROCESSING,
     )
-    autofill_driver.execute(skip_setup=False, auto_save_threshold=None, post_processing_config=DEFAULT_POST_PROCESSING)
     assert (
         len(
             WebDriverWait(autofill_driver.driver, 30).until(


### PR DESCRIPTION
# Description
- Resolves #65
- This is an enhanced iteration of the functionality added in #103 - I decided to take this in a bit of a different direction to that PR's implementation (though I looked to it for inspiration).
- Key functionality:
  - The XML file select now allows selecting multiple files rather than one
  - XML files can be arbitrarily large
    - There will probably be a frontend PR which removes the 612 card limit - problem for another day
      - The blocker here is slow performance with massive projects
  - Selected XML files are aggregated and then split back out
    - We identify projects which can be aggregated by their specified stock & finish settings
    - For example, consider a 400 card nonfoil S30 XML and a 300 card nonfoil S30 XML - the tool would aggregate these into a single 700 card nonfoil S30 project
    - The tool will then split these projects back up such that each of them fit with the max project size of 612 cards, in one of two ways:
      - Naively splitting every 612 cards, or
      - Asking the user to type in their desired splits
        - This captures the case where the user happens to know it's cheaper to split up the cards differently to the naive approach
  - The tool will then run in a loop on each aggregated-then-split-back-out project
    - The user specifies whether to continue editing an existing order or create a new one per-aggregated project

# Checklist

- [x] I have installed `pre-commit` and installed the hooks with `pre-commit install` before creating any commits.
- [x] I have updated any related tests for code I modified or added new tests where appropriate.
- [x] Thorough manual testing
- [ ] I have updated any relevant documentation or created new documentation where appropriate.
  - On the todo list - unfortunately, github wikis are (kind of?) sub-repositories so I can't update the docs in this PR