### PR TITLE
Add modal for guiding users once they've finished their project

### DIFF
--- a/frontend/src/app/app.tsx
+++ b/frontend/src/app/app.tsx
@@ -16,6 +16,7 @@ import { SelectedImagesRibbon } from "@/features/bulkManagement/bulkManagementRi
 import { CardGrid } from "@/features/card/cardGrid";
 import { CommonCardback } from "@/features/card/commonCardback";
 import { Export } from "@/features/export/export";
+import { FinishedMyProject } from "@/features/export/finishedMyProjectModal";
 import { FinishSettings } from "@/features/finishSettings/finishSettings";
 import { Import } from "@/features/import/import";
 import {
@@ -98,15 +99,16 @@ function App() {
             <Row className="g-0 pt-2">
               <SearchSettings />
             </Row>
-            <Row className="g-0 py-2">
-              <Col lg={6} md={12} sm={12} xs={12}>
+            <Row className="g-0 pt-2">
+              <Col lg={7} md={12} sm={12} xs={12}>
                 <Import />
               </Col>
-              <Col lg={6} md={12} sm={12} xs={12}>
+              <Col lg={5} md={12} sm={12} xs={12}>
                 <Export />
               </Col>
+              <FinishedMyProject />
             </Row>
-            <Col className="g-0" lg={{ span: 8, offset: 2 }} md={12}>
+            <Col className="g-0 pt-2" lg={{ span: 8, offset: 2 }} md={12}>
               <CommonCardback selectedImage={cardback} />
             </Col>
           </OverflowCol>

--- a/frontend/src/common/types.ts
+++ b/frontend/src/common/types.ts
@@ -242,7 +242,8 @@ export type Modals =
   | "changeQuery"
   | "supportDeveloper"
   | "supportBackend"
-  | "invalidIdentifiers";
+  | "invalidIdentifiers"
+  | "finishedMyProject";
 
 export interface ModalsState {
   card: CardDocument | null;

--- a/frontend/src/features/export/export.tsx
+++ b/frontend/src/features/export/export.tsx
@@ -10,14 +10,14 @@ export function Export() {
   return (
     <Dropdown>
       <div className="d-grid gap-0">
-        <Dropdown.Toggle variant="success" id="dropdown-basic">
+        <Dropdown.Toggle variant="secondary" id="dropdown-basic">
           <RightPaddedIcon bootstrapIconName="cloud-arrow-down" /> Download
         </Dropdown.Toggle>
       </div>
       <Dropdown.Menu>
-        <ExportDecklist />
         <ExportXML />
         <ExportImages />
+        <ExportDecklist />
       </Dropdown.Menu>
     </Dropdown>
   );

--- a/frontend/src/features/export/exportXML.tsx
+++ b/frontend/src/features/export/exportXML.tsx
@@ -207,30 +207,26 @@ export function generateXML(
   return formatXML(xml, { collapseContent: true });
 }
 
-export function ExportXML() {
-  //# region queries and hooks
-
+export function useExportXML() {
   const store = useStore();
-  const isProjectEmpty = useAppSelector(selectIsProjectEmpty);
 
-  //# endregion
-
-  //# region callbacks
-
-  const downloadFile = () => {
+  return () => {
     const generatedXML = selectGeneratedXML(store.getState() as RootState);
     saveAs(
       new Blob([generatedXML], { type: "text/xml;charset=utf-8" }),
       "cards.xml"
     );
   };
+}
 
-  //# endregion
+export function ExportXML() {
+  const exportXML = useExportXML();
+  const isProjectEmpty = useAppSelector(selectIsProjectEmpty);
 
   return (
     <Dropdown.Item
       disabled={isProjectEmpty}
-      onClick={downloadFile}
+      onClick={exportXML}
       data-testid="export-xml-button"
     >
       <RightPaddedIcon bootstrapIconName="file-code" /> XML

--- a/frontend/src/features/export/finishedMyProjectModal.tsx
+++ b/frontend/src/features/export/finishedMyProjectModal.tsx
@@ -1,0 +1,269 @@
+import React, { useId } from "react";
+import Alert from "react-bootstrap/Alert";
+import Button from "react-bootstrap/Button";
+import Col from "react-bootstrap/Col";
+import Modal from "react-bootstrap/Modal";
+import Row from "react-bootstrap/Row";
+import styled from "styled-components";
+
+import { MakePlayingCards, MakePlayingCardsURL } from "@/common/constants";
+import { useAppDispatch, useAppSelector } from "@/common/types";
+import { Coffee } from "@/components/coffee";
+import { RightPaddedIcon } from "@/components/icon";
+import { useProjectName } from "@/features/backend/backendSlice";
+import { useExportXML } from "@/features/export/exportXML";
+import { showModal } from "@/features/modals/modalsSlice";
+import { selectIsProjectEmpty } from "@/features/project/projectSlice";
+
+interface ExitModal {
+  show: boolean;
+  handleClose: {
+    (): void;
+    (event: React.MouseEvent<HTMLButtonElement, MouseEvent>): void;
+  };
+}
+
+const BigOL = styled.ol`
+  list-style-type: none;
+`;
+
+const BigLI = styled.li`
+  counter-increment: step-counter;
+  position: relative;
+  padding: 10px 10px;
+  &::before {
+    content: counter(step-counter);
+    color: white;
+    font-size: 1.5rem;
+    position: absolute;
+    --size: 32px;
+    left: calc(-1 * var(--size) - 2px);
+    line-height: var(--size);
+    width: var(--size);
+    height: var(--size);
+    border-radius: 50%;
+    border: white 1px solid;
+    text-align: center;
+  }
+`;
+
+const DownloadButton = styled(Col)`
+  text-align: center;
+  border-color: lightblue;
+  border-width: 2px;
+  border-style: solid;
+  border-radius: 6px;
+  padding-top: 10px;
+  padding-bottom: 10px;
+  transition: background-color 0.15s ease-in-out;
+  background-color: rgba(0, 0, 0, 0);
+  &:hover {
+    background-color: rgba(255, 255, 255, 0.7);
+  }
+  cursor: pointer;
+`;
+
+const DownloadButtonLink = styled.a`
+  &:link {
+    color: white;
+    text-decoration: none;
+  }
+  &:visited {
+    color: white;
+    text-decoration: none;
+  }
+  &:not([href]) {
+    color: white;
+    text-decoration: none;
+  }
+`;
+
+function ProjectDownload() {
+  const exportXML = useExportXML();
+  const projectName = useProjectName();
+  return (
+    <>
+      <p>
+        An XML file is a snapshot of all the cards and image versions you
+        selected. Our desktop tool reads this file and automatically turns it
+        into an order with {MakePlayingCards}.
+      </p>
+      <p>
+        You also can <b>re-upload</b> your XML file to {projectName} and{" "}
+        <b>continue editing it later</b>!
+      </p>
+      <Row>
+        <Col md={{ span: 8, offset: 2 }} sm={12}>
+          <DownloadButton onClick={exportXML}>
+            <DownloadButtonLink>
+              <h1 className="bi bi-file-code"></h1>
+              <h4>Download Project as XML</h4>
+            </DownloadButtonLink>
+          </DownloadButton>
+        </Col>
+      </Row>
+    </>
+  );
+}
+
+function PlatformDownload({
+  downloadURLSuffix,
+  platformName,
+  icon,
+}: {
+  downloadURLSuffix: "windows.exe" | "macos" | "linux";
+  platformName: string;
+  icon: string;
+}) {
+  const assetURL = `https://github.com/chilli-axe/mpc-autofill/releases/latest/download/autofill-${downloadURLSuffix}`;
+  return (
+    <>
+      <DownloadButton>
+        <DownloadButtonLink href={assetURL} target="_blank">
+          <h1 className={`bi bi-${icon}`}></h1>
+          <h4>{platformName}</h4>
+        </DownloadButtonLink>
+      </DownloadButton>
+      <br />
+    </>
+  );
+}
+
+function DesktopToolDownload() {
+  return (
+    <>
+      <p>
+        Download the desktop tool for your platform. If you&apos;d rather
+        download the source code instead, you can find it{" "}
+        <a
+          href="https://github.com/chilli-axe/mpc-autofill/tree/master/desktop-tool/"
+          target="_blank"
+        >
+          here
+        </a>
+        !
+      </p>
+      <Row gap={2}>
+        <Col sm={4}>
+          <PlatformDownload
+            platformName="Windows"
+            downloadURLSuffix="windows.exe"
+            icon="windows"
+          />
+        </Col>
+        <Col sm={4}>
+          <PlatformDownload
+            platformName="macOS"
+            downloadURLSuffix="macos"
+            icon="apple"
+          />
+        </Col>
+        <Col sm={4}>
+          <PlatformDownload
+            platformName="Linux"
+            downloadURLSuffix="linux"
+            icon="ubuntu"
+          />
+        </Col>
+      </Row>
+      <Alert variant="info" className="text-center">
+        <b>Having trouble with the above buttons?</b> Grab it directly from
+        GitHub{" "}
+        <a
+          href="https://github.com/chilli-axe/mpc-autofill/releases/latest/"
+          target="_blank"
+        >
+          here
+        </a>
+        !
+      </Alert>
+    </>
+  );
+}
+
+export function FinishedMyProjectModal({ show, handleClose }: ExitModal) {
+  return (
+    <Modal size="xl" scrollable show={show} onHide={handleClose}>
+      <Modal.Header closeButton>
+        <Modal.Title>I&apos;ve Finished My Project</Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        <h5 className="text-center">
+          Nice work! There are three simple steps for turning your project into
+          an order with{" "}
+          <a href={MakePlayingCardsURL} target="_blank">
+            {MakePlayingCards}
+          </a>
+          .
+        </h5>
+        <BigOL>
+          <BigLI className="py-3">
+            <h3>Download Your Project</h3>
+            <ProjectDownload />
+          </BigLI>
+          <BigLI className="py-3">
+            <h3>Download the Desktop Tool</h3>
+            <DesktopToolDownload />
+          </BigLI>
+          <BigLI className="py-3">
+            <h3>Run the Desktop Tool</h3>
+            <p>
+              Move the program and your XML file into <b>the same folder</b>{" "}
+              (for example, put them both on your desktop), then double-click
+              the desktop tool to run it!
+            </p>
+            <p>
+              It&apos;ll ask you a few questions when it starts up, then you get
+              to sit back and watch the magic happen. Check out our wiki{" "}
+              <a href="https://github.com/chilli-axe/mpc-autofill/wiki/Desktop-Tool">
+                here
+              </a>{" "}
+              for more detailed instructions.
+            </p>
+            <Alert
+              style={{ backgroundColor: "#d99a07" }}
+              className="text-center"
+            >
+              <b>Are you on macOS or Linux</b> There&apos;s another step before
+              you can double-click it - check out the wiki (linked above) for
+              details.
+            </Alert>
+          </BigLI>
+        </BigOL>
+        <hr />
+        <h5 className="text-center">
+          And that&apos;s all there is to it!{" "}
+          <i className="bi bi-rocket-takeoff" />
+        </h5>
+        <p className="text-center">
+          If this software has brought you joy and you&apos;d like to throw a
+          few bucks my way, you can find my tip jar here{" "}
+          <i className="bi bi-heart" />
+        </p>
+        <Coffee />
+      </Modal.Body>
+      <Modal.Footer>
+        <Button variant="secondary" onClick={handleClose}>
+          Close
+        </Button>
+      </Modal.Footer>
+    </Modal>
+  );
+}
+
+export function FinishedMyProject() {
+  const isProjectEmpty = useAppSelector(selectIsProjectEmpty);
+  const dispatch = useAppDispatch();
+  return !isProjectEmpty ? (
+    <div className="d-grid gap-0">
+      <Button
+        variant="success"
+        id="dropdown-basic"
+        onClick={() => dispatch(showModal("finishedMyProject"))}
+      >
+        <RightPaddedIcon bootstrapIconName="bag-check" /> I&apos;ve Finished My
+        Project
+      </Button>
+    </div>
+  ) : null;
+}

--- a/frontend/src/features/import/import.tsx
+++ b/frontend/src/features/import/import.tsx
@@ -12,7 +12,7 @@ export function Import() {
     <>
       <Dropdown>
         <div className="d-grid gap-0">
-          <Dropdown.Toggle variant="success" id="dropdown-basic">
+          <Dropdown.Toggle variant="outline-success" id="dropdown-basic">
             <RightPaddedIcon bootstrapIconName="plus-circle" /> Add Cards
           </Dropdown.Toggle>
         </div>

--- a/frontend/src/features/modals/modals.tsx
+++ b/frontend/src/features/modals/modals.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import { useAppDispatch, useAppSelector } from "@/common/types";
 import { MemoizedCardDetailedView } from "@/features/cardDetailedView/cardDetailedViewModal";
 import { ChangeQueryModal } from "@/features/changeQuery/changeQueryModal";
+import { FinishedMyProjectModal } from "@/features/export/finishedMyProjectModal";
 import { InvalidIdentifiersModal } from "@/features/invalidIdentifiers/invalidIdentifiersModal";
 import {
   hideModal,
@@ -47,6 +48,10 @@ export function Modals() {
           handleClose={handleClose}
         />
       )}
+      <FinishedMyProjectModal
+        show={shownModal === "finishedMyProject"}
+        handleClose={handleClose}
+      />
       <SupportDeveloperModal
         show={shownModal === "supportDeveloper"}
         handleClose={handleClose}


### PR DESCRIPTION
# Description
* I've seen several users report that they're (understandably) not quite sure what to do once they've finished building their order
* Adding a new modal for stepping users through the second phase of using the tool
* Looks a bit like this:
![image](https://github.com/chilli-axe/mpc-autofill/assets/3079166/73b6c5d5-e7fc-4789-8803-285c73692bae)

* Re-styled the right panel buttons so they look like this now:
![image](https://github.com/chilli-axe/mpc-autofill/assets/3079166/bcf50b5a-6c96-4304-b296-d70edfd94aca)

# Checklist

- [x] I have installed `pre-commit` and installed the hooks with `pre-commit install` before creating any commits.
- [ ] I have updated any related tests for code I modified or added new tests where appropriate.
- [x] I have manually tested my changes as follows:
  - see above screenshots
  - I tried clicking each of the release buttons and clicking the "download project as xml" button, they all worked how i expected
- [ ] I have updated any relevant documentation or created new documentation where appropriate.
  - not yet. i do need to improve our docs but don't have time/energy to work on that tonight