### PR TITLE
fix: Don't overwrite `.env.local` if one exists

### DIFF
--- a/docker/nginx/Dockerfile
+++ b/docker/nginx/Dockerfile
@@ -8,7 +8,9 @@ COPY common /common
 WORKDIR /frontend
 
 # Point frontend at the correct URL to communicate with the backend
-RUN echo "NEXT_PUBLIC_BACKEND_URL=http://localhost:80" > /frontend/.env.local
+RUN if ! grep -q "^NEXT_PUBLIC_BACKEND_URL=" /frontend/.env /frontend/.env.local 2>/dev/null; then \
+    echo "NEXT_PUBLIC_BACKEND_URL=http://localhost:80" > /frontend/.env.local; \
+fi
 
 # install npm
 RUN apk add --update npm


### PR DESCRIPTION
# Description

Unbreaks incorrect overwriting of environment by skipping copy of `.env.local` if `.env` or `.env.local` already exist.

# Checklist

- [x] I have installed `pre-commit` and installed the hooks with `pre-commit install` before creating any commits.
- [x] I have updated any related tests for code I modified or added new tests where appropriate.
- [x] I have manually tested my changes as follows:
  - `cd frontend`
  - `cp .env.dist .env`
  - Set `NEXT_PUBLIC_BACKEND_URL` to anything other than `localhost`
  - `cd ../docker`
  - `docker compose -f docker-compose.prod.yml -f docker-compose.yml up`
  - Make sure the front end requests from the URL you specified in `NEXT_PUBLIC_BACKEND_URL` as opposed to `localhost`
- [x] I have updated any relevant documentation or created new documentation where appropriate.
