### PR TITLE
✨ Load a wiki page after Selenium is initialized to remind the user to look back at the terminal to answer more questions

### DIFF
--- a/desktop-tool/autofill.py
+++ b/desktop-tool/autofill.py
@@ -14,6 +14,7 @@ from src.order import CardOrder, aggregate_and_split_orders
 from src.pdf_maker import PdfExporter
 from src.processing import ImagePostProcessingConfig
 from src.utils import bold
+from src.web_server import WebServer
 
 # https://stackoverflow.com/questions/12492810/python-how-can-i-make-the-ansi-escape-codes-to-work-also-in-windows
 os.system("")  # enables ansi escape characters in terminal
@@ -159,8 +160,12 @@ def main(
                 card_orders = aggregate_and_split_orders(
                     orders=CardOrder.from_xmls_in_folder(), target_site=target_site, combine_orders=combine_orders
                 )
+                web_server = WebServer()
                 AutofillDriver(
-                    browser=Browsers[browser], target_site=target_site, binary_location=binary_location
+                    browser=Browsers[browser],
+                    target_site=target_site,
+                    binary_location=binary_location,
+                    starting_url=web_server.server_url(),
                 ).execute_orders(
                     orders=card_orders,
                     auto_save_threshold=auto_save_threshold if auto_save else None,

--- a/desktop-tool/autofill.spec
+++ b/desktop-tool/autofill.spec
@@ -6,7 +6,7 @@ block_cipher = None
 
 a = Analysis(['autofill.py'],
              binaries=collect_dynamic_libs('ansicon') + collect_dynamic_libs('enlighten'),
-             datas=[('client_secrets.json', '.')],
+             datas=[('client_secrets.json', '.'), ('post-launch.html', '.')],
              hiddenimports=['colorama', 'jinxed.terminfo.vtwin10', 'wakepy._linux._jeepney_dbus'],
              hookspath=[],
              runtime_hooks=[],

--- a/desktop-tool/post-launch.html
+++ b/desktop-tool/post-launch.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>MPC Autofill</title>
+  </head>
+  <body>
+	<h1>Congratulations!</h1>
+    <p>
+        MPC Autofill has started up successfully, please look back at your terminal
+        application to answer a few questions so the upload process can begin.
+    </p>
+    <p>
+        If you have more questions about using MPC Autofill, check out
+        <a href="https://github.com/chilli-axe/mpc-autofill/wiki/Desktop-Tool">the documentation</a>.
+    </p>
+  </body>
+</html>

--- a/desktop-tool/src/constants.py
+++ b/desktop-tool/src/constants.py
@@ -175,3 +175,5 @@ DPI_HEIGHT_RATIO = 300 / 1110  # TODO: share this between desktop tool and backe
 
 PROJECT_MAX_SIZE = 612  # shared between target sites
 THREADS = 5  # shared between CardImageCollections
+
+POST_LAUNCH_HTML_FILENAME = "post-launch.html"

--- a/desktop-tool/src/driver.py
+++ b/desktop-tool/src/driver.py
@@ -44,6 +44,7 @@ class AutofillDriver:
     binary_location: Optional[str] = attr.ib(default=None)  # path to browser executable
     target_site: TargetSites = attr.ib(default=TargetSites.MakePlayingCards)
     headless: bool = attr.ib(default=False)
+    starting_url: str = attr.ib(default="data:")
 
     # internal properties (init=False)
     state: str = attr.ib(init=False, default=States.initialising)
@@ -62,10 +63,8 @@ class AutofillDriver:
             driver = self.browser.value(headless=self.headless, binary_location=self.binary_location)
             driver.set_window_size(1200, 900)
             driver.implicitly_wait(5)
-            driver.get("https://github.com/chilli-axe/mpc-autofill/wiki/Desktop-Tool-Landing")
-            WebDriverWait(driver, 10).until(
-                visibility_of_element_located((By.ID, "wiki-pages-box-heading"))
-            )
+            driver.get(self.starting_url)
+            WebDriverWait(driver, 10).until(visibility_of_element_located((By.TAG_NAME, "body")))
             logging.info(
                 f"Successfully initialised {bold(self.browser.name)} driver "
                 f"targeting {bold(self.target_site.name)}.\n"

--- a/desktop-tool/src/driver.py
+++ b/desktop-tool/src/driver.py
@@ -18,7 +18,10 @@ from selenium.common.exceptions import (
 )
 from selenium.webdriver.common.by import By
 from selenium.webdriver.remote.webdriver import WebDriver
-from selenium.webdriver.support.expected_conditions import invisibility_of_element
+from selenium.webdriver.support.expected_conditions import (
+    invisibility_of_element,
+    visibility_of_element_located,
+)
 from selenium.webdriver.support.ui import Select, WebDriverWait
 
 from src.constants import THREADS, Browsers, Cardstocks, States, TargetSites
@@ -59,6 +62,10 @@ class AutofillDriver:
             driver = self.browser.value(headless=self.headless, binary_location=self.binary_location)
             driver.set_window_size(1200, 900)
             driver.implicitly_wait(5)
+            driver.get("https://github.com/chilli-axe/mpc-autofill/wiki/Desktop-Tool-Landing")
+            WebDriverWait(driver, 10).until(
+                visibility_of_element_located((By.ID, "wiki-pages-box-heading"))
+            )
             logging.info(
                 f"Successfully initialised {bold(self.browser.name)} driver "
                 f"targeting {bold(self.target_site.name)}.\n"

--- a/desktop-tool/src/web_server.py
+++ b/desktop-tool/src/web_server.py
@@ -1,0 +1,35 @@
+import logging
+import threading
+from http import server
+from pathlib import Path
+
+from src import constants
+
+
+class _Handler(server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        self.send_response(200)
+        self.send_header("Content-Type", "text/html")
+        self.end_headers()
+        self.wfile.write(
+            Path(__file__).joinpath("../..").joinpath(constants.POST_LAUNCH_HTML_FILENAME).resolve().read_bytes()
+        )
+
+    def log_request(self, code: int | str = "-", size: int | str = "-") -> None:
+        # Silence the request log.
+        pass
+
+
+class WebServer:
+    def __init__(self):
+        self._server = server.ThreadingHTTPServer(("", 0), _Handler)
+        self._thread = threading.Thread(target=self._server.serve_forever)
+        self._thread.start()
+        logging.info(f"Web server started on {self.server_url()}")
+
+    def server_url(self) -> str:
+        return f"http://localhost:{self._server.socket.getsockname()[1]}/"
+
+    def __del__(self):
+        self._server.shutdown()
+        self._thread.join()


### PR DESCRIPTION
# Description

I set the page to `Desktop-Tool-Landing` but it can be whatever. Some example content (because wikis don't accept PRs):

```md
# Congratulations!

MPCAutofill has started successfully, please look back at your terminal window to answer a few more questions before the upload can begin.

Check out [the documentation if you have any further questions](Desktop-Tool).
```

# Checklist

- [x] I have installed `pre-commit` and installed the hooks with `pre-commit install` before creating any commits.
- [ ] I have updated any related tests for code I modified or added new tests where appropriate.
- [x] I have manually tested my changes as follows:
  - Ran autofill.py and observed it working.
- [ ] I have updated any relevant documentation or created new documentation where appropriate.
