### PR TITLE
Restructure `editorSearch` API to allow extending SearchQuery model

### DIFF
--- a/MPCAutofill/cardpicker/schema_types.py
+++ b/MPCAutofill/cardpicker/schema_types.py
@@ -502,57 +502,6 @@ class DFCPairsResponse(BaseModel):
         return result
 
 
-class SearchQuery(BaseModel):
-    cardType: CardType
-    query: Optional[str] = None
-
-    @staticmethod
-    def from_dict(obj: Any) -> "SearchQuery":
-        assert isinstance(obj, dict)
-        cardType = CardType(obj.get("cardType"))
-        query = from_union([from_none, from_str], obj.get("query"))
-        return SearchQuery(cardType, query)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["cardType"] = to_enum(CardType, self.cardType)
-        result["query"] = from_union([from_none, from_str], self.query)
-        return result
-
-
-class EditorSearchRequest(BaseModel):
-    queries: List[SearchQuery]
-    searchSettings: SearchSettings
-
-    @staticmethod
-    def from_dict(obj: Any) -> "EditorSearchRequest":
-        assert isinstance(obj, dict)
-        queries = from_list(SearchQuery.from_dict, obj.get("queries"))
-        searchSettings = SearchSettings.from_dict(obj.get("searchSettings"))
-        return EditorSearchRequest(queries, searchSettings)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["queries"] = from_list(lambda x: to_class(SearchQuery, x), self.queries)
-        result["searchSettings"] = to_class(SearchSettings, self.searchSettings)
-        return result
-
-
-class EditorSearchResponse(BaseModel):
-    results: Dict[str, Dict[str, List[str]]]
-
-    @staticmethod
-    def from_dict(obj: Any) -> "EditorSearchResponse":
-        assert isinstance(obj, dict)
-        results = from_dict(lambda x: from_dict(lambda x: from_list(from_str, x), x), obj.get("results"))
-        return EditorSearchResponse(results)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["results"] = from_dict(lambda x: from_dict(lambda x: from_list(from_str, x), x), self.results)
-        return result
-
-
 class ErrorResponse(BaseModel):
     name: str
     errors: Optional[List[Dict[str, Any]]] = None
@@ -857,6 +806,57 @@ class NewCardsPageResponse(BaseModel):
     def to_dict(self) -> dict:
         result: dict = {}
         result["cards"] = from_list(lambda x: to_class(Card, x), self.cards)
+        return result
+
+
+class SearchQuery(BaseModel):
+    cardType: CardType
+    query: Optional[str] = None
+
+    @staticmethod
+    def from_dict(obj: Any) -> "SearchQuery":
+        assert isinstance(obj, dict)
+        cardType = CardType(obj.get("cardType"))
+        query = from_union([from_none, from_str], obj.get("query"))
+        return SearchQuery(cardType, query)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["cardType"] = to_enum(CardType, self.cardType)
+        result["query"] = from_union([from_none, from_str], self.query)
+        return result
+
+
+class OldEditorSearchRequest(BaseModel):
+    queries: List[SearchQuery]
+    searchSettings: SearchSettings
+
+    @staticmethod
+    def from_dict(obj: Any) -> "OldEditorSearchRequest":
+        assert isinstance(obj, dict)
+        queries = from_list(SearchQuery.from_dict, obj.get("queries"))
+        searchSettings = SearchSettings.from_dict(obj.get("searchSettings"))
+        return OldEditorSearchRequest(queries, searchSettings)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["queries"] = from_list(lambda x: to_class(SearchQuery, x), self.queries)
+        result["searchSettings"] = to_class(SearchSettings, self.searchSettings)
+        return result
+
+
+class OldEditorSearchResponse(BaseModel):
+    results: Dict[str, Dict[str, List[str]]]
+
+    @staticmethod
+    def from_dict(obj: Any) -> "OldEditorSearchResponse":
+        assert isinstance(obj, dict)
+        results = from_dict(lambda x: from_dict(lambda x: from_list(from_str, x), x), obj.get("results"))
+        return OldEditorSearchResponse(results)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["results"] = from_dict(lambda x: from_dict(lambda x: from_list(from_str, x), x), self.results)
         return result
 
 
@@ -1327,22 +1327,6 @@ def DFCPairsResponsetodict(x: DFCPairsResponse) -> Any:
     return to_class(DFCPairsResponse, x)
 
 
-def EditorSearchRequestfromdict(s: Any) -> EditorSearchRequest:
-    return EditorSearchRequest.from_dict(s)
-
-
-def EditorSearchRequesttodict(x: EditorSearchRequest) -> Any:
-    return to_class(EditorSearchRequest, x)
-
-
-def EditorSearchResponsefromdict(s: Any) -> EditorSearchResponse:
-    return EditorSearchResponse.from_dict(s)
-
-
-def EditorSearchResponsetodict(x: EditorSearchResponse) -> Any:
-    return to_class(EditorSearchResponse, x)
-
-
 def ErrorResponsefromdict(s: Any) -> ErrorResponse:
     return ErrorResponse.from_dict(s)
 
@@ -1421,6 +1405,22 @@ def NewCardsPageResponsefromdict(s: Any) -> NewCardsPageResponse:
 
 def NewCardsPageResponsetodict(x: NewCardsPageResponse) -> Any:
     return to_class(NewCardsPageResponse, x)
+
+
+def OldEditorSearchRequestfromdict(s: Any) -> OldEditorSearchRequest:
+    return OldEditorSearchRequest.from_dict(s)
+
+
+def OldEditorSearchRequesttodict(x: OldEditorSearchRequest) -> Any:
+    return to_class(OldEditorSearchRequest, x)
+
+
+def OldEditorSearchResponsefromdict(s: Any) -> OldEditorSearchResponse:
+    return OldEditorSearchResponse.from_dict(s)
+
+
+def OldEditorSearchResponsetodict(x: OldEditorSearchResponse) -> Any:
+    return to_class(OldEditorSearchResponse, x)
 
 
 def PatreonResponsefromdict(s: Any) -> PatreonResponse:

--- a/MPCAutofill/cardpicker/schema_types.py
+++ b/MPCAutofill/cardpicker/schema_types.py
@@ -502,6 +502,57 @@ class DFCPairsResponse(BaseModel):
         return result
 
 
+class SearchQuery(BaseModel):
+    cardType: CardType
+    query: Optional[str] = None
+
+    @staticmethod
+    def from_dict(obj: Any) -> "SearchQuery":
+        assert isinstance(obj, dict)
+        cardType = CardType(obj.get("cardType"))
+        query = from_union([from_none, from_str], obj.get("query"))
+        return SearchQuery(cardType, query)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["cardType"] = to_enum(CardType, self.cardType)
+        result["query"] = from_union([from_none, from_str], self.query)
+        return result
+
+
+class EditorSearchRequest(BaseModel):
+    queries: Dict[str, SearchQuery]
+    searchSettings: SearchSettings
+
+    @staticmethod
+    def from_dict(obj: Any) -> "EditorSearchRequest":
+        assert isinstance(obj, dict)
+        queries = from_dict(SearchQuery.from_dict, obj.get("queries"))
+        searchSettings = SearchSettings.from_dict(obj.get("searchSettings"))
+        return EditorSearchRequest(queries, searchSettings)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["queries"] = from_dict(lambda x: to_class(SearchQuery, x), self.queries)
+        result["searchSettings"] = to_class(SearchSettings, self.searchSettings)
+        return result
+
+
+class EditorSearchResponse(BaseModel):
+    results: Dict[str, List[str]]
+
+    @staticmethod
+    def from_dict(obj: Any) -> "EditorSearchResponse":
+        assert isinstance(obj, dict)
+        results = from_dict(lambda x: from_list(from_str, x), obj.get("results"))
+        return EditorSearchResponse(results)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["results"] = from_dict(lambda x: from_list(from_str, x), self.results)
+        return result
+
+
 class ErrorResponse(BaseModel):
     name: str
     errors: Optional[List[Dict[str, Any]]] = None
@@ -806,24 +857,6 @@ class NewCardsPageResponse(BaseModel):
     def to_dict(self) -> dict:
         result: dict = {}
         result["cards"] = from_list(lambda x: to_class(Card, x), self.cards)
-        return result
-
-
-class SearchQuery(BaseModel):
-    cardType: CardType
-    query: Optional[str] = None
-
-    @staticmethod
-    def from_dict(obj: Any) -> "SearchQuery":
-        assert isinstance(obj, dict)
-        cardType = CardType(obj.get("cardType"))
-        query = from_union([from_none, from_str], obj.get("query"))
-        return SearchQuery(cardType, query)
-
-    def to_dict(self) -> dict:
-        result: dict = {}
-        result["cardType"] = to_enum(CardType, self.cardType)
-        result["query"] = from_union([from_none, from_str], self.query)
         return result
 
 
@@ -1325,6 +1358,22 @@ def DFCPairsResponsefromdict(s: Any) -> DFCPairsResponse:
 
 def DFCPairsResponsetodict(x: DFCPairsResponse) -> Any:
     return to_class(DFCPairsResponse, x)
+
+
+def EditorSearchRequestfromdict(s: Any) -> EditorSearchRequest:
+    return EditorSearchRequest.from_dict(s)
+
+
+def EditorSearchRequesttodict(x: EditorSearchRequest) -> Any:
+    return to_class(EditorSearchRequest, x)
+
+
+def EditorSearchResponsefromdict(s: Any) -> EditorSearchResponse:
+    return EditorSearchResponse.from_dict(s)
+
+
+def EditorSearchResponsetodict(x: EditorSearchResponse) -> Any:
+    return to_class(EditorSearchResponse, x)
 
 
 def ErrorResponsefromdict(s: Any) -> ErrorResponse:

--- a/MPCAutofill/cardpicker/tests/__snapshots__/test_views.ambr
+++ b/MPCAutofill/cardpicker/tests/__snapshots__/test_views.ambr
@@ -1671,32 +1671,22 @@
   dict({
     'json': dict({
       'results': dict({
-        'Brainstorm': dict({
-          'CARD': list([
-            '1c4M-sK9gd0Xju0NXCPtqeTW_DQTldVU5',
-          ]),
-        }),
-        'Goblin': dict({
-          'TOKEN': list([
-            '1V5E0avDmNyEUuFfYwx3nA05aj-1HY0rA',
-          ]),
-        }),
-        'Island': dict({
-          'CARD': list([
-            '1IDtqSjJ4Yo45AnNA4SplOiN7ewibifMa',
-            '1HsvTYs1jFGe1c8U1PnNZ9aB8jkAW7KU0',
-          ]),
-        }),
-        'Simple Cube': dict({
-          'CARDBACK': list([
-            '1JtXL6Ca9nQkvhwZZRR9ZuKA9_DzsFf1V',
-          ]),
-        }),
-        'Simple Lotus': dict({
-          'CARDBACK': list([
-            '1oigI6wz0zA--pNMuExKTs40kBNH6VRP_',
-          ]),
-        }),
+        'key1': list([
+          '1c4M-sK9gd0Xju0NXCPtqeTW_DQTldVU5',
+        ]),
+        'key2': list([
+          '1IDtqSjJ4Yo45AnNA4SplOiN7ewibifMa',
+          '1HsvTYs1jFGe1c8U1PnNZ9aB8jkAW7KU0',
+        ]),
+        'key3': list([
+          '1JtXL6Ca9nQkvhwZZRR9ZuKA9_DzsFf1V',
+        ]),
+        'key4': list([
+          '1oigI6wz0zA--pNMuExKTs40kBNH6VRP_',
+        ]),
+        'key5': list([
+          '1V5E0avDmNyEUuFfYwx3nA05aj-1HY0rA',
+        ]),
       }),
     }),
     'status_code': 200,
@@ -1706,12 +1696,10 @@
   dict({
     'json': dict({
       'results': dict({
-        'past in': dict({
-          'CARD': list([
-            '1UPdh7J7hScg4ZnxSPJ-EeBYHLp2s3Oz1',
-            '1dxSLHtw-VwwE09pZCA8OA6LbuWRZPEoU',
-          ]),
-        }),
+        'key1': list([
+          '1UPdh7J7hScg4ZnxSPJ-EeBYHLp2s3Oz1',
+          '1dxSLHtw-VwwE09pZCA8OA6LbuWRZPEoU',
+        ]),
       }),
     }),
     'status_code': 200,
@@ -1721,12 +1709,10 @@
   dict({
     'json': dict({
       'results': dict({
-        'Pást in Flames': dict({
-          'CARD': list([
-            '1UPdh7J7hScg4ZnxSPJ-EeBYHLp2s3Oz1',
-            '1dxSLHtw-VwwE09pZCA8OA6LbuWRZPEoU',
-          ]),
-        }),
+        'key1': list([
+          '1UPdh7J7hScg4ZnxSPJ-EeBYHLp2s3Oz1',
+          '1dxSLHtw-VwwE09pZCA8OA6LbuWRZPEoU',
+        ]),
       }),
     }),
     'status_code': 200,
@@ -1736,11 +1722,9 @@
   dict({
     'json': dict({
       'results': dict({
-        'Pást in Flames': dict({
-          'CARD': list([
-            '1UPdh7J7hScg4ZnxSPJ-EeBYHLp2s3Oz1',
-          ]),
-        }),
+        'key1': list([
+          '1UPdh7J7hScg4ZnxSPJ-EeBYHLp2s3Oz1',
+        ]),
       }),
     }),
     'status_code': 200,
@@ -1750,12 +1734,10 @@
   dict({
     'json': dict({
       'results': dict({
-        'Pást in Flames': dict({
-          'CARD': list([
-            '1UPdh7J7hScg4ZnxSPJ-EeBYHLp2s3Oz1',
-            '1dxSLHtw-VwwE09pZCA8OA6LbuWRZPEoU',
-          ]),
-        }),
+        'key1': list([
+          '1UPdh7J7hScg4ZnxSPJ-EeBYHLp2s3Oz1',
+          '1dxSLHtw-VwwE09pZCA8OA6LbuWRZPEoU',
+        ]),
       }),
     }),
     'status_code': 200,
@@ -1765,12 +1747,10 @@
   dict({
     'json': dict({
       'results': dict({
-        'Pást in Flames': dict({
-          'CARD': list([
-            '1UPdh7J7hScg4ZnxSPJ-EeBYHLp2s3Oz1',
-            '1dxSLHtw-VwwE09pZCA8OA6LbuWRZPEoU',
-          ]),
-        }),
+        'key1': list([
+          '1UPdh7J7hScg4ZnxSPJ-EeBYHLp2s3Oz1',
+          '1dxSLHtw-VwwE09pZCA8OA6LbuWRZPEoU',
+        ]),
       }),
     }),
     'status_code': 200,
@@ -1780,11 +1760,9 @@
   dict({
     'json': dict({
       'results': dict({
-        'Past in Flames': dict({
-          'CARD': list([
-            '1UPdh7J7hScg4ZnxSPJ-EeBYHLp2s3Oz1',
-          ]),
-        }),
+        'key1': list([
+          '1UPdh7J7hScg4ZnxSPJ-EeBYHLp2s3Oz1',
+        ]),
       }),
     }),
     'status_code': 200,
@@ -1794,11 +1772,9 @@
   dict({
     'json': dict({
       'results': dict({
-        'Pást in Flames': dict({
-          'CARD': list([
-            '1dxSLHtw-VwwE09pZCA8OA6LbuWRZPEoU',
-          ]),
-        }),
+        'key1': list([
+          '1dxSLHtw-VwwE09pZCA8OA6LbuWRZPEoU',
+        ]),
       }),
     }),
     'status_code': 200,
@@ -1808,11 +1784,9 @@
   dict({
     'json': dict({
       'results': dict({
-        'Pást in Flames': dict({
-          'CARD': list([
-            '1UPdh7J7hScg4ZnxSPJ-EeBYHLp2s3Oz1',
-          ]),
-        }),
+        'key1': list([
+          '1UPdh7J7hScg4ZnxSPJ-EeBYHLp2s3Oz1',
+        ]),
       }),
     }),
     'status_code': 200,
@@ -1832,10 +1806,8 @@
   dict({
     'json': dict({
       'results': dict({
-        'Simple Cube': dict({
-          'CARDBACK': list([
-          ]),
-        }),
+        'key1': list([
+        ]),
       }),
     }),
     'status_code': 200,
@@ -1845,11 +1817,9 @@
   dict({
     'json': dict({
       'results': dict({
-        'Pást in Flames': dict({
-          'CARD': list([
-            '1dxSLHtw-VwwE09pZCA8OA6LbuWRZPEoU',
-          ]),
-        }),
+        'key1': list([
+          '1dxSLHtw-VwwE09pZCA8OA6LbuWRZPEoU',
+        ]),
       }),
     }),
     'status_code': 200,
@@ -1859,11 +1829,9 @@
   dict({
     'json': dict({
       'results': dict({
-        'Pást in Flames': dict({
-          'CARD': list([
-            '1UPdh7J7hScg4ZnxSPJ-EeBYHLp2s3Oz1',
-          ]),
-        }),
+        'key1': list([
+          '1UPdh7J7hScg4ZnxSPJ-EeBYHLp2s3Oz1',
+        ]),
       }),
     }),
     'status_code': 200,
@@ -1873,10 +1841,8 @@
   dict({
     'json': dict({
       'results': dict({
-        'Simple Cube': dict({
-          'CARDBACK': list([
-          ]),
-        }),
+        'key1': list([
+        ]),
       }),
     }),
     'status_code': 200,
@@ -1886,17 +1852,13 @@
   dict({
     'json': dict({
       'results': dict({
-        'Brainstorm': dict({
-          'CARD': list([
-            '1c4M-sK9gd0Xju0NXCPtqeTW_DQTldVU5',
-          ]),
-        }),
-        'Island': dict({
-          'CARD': list([
-            '1IDtqSjJ4Yo45AnNA4SplOiN7ewibifMa',
-            '1HsvTYs1jFGe1c8U1PnNZ9aB8jkAW7KU0',
-          ]),
-        }),
+        'key1': list([
+          '1c4M-sK9gd0Xju0NXCPtqeTW_DQTldVU5',
+        ]),
+        'key2': list([
+          '1IDtqSjJ4Yo45AnNA4SplOiN7ewibifMa',
+          '1HsvTYs1jFGe1c8U1PnNZ9aB8jkAW7KU0',
+        ]),
       }),
     }),
     'status_code': 200,
@@ -1916,12 +1878,10 @@
   dict({
     'json': dict({
       'results': dict({
-        'Island': dict({
-          'CARD': list([
-            '1IDtqSjJ4Yo45AnNA4SplOiN7ewibifMa',
-            '1HsvTYs1jFGe1c8U1PnNZ9aB8jkAW7KU0',
-          ]),
-        }),
+        'key1': list([
+          '1IDtqSjJ4Yo45AnNA4SplOiN7ewibifMa',
+          '1HsvTYs1jFGe1c8U1PnNZ9aB8jkAW7KU0',
+        ]),
       }),
     }),
     'status_code': 200,
@@ -1964,14 +1924,14 @@
       'errors': list([
         dict({
           'ctx': dict({
-            'class_name': 'OldEditorSearchRequest',
+            'class_name': 'EditorSearchRequest',
           }),
           'input': list([
             'test',
           ]),
           'loc': list([
           ]),
-          'msg': 'Input should be a valid dictionary or instance of OldEditorSearchRequest',
+          'msg': 'Input should be a valid dictionary or instance of EditorSearchRequest',
           'type': 'model_type',
           'url': 'https://errors.pydantic.dev/2.10/v/model_type',
         }),
@@ -1993,10 +1953,12 @@
           }),
           'loc': list([
             'queries',
+            'key1',
+            'cardType',
           ]),
-          'msg': 'Input should be a valid list',
-          'type': 'list_type',
-          'url': 'https://errors.pydantic.dev/2.10/v/list_type',
+          'msg': 'Field required',
+          'type': 'missing',
+          'url': 'https://errors.pydantic.dev/2.10/v/missing',
         }),
       ]),
       'message': 'See `errors` field for detailed breakdown.',
@@ -2010,16 +1972,18 @@
     'json': dict({
       'errors': list([
         dict({
-          'input': dict({
-            'cardType': 'garbage',
-            'query': 'Brainstorm',
+          'ctx': dict({
+            'expected': "'CARD', 'CARDBACK' or 'TOKEN'",
           }),
+          'input': 'garbage',
           'loc': list([
             'queries',
+            'key1',
+            'cardType',
           ]),
-          'msg': 'Input should be a valid list',
-          'type': 'list_type',
-          'url': 'https://errors.pydantic.dev/2.10/v/list_type',
+          'msg': "Input should be 'CARD', 'CARDBACK' or 'TOKEN'",
+          'type': 'enum',
+          'url': 'https://errors.pydantic.dev/2.10/v/enum',
         }),
       ]),
       'message': 'See `errors` field for detailed breakdown.',
@@ -2033,16 +1997,30 @@
     'json': dict({
       'errors': list([
         dict({
-          'input': dict({
-            'cardType': 'CARD',
-            'query_garbage': 'Brainstorm',
+          'ctx': dict({
+            'class_name': 'SearchQuery',
           }),
+          'input': 'Brainstorm',
           'loc': list([
             'queries',
+            'query_garbage',
           ]),
-          'msg': 'Input should be a valid list',
-          'type': 'list_type',
-          'url': 'https://errors.pydantic.dev/2.10/v/list_type',
+          'msg': 'Input should be a valid dictionary or instance of SearchQuery',
+          'type': 'model_type',
+          'url': 'https://errors.pydantic.dev/2.10/v/model_type',
+        }),
+        dict({
+          'ctx': dict({
+            'class_name': 'SearchQuery',
+          }),
+          'input': 'CARD',
+          'loc': list([
+            'queries',
+            'cardType',
+          ]),
+          'msg': 'Input should be a valid dictionary or instance of SearchQuery',
+          'type': 'model_type',
+          'url': 'https://errors.pydantic.dev/2.10/v/model_type',
         }),
       ]),
       'message': 'See `errors` field for detailed breakdown.',
@@ -2107,16 +2085,30 @@
     'json': dict({
       'errors': list([
         dict({
-          'input': dict({
-            'cardType': 'CARD',
-            'query_garbage': 'Brainstorm',
+          'ctx': dict({
+            'class_name': 'SearchQuery',
           }),
+          'input': 'Brainstorm',
           'loc': list([
             'queries',
+            'query_garbage',
           ]),
-          'msg': 'Input should be a valid list',
-          'type': 'list_type',
-          'url': 'https://errors.pydantic.dev/2.10/v/list_type',
+          'msg': 'Input should be a valid dictionary or instance of SearchQuery',
+          'type': 'model_type',
+          'url': 'https://errors.pydantic.dev/2.10/v/model_type',
+        }),
+        dict({
+          'ctx': dict({
+            'class_name': 'SearchQuery',
+          }),
+          'input': 'CARD',
+          'loc': list([
+            'queries',
+            'cardType',
+          ]),
+          'msg': 'Input should be a valid dictionary or instance of SearchQuery',
+          'type': 'model_type',
+          'url': 'https://errors.pydantic.dev/2.10/v/model_type',
         }),
         dict({
           'ctx': dict({
@@ -2141,12 +2133,10 @@
   dict({
     'json': dict({
       'results': dict({
-        'Pást in Flames': dict({
-          'CARD': list([
-            '1UPdh7J7hScg4ZnxSPJ-EeBYHLp2s3Oz1',
-            '1dxSLHtw-VwwE09pZCA8OA6LbuWRZPEoU',
-          ]),
-        }),
+        'key1': list([
+          '1UPdh7J7hScg4ZnxSPJ-EeBYHLp2s3Oz1',
+          '1dxSLHtw-VwwE09pZCA8OA6LbuWRZPEoU',
+        ]),
       }),
     }),
     'status_code': 200,
@@ -2156,12 +2146,10 @@
   dict({
     'json': dict({
       'results': dict({
-        'Pást in Flames': dict({
-          'CARD': list([
-            '1dxSLHtw-VwwE09pZCA8OA6LbuWRZPEoU',
-            '1UPdh7J7hScg4ZnxSPJ-EeBYHLp2s3Oz1',
-          ]),
-        }),
+        'key1': list([
+          '1dxSLHtw-VwwE09pZCA8OA6LbuWRZPEoU',
+          '1UPdh7J7hScg4ZnxSPJ-EeBYHLp2s3Oz1',
+        ]),
       }),
     }),
     'status_code': 200,
@@ -2171,10 +2159,8 @@
   dict({
     'json': dict({
       'results': dict({
-        'Pást in Flames': dict({
-          'CARD': list([
-          ]),
-        }),
+        'key1': list([
+        ]),
       }),
     }),
     'status_code': 200,
@@ -2184,11 +2170,9 @@
   dict({
     'json': dict({
       'results': dict({
-        'Pást in Flames': dict({
-          'CARD': list([
-            '1UPdh7J7hScg4ZnxSPJ-EeBYHLp2s3Oz1',
-          ]),
-        }),
+        'key1': list([
+          '1UPdh7J7hScg4ZnxSPJ-EeBYHLp2s3Oz1',
+        ]),
       }),
     }),
     'status_code': 200,
@@ -2198,11 +2182,9 @@
   dict({
     'json': dict({
       'results': dict({
-        'Brainstorm': dict({
-          'CARD': list([
-            '1c4M-sK9gd0Xju0NXCPtqeTW_DQTldVU5',
-          ]),
-        }),
+        'key1': list([
+          '1c4M-sK9gd0Xju0NXCPtqeTW_DQTldVU5',
+        ]),
       }),
     }),
     'status_code': 200,
@@ -2212,11 +2194,9 @@
   dict({
     'json': dict({
       'results': dict({
-        'Simple Lotus': dict({
-          'CARDBACK': list([
-            '1oigI6wz0zA--pNMuExKTs40kBNH6VRP_',
-          ]),
-        }),
+        'key1': list([
+          '1oigI6wz0zA--pNMuExKTs40kBNH6VRP_',
+        ]),
       }),
     }),
     'status_code': 200,
@@ -2226,11 +2206,9 @@
   dict({
     'json': dict({
       'results': dict({
-        'Goblin': dict({
-          'TOKEN': list([
-            '1V5E0avDmNyEUuFfYwx3nA05aj-1HY0rA',
-          ]),
-        }),
+        'key1': list([
+          '1V5E0avDmNyEUuFfYwx3nA05aj-1HY0rA',
+        ]),
       }),
     }),
     'status_code': 200,

--- a/MPCAutofill/cardpicker/tests/__snapshots__/test_views.ambr
+++ b/MPCAutofill/cardpicker/tests/__snapshots__/test_views.ambr
@@ -1964,14 +1964,14 @@
       'errors': list([
         dict({
           'ctx': dict({
-            'class_name': 'EditorSearchRequest',
+            'class_name': 'OldEditorSearchRequest',
           }),
           'input': list([
             'test',
           ]),
           'loc': list([
           ]),
-          'msg': 'Input should be a valid dictionary or instance of EditorSearchRequest',
+          'msg': 'Input should be a valid dictionary or instance of OldEditorSearchRequest',
           'type': 'model_type',
           'url': 'https://errors.pydantic.dev/2.10/v/model_type',
         }),

--- a/MPCAutofill/cardpicker/tests/test_views.py
+++ b/MPCAutofill/cardpicker/tests/test_views.py
@@ -45,54 +45,52 @@ class TestPostEditorSearchResults:
             reverse(views.post_editor_search),
             {
                 "searchSettings": BASE_SEARCH_SETTINGS,
-                "queries": [{"query": Cards.BRAINSTORM.value.name, "cardType": "CARD"}],
+                "queries": {"key1": {"query": Cards.BRAINSTORM.value.name, "cardType": "CARD"}},
             },
             content_type="application/json",
         )
         snapshot_response(response, snapshot)
         assert response.status_code == 200
-        assert response.json()["results"][Cards.BRAINSTORM.value.name]["CARD"] == [Cards.BRAINSTORM.value.identifier]
+        assert response.json()["results"]["key1"] == [Cards.BRAINSTORM.value.identifier]
 
     def test_search_for_single_cardback(self, client, snapshot):
         response = client.post(
             reverse(views.post_editor_search),
             {
                 "searchSettings": BASE_SEARCH_SETTINGS,
-                "queries": [{"query": Cards.SIMPLE_LOTUS.value.name, "cardType": "CARDBACK"}],
+                "queries": {"key1": {"query": Cards.SIMPLE_LOTUS.value.name, "cardType": "CARDBACK"}},
             },
             content_type="application/json",
         )
         snapshot_response(response, snapshot)
         assert response.status_code == 200
-        assert response.json()["results"][Cards.SIMPLE_LOTUS.value.name]["CARDBACK"] == [
-            Cards.SIMPLE_LOTUS.value.identifier
-        ]
+        assert response.json()["results"]["key1"] == [Cards.SIMPLE_LOTUS.value.identifier]
 
     def test_search_for_single_token(self, client, snapshot):
         response = client.post(
             reverse(views.post_editor_search),
             {
                 "searchSettings": BASE_SEARCH_SETTINGS,
-                "queries": [{"query": Cards.GOBLIN.value.name, "cardType": "TOKEN"}],
+                "queries": {"key1": {"query": Cards.GOBLIN.value.name, "cardType": "TOKEN"}},
             },
             content_type="application/json",
         )
         snapshot_response(response, snapshot)
         assert response.status_code == 200
-        assert response.json()["results"][Cards.GOBLIN.value.name]["TOKEN"] == [Cards.GOBLIN.value.identifier]
+        assert response.json()["results"]["key1"] == [Cards.GOBLIN.value.identifier]
 
     def test_complex_search(self, client, snapshot):
         response = client.post(
             reverse(views.post_editor_search),
             {
                 "searchSettings": BASE_SEARCH_SETTINGS,
-                "queries": [
-                    {"query": Cards.BRAINSTORM.value.name, "cardType": "CARD"},
-                    {"query": Cards.ISLAND.value.name, "cardType": "CARD"},
-                    {"query": Cards.SIMPLE_CUBE.value.name, "cardType": "CARDBACK"},
-                    {"query": Cards.SIMPLE_LOTUS.value.name, "cardType": "CARDBACK"},
-                    {"query": Cards.GOBLIN.value.name, "cardType": "TOKEN"},
-                ],
+                "queries": {
+                    "key1": {"query": Cards.BRAINSTORM.value.name, "cardType": "CARD"},
+                    "key2": {"query": Cards.ISLAND.value.name, "cardType": "CARD"},
+                    "key3": {"query": Cards.SIMPLE_CUBE.value.name, "cardType": "CARDBACK"},
+                    "key4": {"query": Cards.SIMPLE_LOTUS.value.name, "cardType": "CARDBACK"},
+                    "key5": {"query": Cards.GOBLIN.value.name, "cardType": "TOKEN"},
+                },
             },
             content_type="application/json",
         )
@@ -104,14 +102,14 @@ class TestPostEditorSearchResults:
             reverse(views.post_editor_search),
             {
                 "searchSettings": BASE_SEARCH_SETTINGS,
-                "queries": [{"query": Cards.ISLAND.value.name, "cardType": "CARD"}],
+                "queries": {"key1": {"query": Cards.ISLAND.value.name, "cardType": "CARD"}},
             },
             content_type="application/json",
         )
         snapshot_response(response, snapshot)
         assert response.status_code == 200
         # `Island` should be before `Island (Classical)` due to priority being given to names with no parentheses
-        assert response.json()["results"][Cards.ISLAND.value.name]["CARD"] == [
+        assert response.json()["results"]["key1"] == [
             Cards.ISLAND.value.identifier,
             Cards.ISLAND_CLASSICAL.value.identifier,
         ]
@@ -121,13 +119,13 @@ class TestPostEditorSearchResults:
             reverse(views.post_editor_search),
             {
                 "searchSettings": BASE_SEARCH_SETTINGS,
-                "queries": [{"query": Cards.PAST_IN_FLAMES_1.value.name, "cardType": "CARD"}],
+                "queries": {"key1": {"query": Cards.PAST_IN_FLAMES_1.value.name, "cardType": "CARD"}},
             },
             content_type="application/json",
         )
         snapshot_response(response, snapshot)
         assert response.status_code == 200
-        assert response.json()["results"][Cards.PAST_IN_FLAMES_1.value.name]["CARD"] == [
+        assert response.json()["results"]["key1"] == [
             Cards.PAST_IN_FLAMES_1.value.identifier,
             Cards.PAST_IN_FLAMES_2.value.identifier,
         ]
@@ -142,13 +140,13 @@ class TestPostEditorSearchResults:
             reverse(views.post_editor_search),
             {
                 "searchSettings": search_settings,
-                "queries": [{"query": Cards.PAST_IN_FLAMES_1.value.name, "cardType": "CARD"}],
+                "queries": {"key1": {"query": Cards.PAST_IN_FLAMES_1.value.name, "cardType": "CARD"}},
             },
             content_type="application/json",
         )
         snapshot_response(response, snapshot)
         assert response.status_code == 200
-        assert response.json()["results"][Cards.PAST_IN_FLAMES_1.value.name]["CARD"] == [
+        assert response.json()["results"]["key1"] == [
             Cards.PAST_IN_FLAMES_2.value.identifier,
             Cards.PAST_IN_FLAMES_1.value.identifier,
         ]
@@ -163,15 +161,13 @@ class TestPostEditorSearchResults:
             reverse(views.post_editor_search),
             {
                 "searchSettings": search_settings,
-                "queries": [{"query": Cards.PAST_IN_FLAMES_1.value.name, "cardType": "CARD"}],
+                "queries": {"key1": {"query": Cards.PAST_IN_FLAMES_1.value.name, "cardType": "CARD"}},
             },
             content_type="application/json",
         )
         snapshot_response(response, snapshot)
         assert response.status_code == 200
-        assert response.json()["results"][Cards.PAST_IN_FLAMES_1.value.name]["CARD"] == [
-            Cards.PAST_IN_FLAMES_1.value.identifier
-        ]
+        assert response.json()["results"]["key1"] == [Cards.PAST_IN_FLAMES_1.value.identifier]
 
     def test_search_for_card_with_versions_from_two_sources_with_all_sources_disabled(self, client, snapshot):
         search_settings = deepcopy(BASE_SEARCH_SETTINGS)
@@ -183,25 +179,28 @@ class TestPostEditorSearchResults:
             reverse(views.post_editor_search),
             {
                 "searchSettings": search_settings,
-                "queries": [{"query": Cards.PAST_IN_FLAMES_1.value.name, "cardType": "CARD"}],
+                "queries": {"key1": {"query": Cards.PAST_IN_FLAMES_1.value.name, "cardType": "CARD"}},
             },
             content_type="application/json",
         )
         snapshot_response(response, snapshot)
         assert response.status_code == 200
-        assert response.json()["results"][Cards.PAST_IN_FLAMES_1.value.name]["CARD"] == []
+        assert response.json()["results"]["key1"] == []
 
     def test_fuzzy_search(self, client, snapshot):
         search_settings = deepcopy(BASE_SEARCH_SETTINGS)
         search_settings["searchTypeSettings"]["fuzzySearch"] = True
         response = client.post(
             reverse(views.post_editor_search),
-            {"searchSettings": search_settings, "queries": [{"query": "past in", "cardType": "CARD"}]},
+            {
+                "searchSettings": search_settings,
+                "queries": {"key1": {"query": "past in", "cardType": "CARD"}},
+            },
             content_type="application/json",
         )
         snapshot_response(response, snapshot)
         assert response.status_code == 200
-        assert response.json()["results"]["past in"]["CARD"] == [
+        assert response.json()["results"]["key1"] == [
             Cards.PAST_IN_FLAMES_1.value.identifier,
             Cards.PAST_IN_FLAMES_2.value.identifier,
         ]
@@ -213,13 +212,13 @@ class TestPostEditorSearchResults:
             reverse(views.post_editor_search),
             {
                 "searchSettings": search_settings,
-                "queries": [{"query": Cards.SIMPLE_CUBE.value.name, "cardType": "CARDBACK"}],
+                "queries": {"key1": {"query": Cards.SIMPLE_CUBE.value.name, "cardType": "CARDBACK"}},
             },
             content_type="application/json",
         )
         snapshot_response(response, snapshot)
         assert response.status_code == 200
-        assert response.json()["results"][Cards.SIMPLE_CUBE.value.name]["CARDBACK"] == []
+        assert response.json()["results"]["key1"] == []
 
     def test_maximum_dpi_yielding_no_search_results(self, client, snapshot):
         search_settings = deepcopy(BASE_SEARCH_SETTINGS)
@@ -228,13 +227,13 @@ class TestPostEditorSearchResults:
             reverse(views.post_editor_search),
             {
                 "searchSettings": search_settings,
-                "queries": [{"query": Cards.SIMPLE_CUBE.value.name, "cardType": "CARDBACK"}],
+                "queries": {"key1": {"query": Cards.SIMPLE_CUBE.value.name, "cardType": "CARDBACK"}},
             },
             content_type="application/json",
         )
         snapshot_response(response, snapshot)
         assert response.status_code == 200
-        assert response.json()["results"][Cards.SIMPLE_CUBE.value.name]["CARDBACK"] == []
+        assert response.json()["results"]["key1"] == []
 
     def test_minimum_dpi_yielding_fewer_search_results(self, client, snapshot):
         search_settings = deepcopy(BASE_SEARCH_SETTINGS)
@@ -243,15 +242,13 @@ class TestPostEditorSearchResults:
             reverse(views.post_editor_search),
             {
                 "searchSettings": search_settings,
-                "queries": [{"query": Cards.PAST_IN_FLAMES_1.value.name, "cardType": "CARD"}],
+                "queries": {"key1": {"query": Cards.PAST_IN_FLAMES_1.value.name, "cardType": "CARD"}},
             },
             content_type="application/json",
         )
         snapshot_response(response, snapshot)
         assert response.status_code == 200
-        assert response.json()["results"][Cards.PAST_IN_FLAMES_1.value.name]["CARD"] == [
-            Cards.PAST_IN_FLAMES_1.value.identifier
-        ]
+        assert response.json()["results"]["key1"] == [Cards.PAST_IN_FLAMES_1.value.identifier]
 
     def test_maximum_size_yielding_fewer_search_results(self, client, snapshot):
         search_settings = deepcopy(BASE_SEARCH_SETTINGS)
@@ -260,15 +257,13 @@ class TestPostEditorSearchResults:
             reverse(views.post_editor_search),
             {
                 "searchSettings": search_settings,
-                "queries": [{"query": Cards.PAST_IN_FLAMES_1.value.name, "cardType": "CARD"}],
+                "queries": {"key1": {"query": Cards.PAST_IN_FLAMES_1.value.name, "cardType": "CARD"}},
             },
             content_type="application/json",
         )
         snapshot_response(response, snapshot)
         assert response.status_code == 200
-        assert response.json()["results"][Cards.PAST_IN_FLAMES_1.value.name]["CARD"] == [
-            Cards.PAST_IN_FLAMES_2.value.identifier
-        ]
+        assert response.json()["results"]["key1"] == [Cards.PAST_IN_FLAMES_2.value.identifier]
 
     def test_get_one_row_filtered_one_language(self, client, snapshot, past_in_flames_1, past_in_flames_2):
         search_settings = deepcopy(BASE_SEARCH_SETTINGS)
@@ -277,13 +272,13 @@ class TestPostEditorSearchResults:
             reverse(views.post_editor_search),
             {
                 "searchSettings": search_settings,
-                "queries": [{"query": Cards.PAST_IN_FLAMES_1.value.name, "cardType": "CARD"}],
+                "queries": {"key1": {"query": Cards.PAST_IN_FLAMES_1.value.name, "cardType": "CARD"}},
             },
             content_type="application/json",
         )
         snapshot_response(response, snapshot)
         assert response.status_code == 200
-        assert len(response.json()["results"][Cards.PAST_IN_FLAMES_1.value.name]["CARD"]) == 1
+        assert len(response.json()["results"]["key1"]) == 1
 
     def test_get_multiple_rows_filtered_two_languages(self, client, snapshot, past_in_flames_1, past_in_flames_2):
         search_settings = deepcopy(BASE_SEARCH_SETTINGS)
@@ -292,13 +287,13 @@ class TestPostEditorSearchResults:
             reverse(views.post_editor_search),
             {
                 "searchSettings": search_settings,
-                "queries": [{"query": Cards.PAST_IN_FLAMES_1.value.name, "cardType": "CARD"}],
+                "queries": {"key1": {"query": Cards.PAST_IN_FLAMES_1.value.name, "cardType": "CARD"}},
             },
             content_type="application/json",
         )
         snapshot_response(response, snapshot)
         assert response.status_code == 200
-        assert len(response.json()["results"][Cards.PAST_IN_FLAMES_1.value.name]["CARD"]) == 2
+        assert len(response.json()["results"]["key1"]) == 2
 
     def test_get_one_row_filtered_includes_one_tag(
         self, client, snapshot, past_in_flames_1, past_in_flames_2, another_tag_in_data
@@ -309,13 +304,13 @@ class TestPostEditorSearchResults:
             reverse(views.post_editor_search),
             {
                 "searchSettings": search_settings,
-                "queries": [{"query": Cards.PAST_IN_FLAMES_1.value.name, "cardType": "CARD"}],
+                "queries": {"key1": {"query": Cards.PAST_IN_FLAMES_1.value.name, "cardType": "CARD"}},
             },
             content_type="application/json",
         )
         snapshot_response(response, snapshot)
         assert response.status_code == 200
-        assert len(response.json()["results"][Cards.PAST_IN_FLAMES_1.value.name]["CARD"]) == 1
+        assert len(response.json()["results"]["key1"]) == 1
 
     def test_get_one_row_filtered_excludes_one_tag(
         self, client, snapshot, past_in_flames_1, past_in_flames_2, another_tag_in_data
@@ -326,13 +321,13 @@ class TestPostEditorSearchResults:
             reverse(views.post_editor_search),
             {
                 "searchSettings": search_settings,
-                "queries": [{"query": Cards.PAST_IN_FLAMES_2.value.name, "cardType": "CARD"}],
+                "queries": {"key1": {"query": Cards.PAST_IN_FLAMES_2.value.name, "cardType": "CARD"}},
             },
             content_type="application/json",
         )
         snapshot_response(response, snapshot)
         assert response.status_code == 200
-        assert len(response.json()["results"][Cards.PAST_IN_FLAMES_2.value.name]["CARD"]) == 1
+        assert len(response.json()["results"]["key1"]) == 1
 
     def test_get_multiple_rows_filtered_includes_one_tag(
         self, client, snapshot, past_in_flames_1, past_in_flames_2, tag_in_data
@@ -343,13 +338,13 @@ class TestPostEditorSearchResults:
             reverse(views.post_editor_search),
             {
                 "searchSettings": search_settings,
-                "queries": [{"query": Cards.PAST_IN_FLAMES_1.value.name, "cardType": "CARD"}],
+                "queries": {"key1": {"query": Cards.PAST_IN_FLAMES_1.value.name, "cardType": "CARD"}},
             },
             content_type="application/json",
         )
         snapshot_response(response, snapshot)
         assert response.status_code == 200
-        assert len(response.json()["results"][Cards.PAST_IN_FLAMES_1.value.name]["CARD"]) == 2
+        assert len(response.json()["results"]["key1"]) == 2
 
     def test_get_multiple_rows_filtered_includes_one_tag_and_excludes_another(
         self, client, snapshot, past_in_flames_1, past_in_flames_2, tag_in_data, another_tag_in_data
@@ -361,13 +356,13 @@ class TestPostEditorSearchResults:
             reverse(views.post_editor_search),
             {
                 "searchSettings": search_settings,
-                "queries": [{"query": Cards.PAST_IN_FLAMES_1.value.name, "cardType": "CARD"}],
+                "queries": {"key1": {"query": Cards.PAST_IN_FLAMES_1.value.name, "cardType": "CARD"}},
             },
             content_type="application/json",
         )
         snapshot_response(response, snapshot)
         assert response.status_code == 200
-        assert len(response.json()["results"][Cards.PAST_IN_FLAMES_1.value.name]["CARD"]) == 1
+        assert len(response.json()["results"]["key1"]) == 1
 
     def test_get_multiple_rows_filtered_includes_two_tags(
         self, client, snapshot, past_in_flames_1, past_in_flames_2, tag_in_data, another_tag_in_data
@@ -378,13 +373,13 @@ class TestPostEditorSearchResults:
             reverse(views.post_editor_search),
             {
                 "searchSettings": search_settings,
-                "queries": [{"query": Cards.PAST_IN_FLAMES_1.value.name, "cardType": "CARD"}],
+                "queries": {"key1": {"query": Cards.PAST_IN_FLAMES_1.value.name, "cardType": "CARD"}},
             },
             content_type="application/json",
         )
         snapshot_response(response, snapshot)
         assert response.status_code == 200
-        assert len(response.json()["results"][Cards.PAST_IN_FLAMES_1.value.name]["CARD"]) == 2
+        assert len(response.json()["results"]["key1"]) == 2
 
     def test_page_equal_to_max_size(self, client, monkeypatch, snapshot):
         monkeypatch.setattr("cardpicker.views.EDITOR_SEARCH_MAX_QUERIES", 2)
@@ -392,10 +387,10 @@ class TestPostEditorSearchResults:
             reverse(views.post_editor_search),
             {
                 "searchSettings": BASE_SEARCH_SETTINGS,
-                "queries": [
-                    {"query": Cards.BRAINSTORM.value.name, "cardType": "CARD"},
-                    {"query": Cards.ISLAND.value.name, "cardType": "CARD"},
-                ],
+                "queries": {
+                    "key1": {"query": Cards.BRAINSTORM.value.name, "cardType": "CARD"},
+                    "key2": {"query": Cards.ISLAND.value.name, "cardType": "CARD"},
+                },
             },
             content_type="application/json",
         )
@@ -408,11 +403,11 @@ class TestPostEditorSearchResults:
             reverse(views.post_editor_search),
             {
                 "searchSettings": BASE_SEARCH_SETTINGS,
-                "queries": [
-                    {"query": Cards.BRAINSTORM.value.name, "cardType": "CARD"},
-                    {"query": Cards.ISLAND.value.name, "cardType": "CARD"},
-                    {"query": Cards.SIMPLE_CUBE.value.name, "cardType": "CARDBACK"},
-                ],
+                "queries": {
+                    "key1": {"query": Cards.BRAINSTORM.value.name, "cardType": "CARD"},
+                    "key2": {"query": Cards.ISLAND.value.name, "cardType": "CARD"},
+                    "key3": {"query": Cards.SIMPLE_CUBE.value.name, "cardType": "CARDBACK"},
+                },
             },
             content_type="application/json",
         )
@@ -432,11 +427,11 @@ class TestPostEditorSearchResults:
             },
             {
                 "searchSettings": BASE_SEARCH_SETTINGS,
-                "queries": {"query": Cards.BRAINSTORM.value.name, "cardType": "garbage"},
+                "queries": {"key1": {"query": Cards.BRAINSTORM.value.name, "cardType": "garbage"}},
             },
             {
                 "searchSettings": BASE_SEARCH_SETTINGS,
-                "queries": {"query": Cards.BRAINSTORM.value.name, "card_type_garbage": "CARD"},
+                "queries": {"key1": {"query": Cards.BRAINSTORM.value.name, "card_type_garbage": "CARD"}},
             },
         ],
         ids=[
@@ -666,7 +661,7 @@ class TestPostExploreSearchResults:
         assert response.status_code == 400
 
     def test_get_request(self, client, django_settings, snapshot):
-        response = client.get(reverse(views.post_editor_search))
+        response = client.get(reverse(views.post_explore_search))
         snapshot_response(response, snapshot)
         assert response.status_code == 400
 

--- a/MPCAutofill/cardpicker/urls.py
+++ b/MPCAutofill/cardpicker/urls.py
@@ -3,7 +3,8 @@ from django.urls import path
 from . import views
 
 urlpatterns = [
-    path("2/editorSearch/", views.post_editor_search),
+    path("2/editorSearch/", views.old_post_editor_search),
+    path("3/editorSearch/", views.post_editor_search),
     path("2/exploreSearch/", views.post_explore_search),
     path("2/cards/", views.post_cards),
     path("2/sources/", views.get_sources),

--- a/MPCAutofill/cardpicker/views.py
+++ b/MPCAutofill/cardpicker/views.py
@@ -31,8 +31,6 @@ from cardpicker.schema_types import (
     CardsResponse,
     ContributionsResponse,
     DFCPairsResponse,
-    EditorSearchRequest,
-    EditorSearchResponse,
     ErrorResponse,
     ExploreSearchRequest,
     ExploreSearchResponse,
@@ -47,6 +45,8 @@ from cardpicker.schema_types import (
     NewCardsFirstPage,
     NewCardsFirstPagesResponse,
     NewCardsPageResponse,
+    OldEditorSearchRequest,
+    OldEditorSearchResponse,
     Patreon,
     PatreonResponse,
     SampleCardsResponse,
@@ -121,7 +121,7 @@ def post_editor_search(request: HttpRequest) -> HttpResponse:
     if request.method != "POST":
         raise BadRequestException("Expected POST request.")
 
-    editor_search_request = EditorSearchRequest.model_validate(json.loads(request.body))
+    editor_search_request = OldEditorSearchRequest.model_validate(json.loads(request.body))
     if not ping_elasticsearch():
         raise SearchExceptions.ElasticsearchOfflineException()
     if not Index(CardSearch.Index.name).exists():
@@ -140,7 +140,7 @@ def post_editor_search(request: HttpRequest) -> HttpResponse:
                 query=query, card_type=card_type, search_settings=editor_search_request.searchSettings
             )
             results[query][card_type.value] = hits
-    return JsonResponse(EditorSearchResponse(results=results).model_dump())
+    return JsonResponse(OldEditorSearchResponse(results=results).model_dump())
 
 
 @csrf_exempt

--- a/MPCAutofill/cardpicker/views.py
+++ b/MPCAutofill/cardpicker/views.py
@@ -31,6 +31,8 @@ from cardpicker.schema_types import (
     CardsResponse,
     ContributionsResponse,
     DFCPairsResponse,
+    EditorSearchRequest,
+    EditorSearchResponse,
     ErrorResponse,
     ExploreSearchRequest,
     ExploreSearchResponse,
@@ -109,6 +111,39 @@ class ErrorWrappers:
 @csrf_exempt
 @ErrorWrappers.to_json
 def post_editor_search(request: HttpRequest) -> HttpResponse:
+    if request.method != "POST":
+        raise BadRequestException("Expected POST request.")
+
+    editor_search_request = EditorSearchRequest.model_validate(json.loads(request.body))
+    if not ping_elasticsearch():
+        raise SearchExceptions.ElasticsearchOfflineException()
+    if not Index(CardSearch.Index.name).exists():
+        raise SearchExceptions.IndexNotFoundException(CardSearch.__name__)
+
+    if len(editor_search_request.queries) > EDITOR_SEARCH_MAX_QUERIES:
+        raise BadRequestException(
+            f"Invalid query count {len(editor_search_request.queries)}. "
+            f"Must be less than or equal to {EDITOR_SEARCH_MAX_QUERIES}."
+        )
+
+    results: dict[str, list[str]] = {}
+    for hash_key, search_query in editor_search_request.queries.items():
+        if search_query.query is not None and hash_key not in results.keys():
+            hits = retrieve_card_identifiers(
+                query=search_query.query,
+                card_type=search_query.cardType,
+                search_settings=editor_search_request.searchSettings,
+            )
+            results[hash_key] = hits
+    return JsonResponse(EditorSearchResponse(results=results).model_dump())
+
+
+@csrf_exempt
+@ErrorWrappers.to_json
+def old_post_editor_search(request: HttpRequest) -> HttpResponse:
+    # TODO: This endpoint is only kept for backwards compatibility
+    # in case unofficial third-party clients depend on it.
+    # It is not covered by automated tests and is subject to removal in the future.
     """
     Return the first page of search results for a given list of queries.
     Each query should be of the form {card name, card type}.

--- a/frontend/src/common/processing.ts
+++ b/frontend/src/common/processing.ts
@@ -397,3 +397,16 @@ export const extractLanguage = (name: string): [string | undefined, string] => {
   const remainderOfName = results[2];
   return [languageCode, remainderOfName];
 };
+
+export const fnv1aHash = (input: string): number => {
+  let hash = 2166136261; // FNV-1a 32-bit offset basis
+  for (let i = 0; i < input.length; i++) {
+    hash ^= input.charCodeAt(i);
+    hash = Math.imul(hash, 16777619); // 32-bit multiply
+    hash >>>= 0; // keep unsigned 32-bit
+  }
+  return hash;
+};
+
+export const computeSearchQueryHashKey = (searchQuery: SearchQuery): string =>
+  fnv1aHash(JSON.stringify(searchQuery)).toString();

--- a/frontend/src/common/schema_types.ts
+++ b/frontend/src/common/schema_types.ts
@@ -2,7 +2,7 @@
 
 // To parse this data:
 //
-//   import { Convert, Campaign, CanonicalArtist, CanonicalCard, Card, CardType, FilterSettings, Game, ImportSite, Language, NewCardsFirstPage, SearchQuery, SearchSettings, SearchTypeSettings, SortBy, Source, SourceContribution, SourceSettings, SourceType, Supporter, SupporterTier, Tag, CardbacksRequest, CardbacksResponse, CardsRequest, CardsResponse, ContributionsResponse, DFCPairsResponse, EditorSearchRequest, EditorSearchResponse, ErrorResponse, ExploreSearchRequest, ExploreSearchResponse, ImportSiteDecklistRequest, ImportSiteDecklistResponse, ImportSitesResponse, InfoResponse, LanguagesResponse, NewCardsFirstPagesResponse, NewCardsPageResponse, PatreonResponse, SampleCardsResponse, SearchEngineHealthResponse, SourcesResponse, TagsResponse } from "./file";
+//   import { Convert, Campaign, CanonicalArtist, CanonicalCard, Card, CardType, FilterSettings, Game, ImportSite, Language, NewCardsFirstPage, SearchQuery, SearchSettings, SearchTypeSettings, SortBy, Source, SourceContribution, SourceSettings, SourceType, Supporter, SupporterTier, Tag, CardbacksRequest, CardbacksResponse, CardsRequest, CardsResponse, ContributionsResponse, DFCPairsResponse, ErrorResponse, ExploreSearchRequest, ExploreSearchResponse, ImportSiteDecklistRequest, ImportSiteDecklistResponse, ImportSitesResponse, InfoResponse, LanguagesResponse, NewCardsFirstPagesResponse, NewCardsPageResponse, OldEditorSearchRequest, OldEditorSearchResponse, PatreonResponse, SampleCardsResponse, SearchEngineHealthResponse, SourcesResponse, TagsResponse } from "./file";
 //
 //   const campaign = Convert.toCampaign(json);
 //   const canonicalArtist = Convert.toCanonicalArtist(json);
@@ -32,8 +32,6 @@
 //   const cardsResponse = Convert.toCardsResponse(json);
 //   const contributionsResponse = Convert.toContributionsResponse(json);
 //   const dFCPairsResponse = Convert.toDFCPairsResponse(json);
-//   const editorSearchRequest = Convert.toEditorSearchRequest(json);
-//   const editorSearchResponse = Convert.toEditorSearchResponse(json);
 //   const errorResponse = Convert.toErrorResponse(json);
 //   const exploreSearchRequest = Convert.toExploreSearchRequest(json);
 //   const exploreSearchResponse = Convert.toExploreSearchResponse(json);
@@ -44,6 +42,8 @@
 //   const languagesResponse = Convert.toLanguagesResponse(json);
 //   const newCardsFirstPagesResponse = Convert.toNewCardsFirstPagesResponse(json);
 //   const newCardsPageResponse = Convert.toNewCardsPageResponse(json);
+//   const oldEditorSearchRequest = Convert.toOldEditorSearchRequest(json);
+//   const oldEditorSearchResponse = Convert.toOldEditorSearchResponse(json);
 //   const patreonResponse = Convert.toPatreonResponse(json);
 //   const sampleCardsResponse = Convert.toSampleCardsResponse(json);
 //   const searchEngineHealthResponse = Convert.toSearchEngineHealthResponse(json);
@@ -204,20 +204,6 @@ export interface DFCPairsResponse {
   dfcPairs: { [key: string]: string };
 }
 
-export interface EditorSearchRequest {
-  queries: SearchQuery[];
-  searchSettings: SearchSettings;
-}
-
-export interface SearchQuery {
-  cardType: CardType;
-  query: null | string;
-}
-
-export interface EditorSearchResponse {
-  results: { [key: string]: { [key: string]: string[] } };
-}
-
 export interface ErrorResponse {
   errors?: { [key: string]: any }[];
   message?: string;
@@ -310,6 +296,20 @@ export interface Source {
 
 export interface NewCardsPageResponse {
   cards: Card[];
+}
+
+export interface OldEditorSearchRequest {
+  queries: SearchQuery[];
+  searchSettings: SearchSettings;
+}
+
+export interface SearchQuery {
+  cardType: CardType;
+  query: null | string;
+}
+
+export interface OldEditorSearchResponse {
+  results: { [key: string]: { [key: string]: string[] } };
 }
 
 export interface PatreonResponse {
@@ -614,24 +614,6 @@ export class Convert {
     return JSON.stringify(uncast(value, r("DFCPairsResponse")), null, 2);
   }
 
-  public static toEditorSearchRequest(json: string): EditorSearchRequest {
-    return cast(JSON.parse(json), r("EditorSearchRequest"));
-  }
-
-  public static editorSearchRequestToJson(value: EditorSearchRequest): string {
-    return JSON.stringify(uncast(value, r("EditorSearchRequest")), null, 2);
-  }
-
-  public static toEditorSearchResponse(json: string): EditorSearchResponse {
-    return cast(JSON.parse(json), r("EditorSearchResponse"));
-  }
-
-  public static editorSearchResponseToJson(
-    value: EditorSearchResponse
-  ): string {
-    return JSON.stringify(uncast(value, r("EditorSearchResponse")), null, 2);
-  }
-
   public static toErrorResponse(json: string): ErrorResponse {
     return cast(JSON.parse(json), r("ErrorResponse"));
   }
@@ -740,6 +722,28 @@ export class Convert {
     value: NewCardsPageResponse
   ): string {
     return JSON.stringify(uncast(value, r("NewCardsPageResponse")), null, 2);
+  }
+
+  public static toOldEditorSearchRequest(json: string): OldEditorSearchRequest {
+    return cast(JSON.parse(json), r("OldEditorSearchRequest"));
+  }
+
+  public static oldEditorSearchRequestToJson(
+    value: OldEditorSearchRequest
+  ): string {
+    return JSON.stringify(uncast(value, r("OldEditorSearchRequest")), null, 2);
+  }
+
+  public static toOldEditorSearchResponse(
+    json: string
+  ): OldEditorSearchResponse {
+    return cast(JSON.parse(json), r("OldEditorSearchResponse"));
+  }
+
+  public static oldEditorSearchResponseToJson(
+    value: OldEditorSearchResponse
+  ): string {
+    return JSON.stringify(uncast(value, r("OldEditorSearchResponse")), null, 2);
   }
 
   public static toPatreonResponse(json: string): PatreonResponse {
@@ -1121,28 +1125,6 @@ const typeMap: any = {
     [{ json: "dfcPairs", js: "dfcPairs", typ: m("") }],
     false
   ),
-  EditorSearchRequest: o(
-    [
-      { json: "queries", js: "queries", typ: a(r("SearchQuery")) },
-      {
-        json: "searchSettings",
-        js: "searchSettings",
-        typ: r("SearchSettings"),
-      },
-    ],
-    false
-  ),
-  SearchQuery: o(
-    [
-      { json: "cardType", js: "cardType", typ: r("CardType") },
-      { json: "query", js: "query", typ: u(null, "") },
-    ],
-    false
-  ),
-  EditorSearchResponse: o(
-    [{ json: "results", js: "results", typ: m(m(a(""))) }],
-    false
-  ),
   ErrorResponse: o(
     [
       { json: "errors", js: "errors", typ: u(undefined, a(m("any"))) },
@@ -1237,6 +1219,28 @@ const typeMap: any = {
   ),
   NewCardsPageResponse: o(
     [{ json: "cards", js: "cards", typ: a(r("Card")) }],
+    false
+  ),
+  OldEditorSearchRequest: o(
+    [
+      { json: "queries", js: "queries", typ: a(r("SearchQuery")) },
+      {
+        json: "searchSettings",
+        js: "searchSettings",
+        typ: r("SearchSettings"),
+      },
+    ],
+    false
+  ),
+  SearchQuery: o(
+    [
+      { json: "cardType", js: "cardType", typ: r("CardType") },
+      { json: "query", js: "query", typ: u(null, "") },
+    ],
+    false
+  ),
+  OldEditorSearchResponse: o(
+    [{ json: "results", js: "results", typ: m(m(a(""))) }],
     false
   ),
   PatreonResponse: o(

--- a/frontend/src/common/schema_types.ts
+++ b/frontend/src/common/schema_types.ts
@@ -2,7 +2,7 @@
 
 // To parse this data:
 //
-//   import { Convert, Campaign, CanonicalArtist, CanonicalCard, Card, CardType, FilterSettings, Game, ImportSite, Language, NewCardsFirstPage, SearchQuery, SearchSettings, SearchTypeSettings, SortBy, Source, SourceContribution, SourceSettings, SourceType, Supporter, SupporterTier, Tag, CardbacksRequest, CardbacksResponse, CardsRequest, CardsResponse, ContributionsResponse, DFCPairsResponse, ErrorResponse, ExploreSearchRequest, ExploreSearchResponse, ImportSiteDecklistRequest, ImportSiteDecklistResponse, ImportSitesResponse, InfoResponse, LanguagesResponse, NewCardsFirstPagesResponse, NewCardsPageResponse, OldEditorSearchRequest, OldEditorSearchResponse, PatreonResponse, SampleCardsResponse, SearchEngineHealthResponse, SourcesResponse, TagsResponse } from "./file";
+//   import { Convert, Campaign, CanonicalArtist, CanonicalCard, Card, CardType, FilterSettings, Game, ImportSite, Language, NewCardsFirstPage, SearchQuery, SearchSettings, SearchTypeSettings, SortBy, Source, SourceContribution, SourceSettings, SourceType, Supporter, SupporterTier, Tag, CardbacksRequest, CardbacksResponse, CardsRequest, CardsResponse, ContributionsResponse, DFCPairsResponse, EditorSearchRequest, EditorSearchResponse, ErrorResponse, ExploreSearchRequest, ExploreSearchResponse, ImportSiteDecklistRequest, ImportSiteDecklistResponse, ImportSitesResponse, InfoResponse, LanguagesResponse, NewCardsFirstPagesResponse, NewCardsPageResponse, OldEditorSearchRequest, OldEditorSearchResponse, PatreonResponse, SampleCardsResponse, SearchEngineHealthResponse, SourcesResponse, TagsResponse } from "./file";
 //
 //   const campaign = Convert.toCampaign(json);
 //   const canonicalArtist = Convert.toCanonicalArtist(json);
@@ -32,6 +32,8 @@
 //   const cardsResponse = Convert.toCardsResponse(json);
 //   const contributionsResponse = Convert.toContributionsResponse(json);
 //   const dFCPairsResponse = Convert.toDFCPairsResponse(json);
+//   const editorSearchRequest = Convert.toEditorSearchRequest(json);
+//   const editorSearchResponse = Convert.toEditorSearchResponse(json);
 //   const errorResponse = Convert.toErrorResponse(json);
 //   const exploreSearchRequest = Convert.toExploreSearchRequest(json);
 //   const exploreSearchResponse = Convert.toExploreSearchResponse(json);
@@ -204,6 +206,20 @@ export interface DFCPairsResponse {
   dfcPairs: { [key: string]: string };
 }
 
+export interface EditorSearchRequest {
+  queries: { [key: string]: SearchQuery };
+  searchSettings: SearchSettings;
+}
+
+export interface SearchQuery {
+  cardType: CardType;
+  query: null | string;
+}
+
+export interface EditorSearchResponse {
+  results: { [key: string]: string[] };
+}
+
 export interface ErrorResponse {
   errors?: { [key: string]: any }[];
   message?: string;
@@ -301,11 +317,6 @@ export interface NewCardsPageResponse {
 export interface OldEditorSearchRequest {
   queries: SearchQuery[];
   searchSettings: SearchSettings;
-}
-
-export interface SearchQuery {
-  cardType: CardType;
-  query: null | string;
 }
 
 export interface OldEditorSearchResponse {
@@ -612,6 +623,24 @@ export class Convert {
 
   public static dFCPairsResponseToJson(value: DFCPairsResponse): string {
     return JSON.stringify(uncast(value, r("DFCPairsResponse")), null, 2);
+  }
+
+  public static toEditorSearchRequest(json: string): EditorSearchRequest {
+    return cast(JSON.parse(json), r("EditorSearchRequest"));
+  }
+
+  public static editorSearchRequestToJson(value: EditorSearchRequest): string {
+    return JSON.stringify(uncast(value, r("EditorSearchRequest")), null, 2);
+  }
+
+  public static toEditorSearchResponse(json: string): EditorSearchResponse {
+    return cast(JSON.parse(json), r("EditorSearchResponse"));
+  }
+
+  public static editorSearchResponseToJson(
+    value: EditorSearchResponse
+  ): string {
+    return JSON.stringify(uncast(value, r("EditorSearchResponse")), null, 2);
   }
 
   public static toErrorResponse(json: string): ErrorResponse {
@@ -1125,6 +1154,28 @@ const typeMap: any = {
     [{ json: "dfcPairs", js: "dfcPairs", typ: m("") }],
     false
   ),
+  EditorSearchRequest: o(
+    [
+      { json: "queries", js: "queries", typ: m(r("SearchQuery")) },
+      {
+        json: "searchSettings",
+        js: "searchSettings",
+        typ: r("SearchSettings"),
+      },
+    ],
+    false
+  ),
+  SearchQuery: o(
+    [
+      { json: "cardType", js: "cardType", typ: r("CardType") },
+      { json: "query", js: "query", typ: u(null, "") },
+    ],
+    false
+  ),
+  EditorSearchResponse: o(
+    [{ json: "results", js: "results", typ: m(a("")) }],
+    false
+  ),
   ErrorResponse: o(
     [
       { json: "errors", js: "errors", typ: u(undefined, a(m("any"))) },
@@ -1229,13 +1280,6 @@ const typeMap: any = {
         js: "searchSettings",
         typ: r("SearchSettings"),
       },
-    ],
-    false
-  ),
-  SearchQuery: o(
-    [
-      { json: "cardType", js: "cardType", typ: r("CardType") },
-      { json: "query", js: "query", typ: u(null, "") },
     ],
     false
   ),

--- a/frontend/src/common/types.ts
+++ b/frontend/src/common/types.ts
@@ -37,7 +37,7 @@ export type {
   SupporterTier,
   Tag,
 } from "@/common/schema_types";
-import { Orama, Schema, SearchableType } from "@orama/orama";
+import { Orama, SearchableType } from "@orama/orama";
 
 export const assertNever = (value: never) => {
   throw new Error("Unexpected value: " + value);
@@ -104,12 +104,8 @@ export interface SourceDocumentsState extends ThunkStateBase {
   sourceDocuments?: SourceDocuments; // null indicates the data has not yet loaded from the backend
 }
 
-export type SearchResultsForQuery = {
-  [cardType in CardType]?: Array<string>;
-};
-
 export interface SearchResults {
-  [query: string]: SearchResultsForQuery;
+  [hashKey: string]: Array<string>;
 }
 
 export interface SearchResultsState extends ThunkStateBase {

--- a/frontend/src/features/clientSearch/clientSearchService.worker.ts
+++ b/frontend/src/features/clientSearch/clientSearchService.worker.ts
@@ -2,7 +2,7 @@ import { create, getByID, insertMultiple, search } from "@orama/orama";
 import { expose } from "comlink";
 
 import { Printing, Unknown } from "@/common/constants";
-import { toSearchable } from "@/common/processing";
+import { computeSearchQueryHashKey, toSearchable } from "@/common/processing";
 import {
   CardType as CardTypeSchema,
   SearchQuery,
@@ -391,14 +391,9 @@ export class ClientSearchService {
     const localResults: SearchResults = {};
     for (const searchQuery of searchQueries) {
       if (searchQuery.query) {
-        if (
-          !Object.prototype.hasOwnProperty.call(localResults, searchQuery.query)
-        ) {
-          localResults[searchQuery.query] = {
-            CARD: [],
-            CARDBACK: [],
-            TOKEN: [],
-          };
+        const hashkey = computeSearchQueryHashKey(searchQuery);
+        if (!Object.prototype.hasOwnProperty.call(localResults, hashkey)) {
+          localResults[searchQuery.query] = [];
         }
 
         const localResultsForQuery = this.retrieveCardIdentifiers(
@@ -407,8 +402,7 @@ export class ClientSearchService {
           [searchQuery.cardType]
         );
         if (localResultsForQuery !== undefined) {
-          localResults[searchQuery.query][searchQuery.cardType] =
-            localResultsForQuery;
+          localResults[hashkey] = localResultsForQuery;
         }
       }
     }

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -1,7 +1,13 @@
 import { http, HttpResponse } from "msw";
 
 import { Card, Cardback, Token } from "@/common/constants";
-import { Campaign, Supporter, SupporterTier } from "@/common/schema_types";
+import { computeSearchQueryHashKey } from "@/common/processing";
+import {
+  Campaign,
+  CardType,
+  Supporter,
+  SupporterTier,
+} from "@/common/schema_types";
 import {
   cardDocument1,
   cardDocument2,
@@ -253,21 +259,20 @@ export const cardbacksServerError = http.post(buildRoute("2/cardbacks/"), () =>
 //# region search results
 
 export const searchResultsNoResults = http.post(
-  buildRoute("2/editorSearch/"),
+  buildRoute("3/editorSearch/"),
   () => HttpResponse.json({ results: {} }, { status: 200 })
 );
 
 export const searchResultsOneResult = http.post(
-  buildRoute("2/editorSearch/"),
+  buildRoute("3/editorSearch/"),
   () =>
     HttpResponse.json(
       {
         results: {
-          "my search query": {
-            CARD: [cardDocument1.identifier],
-            CARDBACK: [],
-            TOKEN: [],
-          },
+          [computeSearchQueryHashKey({
+            query: "my search query",
+            cardType: CardType.Card,
+          })]: [cardDocument1.identifier],
         },
       },
       { status: 200 }
@@ -275,16 +280,15 @@ export const searchResultsOneResult = http.post(
 );
 
 export const searchResultsOneResultCorrectSearchq = http.post(
-  buildRoute("2/editorSearch/"),
+  buildRoute("3/editorSearch/"),
   () =>
     HttpResponse.json(
       {
         results: {
-          [cardDocument1.searchq]: {
-            CARD: [cardDocument1.identifier],
-            CARDBACK: [],
-            TOKEN: [],
-          },
+          [computeSearchQueryHashKey({
+            query: cardDocument1.searchq,
+            cardType: CardType.Card,
+          })]: [cardDocument1.identifier],
         },
       },
       { status: 200 }
@@ -292,20 +296,19 @@ export const searchResultsOneResultCorrectSearchq = http.post(
 );
 
 export const searchResultsThreeResults = http.post(
-  buildRoute("2/editorSearch/"),
+  buildRoute("3/editorSearch/"),
   () =>
     HttpResponse.json(
       {
         results: {
-          "my search query": {
-            CARD: [
-              cardDocument1.identifier,
-              cardDocument2.identifier,
-              cardDocument3.identifier,
-            ],
-            CARDBACK: [],
-            TOKEN: [],
-          },
+          [computeSearchQueryHashKey({
+            query: "my search query",
+            cardType: CardType.Card,
+          })]: [
+            cardDocument1.identifier,
+            cardDocument2.identifier,
+            cardDocument3.identifier,
+          ],
         },
       },
       { status: 200 }
@@ -314,20 +317,19 @@ export const searchResultsThreeResults = http.post(
 
 // Two sources: card1+card2 from source1, card7 from source2
 export const searchResultsTwoSources = http.post(
-  buildRoute("2/editorSearch/"),
+  buildRoute("3/editorSearch/"),
   () =>
     HttpResponse.json(
       {
         results: {
-          "my search query": {
-            CARD: [
-              cardDocument1.identifier,
-              cardDocument2.identifier,
-              cardDocument7.identifier,
-            ],
-            CARDBACK: [],
-            TOKEN: [],
-          },
+          [computeSearchQueryHashKey({
+            query: "my search query",
+            cardType: CardType.Card,
+          })]: [
+            cardDocument1.identifier,
+            cardDocument2.identifier,
+            cardDocument7.identifier,
+          ],
         },
       },
       { status: 200 }
@@ -336,21 +338,20 @@ export const searchResultsTwoSources = http.post(
 
 // Cards with canonicalCard data for CanonicalCardFilter tests
 export const searchResultsWithCanonicalCards = http.post(
-  buildRoute("2/editorSearch/"),
+  buildRoute("3/editorSearch/"),
   () =>
     HttpResponse.json(
       {
         results: {
-          "my search query": {
-            CARD: [
-              cardDocument8.identifier,
-              cardDocument9.identifier,
-              cardDocument10.identifier,
-              cardDocument11.identifier,
-            ],
-            CARDBACK: [],
-            TOKEN: [],
-          },
+          [computeSearchQueryHashKey({
+            query: "my search query",
+            cardType: CardType.Card,
+          })]: [
+            cardDocument8.identifier,
+            cardDocument9.identifier,
+            cardDocument10.identifier,
+            cardDocument11.identifier,
+          ],
         },
       },
       { status: 200 }
@@ -358,21 +359,28 @@ export const searchResultsWithCanonicalCards = http.post(
 );
 
 export const searchResultsFourResults = http.post(
-  buildRoute("2/editorSearch/"),
+  buildRoute("3/editorSearch/"),
   () =>
     HttpResponse.json(
       {
         results: {
-          "my search query": {
-            CARD: [
-              cardDocument1.identifier,
-              cardDocument2.identifier,
-              cardDocument3.identifier,
-              cardDocument4.identifier,
-            ],
-            CARDBACK: [cardDocument5.identifier],
-            TOKEN: [cardDocument6.identifier],
-          },
+          [computeSearchQueryHashKey({
+            query: "my search query",
+            cardType: CardType.Card,
+          })]: [
+            cardDocument1.identifier,
+            cardDocument2.identifier,
+            cardDocument3.identifier,
+            cardDocument4.identifier,
+          ],
+          [computeSearchQueryHashKey({
+            query: "my search query",
+            cardType: CardType.Cardback,
+          })]: [cardDocument5.identifier],
+          [computeSearchQueryHashKey({
+            query: "my search query",
+            cardType: CardType.Token,
+          })]: [cardDocument6.identifier],
         },
       },
       { status: 200 }
@@ -380,41 +388,35 @@ export const searchResultsFourResults = http.post(
 );
 
 export const searchResultsSixResults = http.post(
-  buildRoute("2/editorSearch/"),
+  buildRoute("3/editorSearch/"),
   () =>
     HttpResponse.json(
       {
         results: {
-          "query 1": {
-            CARD: [cardDocument1.identifier],
-            CARDBACK: [],
-            TOKEN: [],
-          },
-          "query 2": {
-            CARD: [cardDocument2.identifier],
-            CARDBACK: [],
-            TOKEN: [],
-          },
-          "query 3": {
-            CARD: [cardDocument3.identifier],
-            CARDBACK: [],
-            TOKEN: [],
-          },
-          "query 4": {
-            CARD: [cardDocument4.identifier],
-            CARDBACK: [],
-            TOKEN: [],
-          },
-          "query 5": {
-            CARD: [],
-            CARDBACK: [cardDocument5.identifier],
-            TOKEN: [],
-          },
-          "query 6": {
-            CARD: [],
-            CARDBACK: [],
-            TOKEN: [cardDocument6.identifier],
-          },
+          [computeSearchQueryHashKey({
+            query: "query 1",
+            cardType: CardType.Card,
+          })]: [cardDocument1.identifier],
+          [computeSearchQueryHashKey({
+            query: "query 2",
+            cardType: CardType.Card,
+          })]: [cardDocument2.identifier],
+          [computeSearchQueryHashKey({
+            query: "query 3",
+            cardType: CardType.Card,
+          })]: [cardDocument3.identifier],
+          [computeSearchQueryHashKey({
+            query: "query 4",
+            cardType: CardType.Card,
+          })]: [cardDocument4.identifier],
+          [computeSearchQueryHashKey({
+            query: "query 5",
+            cardType: CardType.Cardback,
+          })]: [cardDocument5.identifier],
+          [computeSearchQueryHashKey({
+            query: "query 6",
+            cardType: CardType.Token,
+          })]: [cardDocument6.identifier],
         },
       },
       { status: 200 }
@@ -422,26 +424,23 @@ export const searchResultsSixResults = http.post(
 );
 
 export const searchResultsForDFCMatchedCards1And4 = http.post(
-  buildRoute("2/editorSearch/"),
+  buildRoute("3/editorSearch/"),
   () =>
     HttpResponse.json(
       {
         results: {
-          "my search query": {
-            CARD: [cardDocument1.identifier],
-            CARDBACK: [],
-            TOKEN: [],
-          },
-          "card 3": {
-            CARD: [cardDocument3.identifier],
-            CARDBACK: [],
-            TOKEN: [],
-          },
-          "card 4": {
-            CARD: [cardDocument4.identifier],
-            CARDBACK: [],
-            TOKEN: [],
-          },
+          [computeSearchQueryHashKey({
+            query: "my search query",
+            cardType: CardType.Card,
+          })]: [cardDocument1.identifier],
+          [computeSearchQueryHashKey({
+            query: "card 3",
+            cardType: CardType.Card,
+          })]: [cardDocument3.identifier],
+          [computeSearchQueryHashKey({
+            query: "card 4",
+            cardType: CardType.Card,
+          })]: [cardDocument4.identifier],
         },
       },
       { status: 200 }
@@ -449,8 +448,8 @@ export const searchResultsForDFCMatchedCards1And4 = http.post(
 );
 
 export const searchResultsServerError = http.post(
-  buildRoute("2/editorSearch/"),
-  () => HttpResponse.json(createError("2/editorSearch"), { status: 200 })
+  buildRoute("3/editorSearch/"),
+  () => HttpResponse.json(createError("3/editorSearch"), { status: 200 })
 );
 
 //# endregion

--- a/frontend/src/store/api.ts
+++ b/frontend/src/store/api.ts
@@ -16,8 +16,6 @@ import {
   CardsResponse,
   ContributionsResponse,
   DFCPairsResponse,
-  EditorSearchRequest,
-  EditorSearchResponse,
   ExploreSearchRequest,
   ExploreSearchResponse,
   ImportSite,
@@ -31,6 +29,8 @@ import {
   NewCardsFirstPage,
   NewCardsFirstPagesResponse,
   NewCardsPageResponse,
+  OldEditorSearchRequest,
+  OldEditorSearchResponse,
   Patreon,
   PatreonResponse,
   SampleCardsResponse,
@@ -340,13 +340,13 @@ export async function APIEditorSearch(
     body: JSON.stringify({
       searchSettings,
       queries: queriesToSearch,
-    } as EditorSearchRequest),
+    } as OldEditorSearchRequest),
     credentials: "same-origin",
     headers: getCSRFHeader(),
   });
   return rawResponse.json().then((content) => {
     if (rawResponse.status === 200 && content.results != null) {
-      return content.results as EditorSearchResponse["results"];
+      return content.results as OldEditorSearchResponse["results"];
     }
     throw { name: content.name, message: content.message };
   });

--- a/frontend/src/store/api.ts
+++ b/frontend/src/store/api.ts
@@ -8,7 +8,11 @@ import {
 
 import { GoogleDriveImageAPIURL, QueryTags } from "@/common/constants";
 import { getCSRFHeader } from "@/common/cookies";
-import { formatURL, processQuery } from "@/common/processing";
+import {
+  computeSearchQueryHashKey,
+  formatURL,
+  processQuery,
+} from "@/common/processing";
 import {
   Card,
   CardbacksResponse,
@@ -16,6 +20,8 @@ import {
   CardsResponse,
   ContributionsResponse,
   DFCPairsResponse,
+  EditorSearchRequest,
+  EditorSearchResponse,
   ExploreSearchRequest,
   ExploreSearchResponse,
   ImportSite,
@@ -29,8 +35,6 @@ import {
   NewCardsFirstPage,
   NewCardsFirstPagesResponse,
   NewCardsPageResponse,
-  OldEditorSearchRequest,
-  OldEditorSearchResponse,
   Patreon,
   PatreonResponse,
   SampleCardsResponse,
@@ -43,7 +47,6 @@ import {
   DFCPairs,
   SearchQuery,
   SearchResults,
-  SearchResultsForQuery,
   SearchSettings,
   SourceDocuments,
 } from "@/common/types";
@@ -335,18 +338,23 @@ export async function APIEditorSearch(
   searchSettings: SearchSettings,
   queriesToSearch: Array<SearchQuery>
 ): Promise<SearchResults> {
-  const rawResponse = await fetch(formatURL(backendURL, "/2/editorSearch/"), {
+  const rawResponse = await fetch(formatURL(backendURL, "/3/editorSearch/"), {
     method: "POST",
     body: JSON.stringify({
       searchSettings,
-      queries: queriesToSearch,
-    } as OldEditorSearchRequest),
+      queries: Object.fromEntries(
+        queriesToSearch.map((searchQuery) => [
+          computeSearchQueryHashKey(searchQuery),
+          searchQuery,
+        ])
+      ),
+    } as EditorSearchRequest),
     credentials: "same-origin",
     headers: getCSRFHeader(),
   });
   return rawResponse.json().then((content) => {
     if (rawResponse.status === 200 && content.results != null) {
-      return content.results as OldEditorSearchResponse["results"];
+      return content.results as EditorSearchResponse["results"];
     }
     throw { name: content.name, message: content.message };
   });

--- a/frontend/src/store/listenerMiddleware.ts
+++ b/frontend/src/store/listenerMiddleware.ts
@@ -9,6 +9,7 @@ import {
   getLocalStorageSearchSettings,
   setLocalStorageFavorites,
 } from "@/common/cookies";
+import { computeSearchQueryHashKey } from "@/common/processing";
 import { Faces } from "@/common/types";
 import { api } from "@/store/api";
 import {
@@ -218,11 +219,12 @@ startAppListening({
         return slots
           .map(([face, slot]) => {
             const searchQuery = currentState.project.members[slot][face]?.query;
-            return searchQuery?.query != null
-              ? currentState.searchResults.searchResults[searchQuery.query][
-                  searchQuery.cardType
-                ] != null
-              : true;
+            if (searchQuery?.query != null) {
+              const hashKey = computeSearchQueryHashKey(searchQuery);
+              return currentState.searchResults.searchResults[hashKey] != null;
+            } else {
+              return true;
+            }
           })
           .every((value) => value);
       } else {

--- a/frontend/src/store/slices/projectSlice.test.ts
+++ b/frontend/src/store/slices/projectSlice.test.ts
@@ -1,3 +1,4 @@
+import { computeSearchQueryHashKey } from "@/common/processing";
 import { CardType, ThunkStatus } from "@/common/types";
 import { selectQueriesWithoutSearchResults } from "@/store/slices/projectSlice";
 import { setupStore } from "@/store/store";
@@ -186,7 +187,10 @@ describe("selectQueriesWithoutSearchResults tests", () => {
       },
       searchResults: {
         searchResults: {
-          "query 1": { CARD: [], CARDBACK: [], TOKEN: [] },
+          [computeSearchQueryHashKey({
+            query: "query 1",
+            cardType: "CARD" as CardType,
+          })]: [],
         },
         status: "idle" as ThunkStatus,
         error: null,

--- a/frontend/src/store/slices/projectSlice.ts
+++ b/frontend/src/store/slices/projectSlice.ts
@@ -6,7 +6,11 @@ import { createSelector, PayloadAction } from "@reduxjs/toolkit";
 
 import { Card, Cardback } from "@/common/constants";
 import { Back, Front, ProjectMaxSize } from "@/common/constants";
-import { processPrefix, toSearchable } from "@/common/processing";
+import {
+  computeSearchQueryHashKey,
+  processPrefix,
+  toSearchable,
+} from "@/common/processing";
 import { SourceType } from "@/common/schema_types";
 import {
   CardDocuments,
@@ -407,12 +411,11 @@ export const selectUniqueCardIdentifiers = createSelector(
         .flatMap((slotProjectMembers) =>
           [Front, Back].flatMap((face) => {
             const searchQuery = slotProjectMembers[face]?.query;
-
-            if (!searchQuery?.query || !searchResults[searchQuery.query]) {
+            if (!searchQuery?.query) {
               return [];
             }
-
-            return searchResults[searchQuery.query][searchQuery.cardType] ?? [];
+            const hashKey = computeSearchQueryHashKey(searchQuery);
+            return searchResults[hashKey] ?? [];
           })
         )
         .concat(cardbacks)
@@ -465,18 +468,14 @@ export const selectQueriesWithoutSearchResults = createSelector(
     return projectMembers.flatMap((slotProjectMembers) =>
       [Front, Back].flatMap((face) => {
         const searchQuery = slotProjectMembers[face]?.query;
-        const stringifiedSearchQuery = JSON.stringify(searchQuery ?? "");
-        if (
-          searchQuery?.query != null &&
-          (searchResults[searchQuery.query] ?? {})[searchQuery.cardType] ==
-            null &&
-          !set.has(stringifiedSearchQuery)
-        ) {
-          set.add(stringifiedSearchQuery);
-          return [searchQuery];
-        } else {
-          return [];
+        if (searchQuery?.query != null) {
+          const hashKey = computeSearchQueryHashKey(searchQuery);
+          if (searchResults[hashKey] == null && !set.has(hashKey)) {
+            set.add(hashKey);
+            return [searchQuery];
+          }
         }
+        return [];
       })
     );
   }

--- a/frontend/src/store/slices/searchResultsSlice.test.ts
+++ b/frontend/src/store/slices/searchResultsSlice.test.ts
@@ -2,27 +2,27 @@ import { mergeSearchResults } from "@/store/slices/searchResultsSlice";
 
 describe("mergeSearchResults", () => {
   test("deduplicates identifiers present in both local and remote results", () => {
-    const local = { "my query": { CARD: ["id-1", "id-2"] } };
-    const remote = { "my query": { CARD: ["id-2", "id-3"] } };
+    const local = { key1: ["id-1", "id-2"] };
+    const remote = { key1: ["id-2", "id-3"] };
     expect(mergeSearchResults(local, remote)).toEqual({
-      "my query": { CARD: ["id-1", "id-2", "id-3"] },
+      key1: ["id-1", "id-2", "id-3"],
     });
   });
 
   test("merges non-overlapping results without duplication", () => {
-    const local = { "my query": { CARD: ["id-1"] } };
-    const remote = { "my query": { CARD: ["id-2"] } };
+    const local = { key1: ["id-1"] };
+    const remote = { key1: ["id-2"] };
     expect(mergeSearchResults(local, remote)).toEqual({
-      "my query": { CARD: ["id-1", "id-2"] },
+      key1: ["id-1", "id-2"],
     });
   });
 
-  test("merges disjoint queries", () => {
-    const local = { "query a": { CARD: ["id-1"] } };
-    const remote = { "query b": { CARD: ["id-2"] } };
+  test("merges disjoint keys", () => {
+    const local = { key1: ["id-1"] };
+    const remote = { key2: ["id-2"] };
     expect(mergeSearchResults(local, remote)).toEqual({
-      "query a": { CARD: ["id-1"] },
-      "query b": { CARD: ["id-2"] },
+      key1: ["id-1"],
+      key2: ["id-2"],
     });
   });
 });

--- a/frontend/src/store/slices/searchResultsSlice.ts
+++ b/frontend/src/store/slices/searchResultsSlice.ts
@@ -5,6 +5,7 @@
 import { createSelector } from "@reduxjs/toolkit";
 
 import { Back, SearchResultsEndpointPageSize } from "@/common/constants";
+import { computeSearchQueryHashKey } from "@/common/processing";
 import {
   CardType,
   createAppAsyncThunk,
@@ -33,22 +34,18 @@ export const mergeSearchResults = (
   b: SearchResults
 ): SearchResults => {
   const mergedResults: SearchResults = structuredClone(a);
-  for (const [query, searchResultsForQuery] of Object.entries(b)) {
-    if (Object.prototype.hasOwnProperty.call(mergedResults, query)) {
-      for (const [cardType, searchResults] of Object.entries(
-        searchResultsForQuery
-      ) as Array<[CardType, Array<string>]>) {
-        // initialize the array if it doesn't exist
-        mergedResults[query][cardType] ??= [];
-        // merge the arrays
-        const existingIds = new Set(mergedResults[query][cardType]);
-        mergedResults[query][cardType] = [
-          ...mergedResults[query][cardType],
-          ...searchResults.filter((id) => !existingIds.has(id)),
-        ];
-      }
+  for (const [hashKey, searchResults] of Object.entries(b)) {
+    if (Object.prototype.hasOwnProperty.call(mergedResults, hashKey)) {
+      // initialize the array if it doesn't exist
+      mergedResults[hashKey] ??= [];
+      // merge the arrays
+      const existingIds = new Set(mergedResults[hashKey]);
+      mergedResults[hashKey] = [
+        ...mergedResults[hashKey],
+        ...searchResults.filter((id) => !existingIds.has(id)),
+      ];
     } else {
-      mergedResults[query] = structuredClone(searchResultsForQuery);
+      mergedResults[hashKey] = structuredClone(searchResults);
     }
   }
   return mergedResults;
@@ -117,6 +114,7 @@ export async function fetchSearchResultsAndReportError(dispatch: AppDispatch) {
   try {
     await dispatch(fetchSearchResults()).unwrap();
   } catch (error: any) {
+    console.log(error);
     dispatch(
       setNotification([
         typePrefix,
@@ -215,7 +213,9 @@ export const selectSearchResultsForQueryOrDefault = createSelector(
   ) => selectCardbacks(state),
   (searchResults, query, cardType, face, cardbacks) =>
     query != null && query.length > 0 && cardType !== undefined
-      ? (searchResults[query] ?? {})[cardType]
+      ? searchResults[
+          computeSearchQueryHashKey({ query: query, cardType: cardType })
+        ]
       : face === Back
       ? cardbacks
       : defaultEmptySearchResults

--- a/frontend/tests/AddCardToFavorites.spec.ts
+++ b/frontend/tests/AddCardToFavorites.spec.ts
@@ -3,6 +3,7 @@ import { expect } from "@playwright/test";
 import { SelectedImageSeparator } from "@/common/constants";
 import { cardDocument1 } from "@/common/test-constants";
 import {
+  cardbacksTwoOtherResults,
   cardDocumentsOneResult,
   defaultHandlers,
   searchResultsOneResult,
@@ -33,6 +34,7 @@ test.describe("AddCardToFavorites tests", () => {
   }) => {
     network.use(
       cardDocumentsOneResult,
+      cardbacksTwoOtherResults,
       sourceDocumentsOneResult,
       searchResultsOneResult,
       ...defaultHandlers
@@ -55,6 +57,7 @@ test.describe("AddCardToFavorites tests", () => {
   test("adding card to favorites", async ({ page, network }) => {
     network.use(
       cardDocumentsOneResult,
+      cardbacksTwoOtherResults,
       sourceDocumentsOneResult,
       searchResultsOneResult,
       ...defaultHandlers
@@ -96,6 +99,7 @@ test.describe("AddCardToFavorites tests", () => {
   test("removing card from favorites", async ({ page, network }) => {
     network.use(
       cardDocumentsOneResult,
+      cardbacksTwoOtherResults,
       sourceDocumentsOneResult,
       searchResultsOneResult,
       ...defaultHandlers
@@ -143,6 +147,7 @@ test.describe("AddCardToFavorites tests", () => {
   test("toggling favorite status multiple times", async ({ page, network }) => {
     network.use(
       cardDocumentsOneResult,
+      cardbacksTwoOtherResults,
       sourceDocumentsOneResult,
       searchResultsOneResult,
       ...defaultHandlers
@@ -182,6 +187,7 @@ test.describe("AddCardToFavorites tests", () => {
   }) => {
     network.use(
       cardDocumentsOneResult,
+      cardbacksTwoOtherResults,
       sourceDocumentsOneResult,
       searchResultsOneResult,
       ...defaultHandlers

--- a/frontend/tests/Toasts.spec.ts
+++ b/frontend/tests/Toasts.spec.ts
@@ -113,11 +113,11 @@ test.describe("error reporting toasts", () => {
     await expect(page.getByText("An Error Occurred")).not.toBeVisible();
   }
 
-  test("/2/editorSearch", async ({ page, network }) => {
+  test("/3/editorSearch", async ({ page, network }) => {
     await assertErrorToast(
       page,
       network,
-      "2/editorSearch",
+      "3/editorSearch",
       [
         cardDocumentsThreeResults,
         cardbacksTwoResults,

--- a/schemas/schemas/endpoints/EditorSearchRequest.json
+++ b/schemas/schemas/endpoints/EditorSearchRequest.json
@@ -1,0 +1,18 @@
+{
+  "title": "Editor Search Request",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "queries": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "../SearchQuery.json"
+      }
+    },
+    "searchSettings": {
+      "$ref": "../SearchSettings.json"
+    }
+  },
+  "required": ["queries", "searchSettings"],
+  "additionalProperties": false
+}

--- a/schemas/schemas/endpoints/EditorSearchResponse.json
+++ b/schemas/schemas/endpoints/EditorSearchResponse.json
@@ -1,0 +1,16 @@
+{
+  "title": "Editor Search Response",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "results": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "array",
+        "items": { "type": "string" }
+      }
+    }
+  },
+  "required": ["results"],
+  "additionalProperties": false
+}

--- a/schemas/schemas/endpoints/OldEditorSearchRequest.json
+++ b/schemas/schemas/endpoints/OldEditorSearchRequest.json
@@ -1,5 +1,5 @@
 {
-  "title": "Editor Search Request",
+  "title": "Old Editor Search Request",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "type": "object",
   "properties": {

--- a/schemas/schemas/endpoints/OldEditorSearchResponse.json
+++ b/schemas/schemas/endpoints/OldEditorSearchResponse.json
@@ -1,5 +1,5 @@
 {
-  "title": "Editor Search Response",
+  "title": "Old Editor Search Response",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "type": "object",
   "properties": {


### PR DESCRIPTION
# Description

* PR 1/n for allowing per-search query filters on canonical card expansion code + collector number
* Some baseline restructuring of the `editorSearch` endpoint is required
* Previously, the API response nested search results by search query and card type - e.g.:
```
{
  "char":{
    "CARD": ["abc"],
    "CARDBACK": [],
  }
}
```
* and it's impractical to extend this data structure when adding more fields to `SearchQuery`
* Solution is to reorient the API around hash keys - so the client now provides:
```
{
  "some hash key": {
    "query": "char",
    "cardType": "CARD"
  }
}
```
* and the server gives back
```
{
  "some hash key": ["abc", "def"]
}
```
* Implementing this in a backwards-compatible way by maintaining the existing endpoint and adding a new one under `3/editorSearch`

# Checklist

- [x] I have installed `pre-commit` and installed the hooks with `pre-commit install` before creating any commits.
- [x] I have updated any related tests for code I modified or added new tests where appropriate.
- [x] I have manually tested my changes as follows:
  - Manually exercised the project editor, verified network traffic in browser devtools
- [ ] I have updated any relevant documentation or created new documentation where appropriate.
  - None required