### PR TITLE
Fix `nginx: [emerg] host not found in upstream "django:8000"` error

### DIFF
--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -40,6 +40,8 @@ services:
     build:
       context: ..
       dockerfile: ./docker/nginx/Dockerfile
+    depends_on:
+      - django
     ports:
       - "80:80" # TODO: support ports other than 80
 


### PR DESCRIPTION
# Description

Running `docker compose -f docker-compose.prod.yml -f docker-compose.yml up` results in the following error:
```
2024-09-14 20:31:27 /docker-entrypoint.sh: /docker-entrypoint.d/ is not empty, will attempt to perform configuration
2024-09-14 20:31:27 /docker-entrypoint.sh: Looking for shell scripts in /docker-entrypoint.d/
2024-09-14 20:31:27 /docker-entrypoint.sh: Launching /docker-entrypoint.d/10-listen-on-ipv6-by-default.sh
2024-09-14 20:31:27 10-listen-on-ipv6-by-default.sh: info: /etc/nginx/conf.d/default.conf is not a file or does not exist
2024-09-14 20:31:27 /docker-entrypoint.sh: Launching /docker-entrypoint.d/20-envsubst-on-templates.sh
2024-09-14 20:31:27 /docker-entrypoint.sh: Launching /docker-entrypoint.d/30-tune-worker-processes.sh
2024-09-14 20:31:27 /docker-entrypoint.sh: Configuration complete; ready for start up
2024-09-14 20:31:27 2024/09/15 00:31:27 [emerg] 1#1: host not found in upstream "django:8000" in /etc/nginx/conf.d/nginx.conf:2
2024-09-14 20:31:27 nginx: [emerg] host not found in upstream "django:8000" in /etc/nginx/conf.d/nginx.conf:2
```

Make sure Nginx waits for Django to be ready.

# Checklist

- [x] I have installed `pre-commit` and installed the hooks with `pre-commit install` before creating any commits.
- [x] I have updated any related tests for code I modified or added new tests where appropriate.
- [x] I have manually tested my changes as follows:
  - `cd docker && docker compose -f docker-compose.prod.yml -f docker-compose.yml up`
- [x] I have updated any relevant documentation or created new documentation where appropriate.
