### PR TITLE
Remove TCGPlayer deckbuilder integration

### DIFF
--- a/MPCAutofill/cardpicker/integrations/game/mtg.py
+++ b/MPCAutofill/cardpicker/integrations/game/mtg.py
@@ -1,4 +1,3 @@
-import html
 import re
 from typing import Any, Type
 from urllib.parse import parse_qs, urlparse
@@ -224,32 +223,6 @@ class TappedOut(ImportSite):
         return card_list
 
 
-class TCGPlayer(ImportSite):
-    @staticmethod
-    def get_host_names() -> list[str]:
-        return ["decks.tcgplayer.com"]  # www. is explicitly not valid
-
-    @classmethod
-    def retrieve_card_list(cls, url: str) -> str:
-        # TCGPlayer doesn't expose a useful API, so we need to parse the html directly
-        path = urlparse(url).path
-        response = cls.request(
-            path=path,
-            # TCGPlayer now requires that `User-Agent` is passed through.
-            # the TCGPlayer deckbuilder is no longer supported, so this bandaid solution will only live
-            # until the deckbuilder is fully killed off. see PR #292 on GitHub.
-            headers={"User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:132.0) Gecko/20100101 Firefox/132.0"},
-        )
-        card_tuple = re.findall(
-            '<span class="subdeck-group__card-qty">(.+?)</span> ' '<span class="subdeck-group__card-name">(.+?)</span>',
-            response.text,
-        )
-        card_list = ""
-        for qty, name in card_tuple:
-            card_list += "{} {}\n".format(qty, html.unescape(name))
-        return card_list
-
-
 # endregion
 
 
@@ -336,7 +309,6 @@ class MTG(GameIntegration):
             MTGGoldfish,
             Scryfall,
             TappedOut,
-            TCGPlayer,
         ]
 
     # endregion

--- a/MPCAutofill/cardpicker/tests/__snapshots__/test_integrations.ambr
+++ b/MPCAutofill/cardpicker/tests/__snapshots__/test_integrations.ambr
@@ -54,13 +54,6 @@
     'Past in Flames': 3,
   })
 # ---
-# name: TestMTGIntegration.test_valid_url[tcgplayer]
-  Counter({
-    '1 Delver of Secrets': 1,
-    '3 Past in Flames': 1,
-    '4 Brainstorm': 1,
-  })
-# ---
 # name: TestMTGIntegration.test_valid_url[deckstats]
   Counter({
     '1 Delver of Secrets // Insectile Aberration': 1,

--- a/MPCAutofill/cardpicker/tests/test_integrations.py
+++ b/MPCAutofill/cardpicker/tests/test_integrations.py
@@ -46,7 +46,6 @@ class TestMTGIntegration:
         SCRYFALL_WITH_WWW = "https://www.scryfall.com/@mpcautofill/decks/71bb2d40-c922-4a01-a63e-7ba2dde29a5c"
         TAPPEDOUT = "https://tappedout.net/mtg-decks/09-10-22-DoY-test"
         TAPPEDOUT_WITH_WWW = "https://www.tappedout.net/mtg-decks/09-10-22-DoY-test"
-        TCGPLAYER = "https://decks.tcgplayer.com/magic/standard/mpc-autofill/test/1398367"
 
     # endregion
 


### PR DESCRIPTION
# Description

The deckbuilder was deactivated by TCGPlayer on 2025-05-14:
<img width="974" alt="image" src="https://github.com/user-attachments/assets/0726d216-cedd-4a4c-a7a7-4ede5e58b1e2" />

It's a shame to see this go - thanks @claythearc for originally contributing this in #68 :)

# Checklist

- [x] I have installed `pre-commit` and installed the hooks with `pre-commit install` before creating any commits.
- [x] I have updated any related tests for code I modified or added new tests where appropriate.
- [x] I have manually tested my changes as follows:
  - Ensured TCGPlayer is no longer listed as a valid import site in the frontend
- [x] I have updated any relevant documentation or created new documentation where appropriate.
  - None required