### PR TITLE
[Breaking] Separate patreon integration from /info endpoint

### DIFF
--- a/MPCAutofill/cardpicker/schema_types.py
+++ b/MPCAutofill/cardpicker/schema_types.py
@@ -614,101 +614,11 @@ class ImportSitesResponse(BaseModel):
         return result
 
 
-class CampaignClass(BaseModel):
-    about: str
-    id: str
-
-    @staticmethod
-    def from_dict(obj: Any) -> "CampaignClass":
-        assert isinstance(obj, dict)
-        about = from_str(obj.get("about"))
-        id = from_str(obj.get("id"))
-        return CampaignClass(about, id)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["about"] = from_str(self.about)
-        result["id"] = from_str(self.id)
-        return result
-
-
-class Supporter(BaseModel):
-    date: str
-    name: str
-    tier: str
-    usd: float
-
-    @staticmethod
-    def from_dict(obj: Any) -> "Supporter":
-        assert isinstance(obj, dict)
-        date = from_str(obj.get("date"))
-        name = from_str(obj.get("name"))
-        tier = from_str(obj.get("tier"))
-        usd = from_float(obj.get("usd"))
-        return Supporter(date, name, tier, usd)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["date"] = from_str(self.date)
-        result["name"] = from_str(self.name)
-        result["tier"] = from_str(self.tier)
-        result["usd"] = to_float(self.usd)
-        return result
-
-
-class SupporterTier(BaseModel):
-    description: str
-    title: str
-    usd: float
-
-    @staticmethod
-    def from_dict(obj: Any) -> "SupporterTier":
-        assert isinstance(obj, dict)
-        description = from_str(obj.get("description"))
-        title = from_str(obj.get("title"))
-        usd = from_float(obj.get("usd"))
-        return SupporterTier(description, title, usd)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["description"] = from_str(self.description)
-        result["title"] = from_str(self.title)
-        result["usd"] = to_float(self.usd)
-        return result
-
-
-class Patreon(BaseModel):
-    members: List[Supporter]
-    campaign: Optional[CampaignClass] = None
-    tiers: Optional[Dict[str, SupporterTier]] = None
-    url: Optional[str] = None
-
-    @staticmethod
-    def from_dict(obj: Any) -> "Patreon":
-        assert isinstance(obj, dict)
-        members = from_list(Supporter.from_dict, obj.get("members"))
-        campaign = from_union([from_none, CampaignClass.from_dict], obj.get("campaign"))
-        tiers = from_union([from_none, lambda x: from_dict(SupporterTier.from_dict, x)], obj.get("tiers"))
-        url = from_union([from_none, from_str], obj.get("url"))
-        return Patreon(members, campaign, tiers, url)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["members"] = from_list(lambda x: to_class(Supporter, x), self.members)
-        result["campaign"] = from_union([from_none, lambda x: to_class(CampaignClass, x)], self.campaign)
-        result["tiers"] = from_union(
-            [from_none, lambda x: from_dict(lambda x: to_class(SupporterTier, x), x)], self.tiers
-        )
-        result["url"] = from_union([from_none, from_str], self.url)
-        return result
-
-
 class Info(BaseModel):
     description: Optional[str] = None
     discord: Optional[str] = None
     email: Optional[str] = None
     name: Optional[str] = None
-    patreon: Optional[Patreon] = None
     reddit: Optional[str] = None
 
     @staticmethod
@@ -718,9 +628,8 @@ class Info(BaseModel):
         discord = from_union([from_none, from_str], obj.get("discord"))
         email = from_union([from_none, from_str], obj.get("email"))
         name = from_union([from_none, from_str], obj.get("name"))
-        patreon = from_union([from_none, Patreon.from_dict], obj.get("patreon"))
         reddit = from_union([from_none, from_str], obj.get("reddit"))
-        return Info(description, discord, email, name, patreon, reddit)
+        return Info(description, discord, email, name, reddit)
 
     def to_dict(self) -> dict:
         result: dict = {}
@@ -728,7 +637,6 @@ class Info(BaseModel):
         result["discord"] = from_union([from_none, from_str], self.discord)
         result["email"] = from_union([from_none, from_str], self.email)
         result["name"] = from_union([from_none, from_str], self.name)
-        result["patreon"] = from_union([from_none, lambda x: to_class(Patreon, x)], self.patreon)
         result["reddit"] = from_union([from_none, from_str], self.reddit)
         return result
 
@@ -865,6 +773,110 @@ class NewCardsPageResponse(BaseModel):
     def to_dict(self) -> dict:
         result: dict = {}
         result["cards"] = from_list(lambda x: to_class(Card, x), self.cards)
+        return result
+
+
+class CampaignClass(BaseModel):
+    about: str
+    id: str
+
+    @staticmethod
+    def from_dict(obj: Any) -> "CampaignClass":
+        assert isinstance(obj, dict)
+        about = from_str(obj.get("about"))
+        id = from_str(obj.get("id"))
+        return CampaignClass(about, id)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["about"] = from_str(self.about)
+        result["id"] = from_str(self.id)
+        return result
+
+
+class Supporter(BaseModel):
+    date: str
+    name: str
+    tier: str
+    usd: float
+
+    @staticmethod
+    def from_dict(obj: Any) -> "Supporter":
+        assert isinstance(obj, dict)
+        date = from_str(obj.get("date"))
+        name = from_str(obj.get("name"))
+        tier = from_str(obj.get("tier"))
+        usd = from_float(obj.get("usd"))
+        return Supporter(date, name, tier, usd)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["date"] = from_str(self.date)
+        result["name"] = from_str(self.name)
+        result["tier"] = from_str(self.tier)
+        result["usd"] = to_float(self.usd)
+        return result
+
+
+class SupporterTier(BaseModel):
+    description: str
+    title: str
+    usd: float
+
+    @staticmethod
+    def from_dict(obj: Any) -> "SupporterTier":
+        assert isinstance(obj, dict)
+        description = from_str(obj.get("description"))
+        title = from_str(obj.get("title"))
+        usd = from_float(obj.get("usd"))
+        return SupporterTier(description, title, usd)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["description"] = from_str(self.description)
+        result["title"] = from_str(self.title)
+        result["usd"] = to_float(self.usd)
+        return result
+
+
+class Patreon(BaseModel):
+    members: List[Supporter]
+    campaign: Optional[CampaignClass] = None
+    tiers: Optional[Dict[str, SupporterTier]] = None
+    url: Optional[str] = None
+
+    @staticmethod
+    def from_dict(obj: Any) -> "Patreon":
+        assert isinstance(obj, dict)
+        members = from_list(Supporter.from_dict, obj.get("members"))
+        campaign = from_union([from_none, CampaignClass.from_dict], obj.get("campaign"))
+        tiers = from_union([from_none, lambda x: from_dict(SupporterTier.from_dict, x)], obj.get("tiers"))
+        url = from_union([from_none, from_str], obj.get("url"))
+        return Patreon(members, campaign, tiers, url)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["members"] = from_list(lambda x: to_class(Supporter, x), self.members)
+        result["campaign"] = from_union([from_none, lambda x: to_class(CampaignClass, x)], self.campaign)
+        result["tiers"] = from_union(
+            [from_none, lambda x: from_dict(lambda x: to_class(SupporterTier, x), x)], self.tiers
+        )
+        result["url"] = from_union([from_none, from_str], self.url)
+        return result
+
+
+class PatreonResponse(BaseModel):
+    patreon: Patreon
+
+    @staticmethod
+    def from_dict(obj: Any) -> "PatreonResponse":
+        assert isinstance(obj, dict)
+        patreon = Patreon.from_dict(obj.get("patreon"))
+        return PatreonResponse(patreon)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["patreon"] = to_class(Patreon, self.patreon)
         return result
 
 
@@ -1301,6 +1313,14 @@ def NewCardsPageResponsefromdict(s: Any) -> NewCardsPageResponse:
 
 def NewCardsPageResponsetodict(x: NewCardsPageResponse) -> Any:
     return to_class(NewCardsPageResponse, x)
+
+
+def PatreonResponsefromdict(s: Any) -> PatreonResponse:
+    return PatreonResponse.from_dict(s)
+
+
+def PatreonResponsetodict(x: PatreonResponse) -> Any:
+    return to_class(PatreonResponse, x)
 
 
 def SampleCardsResponsefromdict(s: Any) -> SampleCardsResponse:

--- a/MPCAutofill/cardpicker/urls.py
+++ b/MPCAutofill/cardpicker/urls.py
@@ -18,5 +18,6 @@ urlpatterns = [
     path("2/newCardsFirstPages/", views.get_new_cards_first_pages),
     path("2/newCardsPage/", views.get_new_cards_page),
     path("2/info/", views.get_info),
+    path("2/patreon/", views.get_patreon),
     path("2/searchEngineHealth/", views.get_search_engine_health),
 ]

--- a/MPCAutofill/cardpicker/views.py
+++ b/MPCAutofill/cardpicker/views.py
@@ -48,6 +48,7 @@ from cardpicker.schema_types import (
     NewCardsFirstPagesResponse,
     NewCardsPageResponse,
     Patreon,
+    PatreonResponse,
     SampleCardsResponse,
     SearchEngineHealthResponse,
     SortBy,
@@ -460,9 +461,6 @@ def get_info(request: HttpRequest) -> HttpResponse:
     if request.method != "GET":
         raise BadRequestException("Expected GET request.")
 
-    campaign, tiers = get_patreon_campaign_details()
-    members = get_patrons(campaign.id, tiers) if campaign is not None and tiers is not None else None
-
     return JsonResponse(
         InfoResponse(
             info=Info(
@@ -471,12 +469,27 @@ def get_info(request: HttpRequest) -> HttpResponse:
                 email=settings.TARGET_EMAIL,
                 reddit=settings.REDDIT,
                 discord=settings.DISCORD,
-                patreon=Patreon(
-                    url=settings.PATREON_URL,
-                    members=members or [],
-                    tiers=tiers,
-                    campaign=campaign,
-                ),
+            )
+        ).model_dump()
+    )
+
+
+@csrf_exempt
+@ErrorWrappers.to_json
+def get_patreon(request: HttpRequest) -> HttpResponse:
+    if request.method != "GET":
+        raise BadRequestException("Expected GET request.")
+
+    campaign, tiers = get_patreon_campaign_details()
+    members = get_patrons(campaign.id, tiers) if campaign is not None and tiers is not None else None
+
+    return JsonResponse(
+        PatreonResponse(
+            patreon=Patreon(
+                url=settings.PATREON_URL,
+                members=members or [],
+                tiers=tiers,
+                campaign=campaign,
             )
         ).model_dump()
     )

--- a/frontend/src/common/schema_types.ts
+++ b/frontend/src/common/schema_types.ts
@@ -2,7 +2,7 @@
 
 // To parse this data:
 //
-//   import { Convert, Campaign, Card, CardType, FilterSettings, ImportSite, Language, NewCardsFirstPage, SearchQuery, SearchSettings, SearchTypeSettings, SortBy, Source, SourceContribution, SourceSettings, SourceType, Supporter, SupporterTier, Tag, CardbacksRequest, CardbacksResponse, CardsRequest, CardsResponse, ContributionsResponse, DFCPairsResponse, EditorSearchRequest, EditorSearchResponse, ErrorResponse, ExploreSearchRequest, ExploreSearchResponse, ImportSiteDecklistRequest, ImportSiteDecklistResponse, ImportSitesResponse, InfoResponse, LanguagesResponse, NewCardsFirstPagesResponse, NewCardsPageResponse, SampleCardsResponse, SearchEngineHealthResponse, SourcesResponse, TagsResponse } from "./file";
+//   import { Convert, Campaign, Card, CardType, FilterSettings, ImportSite, Language, NewCardsFirstPage, SearchQuery, SearchSettings, SearchTypeSettings, SortBy, Source, SourceContribution, SourceSettings, SourceType, Supporter, SupporterTier, Tag, CardbacksRequest, CardbacksResponse, CardsRequest, CardsResponse, ContributionsResponse, DFCPairsResponse, EditorSearchRequest, EditorSearchResponse, ErrorResponse, ExploreSearchRequest, ExploreSearchResponse, ImportSiteDecklistRequest, ImportSiteDecklistResponse, ImportSitesResponse, InfoResponse, LanguagesResponse, NewCardsFirstPagesResponse, NewCardsPageResponse, PatreonResponse, SampleCardsResponse, SearchEngineHealthResponse, SourcesResponse, TagsResponse } from "./file";
 //
 //   const campaign = Convert.toCampaign(json);
 //   const card = Convert.toCard(json);
@@ -41,6 +41,7 @@
 //   const languagesResponse = Convert.toLanguagesResponse(json);
 //   const newCardsFirstPagesResponse = Convert.toNewCardsFirstPagesResponse(json);
 //   const newCardsPageResponse = Convert.toNewCardsPageResponse(json);
+//   const patreonResponse = Convert.toPatreonResponse(json);
 //   const sampleCardsResponse = Convert.toSampleCardsResponse(json);
 //   const searchEngineHealthResponse = Convert.toSearchEngineHealthResponse(json);
 //   const sourcesResponse = Convert.toSourcesResponse(json);
@@ -243,33 +244,7 @@ export interface Info {
   discord: null | string;
   email: null | string;
   name: null | string;
-  patreon: Patreon | null;
   reddit: null | string;
-}
-
-export interface Patreon {
-  campaign: Campaign | null;
-  members: Supporter[];
-  tiers: { [key: string]: SupporterTier } | null;
-  url: null | string;
-}
-
-export interface Campaign {
-  about: string;
-  id: string;
-}
-
-export interface Supporter {
-  date: string;
-  name: string;
-  tier: string;
-  usd: number;
-}
-
-export interface SupporterTier {
-  description: string;
-  title: string;
-  usd: number;
 }
 
 export interface LanguagesResponse {
@@ -306,6 +281,35 @@ export interface Source {
 
 export interface NewCardsPageResponse {
   cards: Card[];
+}
+
+export interface PatreonResponse {
+  patreon: Patreon;
+}
+
+export interface Patreon {
+  campaign: Campaign | null;
+  members: Supporter[];
+  tiers: { [key: string]: SupporterTier } | null;
+  url: null | string;
+}
+
+export interface Campaign {
+  about: string;
+  id: string;
+}
+
+export interface Supporter {
+  date: string;
+  name: string;
+  tier: string;
+  usd: number;
+}
+
+export interface SupporterTier {
+  description: string;
+  title: string;
+  usd: number;
 }
 
 export interface SampleCardsResponse {
@@ -679,6 +683,14 @@ export class Convert {
     value: NewCardsPageResponse
   ): string {
     return JSON.stringify(uncast(value, r("NewCardsPageResponse")), null, 2);
+  }
+
+  public static toPatreonResponse(json: string): PatreonResponse {
+    return cast(JSON.parse(json), r("PatreonResponse"));
+  }
+
+  public static patreonResponseToJson(value: PatreonResponse): string {
+    return JSON.stringify(uncast(value, r("PatreonResponse")), null, 2);
   }
 
   public static toSampleCardsResponse(json: string): SampleCardsResponse {
@@ -1103,41 +1115,7 @@ const typeMap: any = {
       { json: "discord", js: "discord", typ: u(null, "") },
       { json: "email", js: "email", typ: u(null, "") },
       { json: "name", js: "name", typ: u(null, "") },
-      { json: "patreon", js: "patreon", typ: u(r("Patreon"), null) },
       { json: "reddit", js: "reddit", typ: u(null, "") },
-    ],
-    false
-  ),
-  Patreon: o(
-    [
-      { json: "campaign", js: "campaign", typ: u(r("Campaign"), null) },
-      { json: "members", js: "members", typ: a(r("Supporter")) },
-      { json: "tiers", js: "tiers", typ: u(m(r("SupporterTier")), null) },
-      { json: "url", js: "url", typ: u(null, "") },
-    ],
-    false
-  ),
-  Campaign: o(
-    [
-      { json: "about", js: "about", typ: "" },
-      { json: "id", js: "id", typ: "" },
-    ],
-    false
-  ),
-  Supporter: o(
-    [
-      { json: "date", js: "date", typ: "" },
-      { json: "name", js: "name", typ: "" },
-      { json: "tier", js: "tier", typ: "" },
-      { json: "usd", js: "usd", typ: 3.14 },
-    ],
-    false
-  ),
-  SupporterTier: o(
-    [
-      { json: "description", js: "description", typ: "" },
-      { json: "title", js: "title", typ: "" },
-      { json: "usd", js: "usd", typ: 3.14 },
     ],
     false
   ),
@@ -1178,6 +1156,43 @@ const typeMap: any = {
   ),
   NewCardsPageResponse: o(
     [{ json: "cards", js: "cards", typ: a(r("Card")) }],
+    false
+  ),
+  PatreonResponse: o(
+    [{ json: "patreon", js: "patreon", typ: r("Patreon") }],
+    false
+  ),
+  Patreon: o(
+    [
+      { json: "campaign", js: "campaign", typ: u(r("Campaign"), null) },
+      { json: "members", js: "members", typ: a(r("Supporter")) },
+      { json: "tiers", js: "tiers", typ: u(m(r("SupporterTier")), null) },
+      { json: "url", js: "url", typ: u(null, "") },
+    ],
+    false
+  ),
+  Campaign: o(
+    [
+      { json: "about", js: "about", typ: "" },
+      { json: "id", js: "id", typ: "" },
+    ],
+    false
+  ),
+  Supporter: o(
+    [
+      { json: "date", js: "date", typ: "" },
+      { json: "name", js: "name", typ: "" },
+      { json: "tier", js: "tier", typ: "" },
+      { json: "usd", js: "usd", typ: 3.14 },
+    ],
+    false
+  ),
+  SupporterTier: o(
+    [
+      { json: "description", js: "description", typ: "" },
+      { json: "title", js: "title", typ: "" },
+      { json: "usd", js: "usd", typ: 3.14 },
+    ],
     false
   ),
   SampleCardsResponse: o(

--- a/frontend/src/features/support/SupportBackendModal.tsx
+++ b/frontend/src/features/support/SupportBackendModal.tsx
@@ -5,7 +5,7 @@ import Modal from "react-bootstrap/Modal";
 
 import { AutofillTable } from "@/components/AutofillTable";
 import { Spinner } from "@/components/Spinner";
-import { useGetBackendInfoQuery } from "@/store/api";
+import { useGetBackendInfoQuery, useGetPatreonQuery } from "@/store/api";
 
 interface SupportBackendModalProps {
   show: boolean;
@@ -22,6 +22,7 @@ export function SupportBackendModal({
   //# region queries and hooks
 
   const backendInfoQuery = useGetBackendInfoQuery();
+  const patreonQuery = useGetPatreonQuery();
 
   //# endregion
 
@@ -33,48 +34,44 @@ export function SupportBackendModal({
         </Modal.Title>
       </Modal.Header>
       <Modal.Body>
-        {backendInfoQuery?.data?.patreon == null ? (
+        {patreonQuery?.data === undefined ? (
           <Spinner />
         ) : (
           <>
-            {backendInfoQuery.data.patreon.campaign?.about != null && (
+            {patreonQuery.data.campaign?.about != null && (
               <p
                 dangerouslySetInnerHTML={{
-                  __html: backendInfoQuery.data.patreon.campaign.about,
+                  __html: patreonQuery.data.campaign.about,
                 }}
               />
             )}
             <Alert variant="info">
               <h4>Patron Tiers</h4>
-              {Object.values(backendInfoQuery.data.patreon.tiers ?? {}).map(
-                (tier) => (
-                  <h6 key={`patreon-tier-${tier.title}`}>
-                    <h6>
-                      {tier.title} (${tier.usd} USD)
-                    </h6>
-                    <p
-                      dangerouslySetInnerHTML={{ __html: tier.description }}
-                    ></p>
+              {Object.values(patreonQuery.data.tiers ?? {}).map((tier) => (
+                <h6 key={`patreon-tier-${tier.title}`}>
+                  <h6>
+                    {tier.title} (${tier.usd} USD)
                   </h6>
-                )
-              )}
+                  <p dangerouslySetInnerHTML={{ __html: tier.description }}></p>
+                </h6>
+              ))}
               <hr />
-              {backendInfoQuery.data.patreon.url != null && (
+              {patreonQuery.data.url != null && (
                 <a
                   style={{ textAlign: "center" }}
-                  href={backendInfoQuery.data.patreon.url}
+                  href={patreonQuery.data.url}
                   target="_blank"
                 >
                   Become a Patron today!
                 </a>
               )}
             </Alert>
-            {backendInfoQuery.data.patreon.members != null && (
+            {patreonQuery.data.members != null && (
               <>
                 <h4>Patrons</h4>
                 <AutofillTable
                   headers={["Name", "Tier", "Patron Since"]}
-                  data={backendInfoQuery.data.patreon.members.map((patron) => [
+                  data={patreonQuery.data.members.map((patron) => [
                     patron.name,
                     patron.tier,
                     patron.date,

--- a/frontend/src/features/toasts/Toasts.tsx
+++ b/frontend/src/features/toasts/Toasts.tsx
@@ -142,7 +142,7 @@ function NotificationToast() {
 export function Toasts() {
   return (
     <DisableSSR>
-      <ToastContainer position="top-start" className="p-3">
+      <ToastContainer position="bottom-start" className="p-3">
         <GoogleAnalyticsConsentToast />
         <NotificationToast />
       </ToastContainer>

--- a/frontend/src/features/ui/Navbar.tsx
+++ b/frontend/src/features/ui/Navbar.tsx
@@ -17,7 +17,7 @@ import {
   DownloadManager,
   OpenDownloadManagerButton,
 } from "@/features/download/DownloadManager";
-import { useGetBackendInfoQuery } from "@/store/api";
+import { useGetBackendInfoQuery, useGetPatreonQuery } from "@/store/api";
 import {
   useBackendConfigured,
   useProjectName,
@@ -40,6 +40,7 @@ export default function ProjectNavbar() {
   const dispatch = useAppDispatch();
   const backendConfigured = useBackendConfigured();
   const backendInfoQuery = useGetBackendInfoQuery();
+  const patreonQuery = useGetPatreonQuery();
 
   const [shownOffcanvas, setShownOffcanvas] = useState<
     "backendConfig" | "downloadManager" | null
@@ -134,8 +135,7 @@ export default function ProjectNavbar() {
                   <i className="bi bi-code" /> Support the Developer
                 </NavDropdown.Item>
                 {backendInfoQuery.data?.name != null &&
-                  (backendInfoQuery.data?.patreon?.url ?? "").trim().length >
-                    0 && (
+                  (patreonQuery.data?.url ?? "").trim().length > 0 && (
                     <NavDropdown.Item onClick={handleShowSupportBackendModal}>
                       <i className="bi bi-server" /> Support{" "}
                       {backendInfoQuery.data.name}

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -1,6 +1,7 @@
 import { http, HttpResponse } from "msw";
 
 import { Card, Cardback, Token } from "@/common/constants";
+import { Campaign, Supporter, SupporterTier } from "@/common/schema_types";
 import {
   cardDocument1,
   cardDocument2,
@@ -497,7 +498,7 @@ export const newCardsFirstPageServerError = http.get(
 
 //# region backend info
 
-export const backendInfoNoPatreon = http.get(buildRoute("2/info"), () =>
+export const backendInfo = http.get(buildRoute("2/info"), () =>
   HttpResponse.json(
     {
       info: {
@@ -506,12 +507,19 @@ export const backendInfoNoPatreon = http.get(buildRoute("2/info"), () =>
         email: "test@test.com",
         reddit: "reddit.com",
         discord: "discord.com",
-        patreon: {
-          url: "",
-          members: null,
-          tiers: null,
-          campaign: null,
-        },
+      },
+    },
+    { status: 200 }
+  )
+);
+export const patreon = http.get(buildRoute("2/patreon"), () =>
+  HttpResponse.json(
+    {
+      patreon: {
+        campaign: null,
+        members: [],
+        tiers: null,
+        url: null,
       },
     },
     { status: 200 }
@@ -545,7 +553,8 @@ export const defaultHandlers = [
   tagsNoResults,
   importSitesOneResult,
   sampleCards,
-  backendInfoNoPatreon,
+  backendInfo,
+  patreon,
   searchEngineHealthy,
 ];
 

--- a/frontend/src/store/api.ts
+++ b/frontend/src/store/api.ts
@@ -31,6 +31,8 @@ import {
   NewCardsFirstPage,
   NewCardsFirstPagesResponse,
   NewCardsPageResponse,
+  Patreon,
+  PatreonResponse,
   SampleCardsResponse,
   SourcesResponse,
   Tag,
@@ -122,6 +124,12 @@ export const api = createApi({
       providesTags: [QueryTags.BackendSpecific],
       transformResponse: (response: InfoResponse, meta, arg) => response.info,
     }),
+    getPatreon: builder.query<Patreon, void>({
+      query: () => ({ url: `2/patreon/`, method: "GET" }),
+      providesTags: [QueryTags.BackendSpecific],
+      transformResponse: (response: PatreonResponse, meta, arg) =>
+        response.patreon,
+    }),
     getGoogleDriveImage: builder.query<string, string>({
       query: (identifier: string) => ({
         url: GoogleDriveImageAPIURL,
@@ -194,6 +202,7 @@ const {
   useGetSampleCardsQuery: useRawGetSampleCardsQuery,
   useGetContributionsQuery: useRawGetContributionsQuery,
   useGetBackendInfoQuery: useRawGetBackendInfoQuery,
+  useGetPatreonQuery: useRawGetPatreonQuery,
   useGetNewCardsFirstPageQuery: useRawGetNewCardsFirstPageQuery,
   useGetNewCardsPageQuery: useRawGetNewCardsPageQuery,
   usePostExploreSearchQuery: useRawPostExploreSearchQuery,
@@ -244,6 +253,13 @@ export function useGetContributionsQuery() {
 export function useGetBackendInfoQuery() {
   const backendConfigured = useBackendConfigured();
   return useRawGetBackendInfoQuery(undefined, {
+    skip: !backendConfigured,
+  });
+}
+
+export function useGetPatreonQuery() {
+  const backendConfigured = useBackendConfigured();
+  return useRawGetPatreonQuery(undefined, {
     skip: !backendConfigured,
   });
 }

--- a/schemas/schemas/endpoints/InfoResponse.json
+++ b/schemas/schemas/endpoints/InfoResponse.json
@@ -10,41 +10,9 @@
         "description": { "type": ["string", "null"] },
         "email": { "type": ["string", "null"] },
         "reddit": { "type": ["string", "null"] },
-        "discord": { "type": ["string", "null"] },
-        "patreon": {
-          "type": ["object", "null"],
-          "properties": {
-            "url": { "type": ["string", "null"] },
-            "members": {
-              "type": "array",
-              "items": {
-                "$ref": "../Supporter.json"
-              }
-            },
-            "tiers": {
-              "type": ["object", "null"],
-              "patternProperties": {
-                ".*": {
-                  "$ref": "../SupporterTier.json"
-                }
-              }
-            },
-            "campaign": {
-              "$ref": "../Campaign.json"
-            }
-          },
-          "required": ["url", "members", "tiers", "campaign"],
-          "additionalProperties": false
-        }
+        "discord": { "type": ["string", "null"] }
       },
-      "required": [
-        "name",
-        "description",
-        "email",
-        "reddit",
-        "discord",
-        "patreon"
-      ],
+      "required": ["name", "description", "email", "reddit", "discord"],
       "additionalProperties": false
     }
   },

--- a/schemas/schemas/endpoints/PatreonResponse.json
+++ b/schemas/schemas/endpoints/PatreonResponse.json
@@ -1,0 +1,34 @@
+{
+  "title": "Patreon Response",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "patreon": {
+      "type": "object",
+      "properties": {
+        "url": { "type": ["string", "null"] },
+        "members": {
+          "type": "array",
+          "items": {
+            "$ref": "../Supporter.json"
+          }
+        },
+        "tiers": {
+          "type": ["object", "null"],
+          "patternProperties": {
+            ".*": {
+              "$ref": "../SupporterTier.json"
+            }
+          }
+        },
+        "campaign": {
+          "$ref": "../Campaign.json"
+        }
+      },
+      "required": ["url", "members", "tiers", "campaign"],
+      "additionalProperties": false
+    }
+  },
+  "required": ["patreon"],
+  "additionalProperties": false
+}


### PR DESCRIPTION
# Description

* Motivation for this PR is the `/info` page drives the title on the front page, meaning this can be slow to render according to the configured site name if the Patreon API call/s take a lil while
* This PR is an API breaking change - i.e. that the frontend and backend must be deployed together

# Checklist

- [x] I have installed `pre-commit` and installed the hooks with `pre-commit install` before creating any commits.
- [x] I have updated any related tests for code I modified or added new tests where appropriate.
- [ ] I have manually tested my changes as follows:
  - None yet, will do this later
- [x] I have updated any relevant documentation or created new documentation where appropriate.
