### PR TITLE
Sign Windows desktop tool with SignPath certificate

### DIFF
--- a/.github/workflows/build-desktop-tool.yml
+++ b/.github/workflows/build-desktop-tool.yml
@@ -79,6 +79,6 @@ jobs:
         id: upload-signed-artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.TARGET }} Build
+          name: ${{ matrix.TARGET }} Signed Build
           path: |
             desktop-tool/build/autofill.${{ matrix.EXTENSION }}


### PR DESCRIPTION
# Description
* SignPath has graciously provided us with a code signing certificate under their OSS program: https://signpath.org/ - thank you SignPath!
* This PR integrates code signing for our Windows executables into the GitHub Actions build process.
* Currently pointing at the test cert they provided - I'll update this to use the actual cert when it's available.

# Checklist

- [x] I have installed `pre-commit` and installed the hooks with `pre-commit install` before creating any commits.
- [x] I have updated any related tests for code I modified or added new tests where appropriate.
- [x] I have manually tested my changes as follows:
  - Manually ran desktop tool build action on this branch, verified that the Windows executable is successfully signed by SignPath & the executable downloaded from GitHub is signed: https://github.com/chilli-axe/mpc-autofill/actions/runs/21092493404
- [ ] I have updated any relevant documentation or created new documentation where appropriate.
  - Not yet, I'll do this later