### PR TITLE
Search filter by expansion code and collector number - backend

### DIFF
--- a/MPCAutofill/cardpicker/documents.py
+++ b/MPCAutofill/cardpicker/documents.py
@@ -2,6 +2,8 @@ from django_elasticsearch_dsl import Document, fields
 from django_elasticsearch_dsl.registries import registry
 from elasticsearch_dsl import analyzer
 
+from django.db.models import QuerySet
+
 from cardpicker.models import Card
 
 # custom elasticsearch analysers are configured here to add the `asciifolding` filter, which handles accents:
@@ -22,6 +24,8 @@ class CardSearch(Document):
     date_modified = fields.DateField()
     language = fields.TextField(analyzer=precise_analyser)  # case insensitivity is one less thing which can go wrong
     tags = fields.KeywordField()  # all elasticsearch fields support arrays by default
+    expansion_code = fields.KeywordField(attr="get_expansion_code")
+    collector_number = fields.KeywordField(attr="get_collector_number")
 
     class Index:
         # name of the elasticsearch index
@@ -32,3 +36,7 @@ class CardSearch(Document):
     class Django:
         model = Card
         fields = ["identifier", "priority", "dpi", "size"]
+
+    def get_queryset(self) -> QuerySet[Card]:
+        # https://django-elasticsearch-dsl.readthedocs.io/en/latest/fields.html#handle-relationship-with-nestedfield-objectfield
+        return super().get_queryset().select_related("canonical_card", "canonical_card__expansion")

--- a/MPCAutofill/cardpicker/models.py
+++ b/MPCAutofill/cardpicker/models.py
@@ -347,6 +347,12 @@ class Card(models.Model):
             self.identifier
         )
 
+    def get_expansion_code(self) -> str | None:
+        return self.canonical_card.expansion.code.upper() if self.canonical_card else None
+
+    def get_collector_number(self) -> str | None:
+        return self.canonical_card.collector_number if self.canonical_card else None
+
     class Meta:
         ordering = ["-priority"]
 

--- a/MPCAutofill/cardpicker/schema_types.py
+++ b/MPCAutofill/cardpicker/schema_types.py
@@ -504,18 +504,26 @@ class DFCPairsResponse(BaseModel):
 
 class SearchQuery(BaseModel):
     cardType: CardType
+    collectorNumber: Optional[str] = None
+    expansionCode: Optional[str] = None
     query: Optional[str] = None
 
     @staticmethod
     def from_dict(obj: Any) -> "SearchQuery":
         assert isinstance(obj, dict)
         cardType = CardType(obj.get("cardType"))
+        collectorNumber = from_union([from_str, from_none], obj.get("collectorNumber"))
+        expansionCode = from_union([from_str, from_none], obj.get("expansionCode"))
         query = from_union([from_none, from_str], obj.get("query"))
-        return SearchQuery(cardType, query)
+        return SearchQuery(cardType, collectorNumber, expansionCode, query)
 
     def to_dict(self) -> dict:
         result: dict = {}
         result["cardType"] = to_enum(CardType, self.cardType)
+        if self.collectorNumber is not None:
+            result["collectorNumber"] = from_union([from_str, from_none], self.collectorNumber)
+        if self.expansionCode is not None:
+            result["expansionCode"] = from_union([from_str, from_none], self.expansionCode)
         result["query"] = from_union([from_none, from_str], self.query)
         return result
 

--- a/MPCAutofill/cardpicker/search/search_functions.py
+++ b/MPCAutofill/cardpicker/search/search_functions.py
@@ -1,6 +1,6 @@
 import datetime as dt
 import threading
-from typing import Any, Callable, Optional, TypeVar, cast
+from typing import Any, Callable, TypeVar, cast
 
 import pycountry
 from elasticsearch import Elasticsearch
@@ -88,7 +88,13 @@ def get_scaled_maximum_size(search_settings: SearchSettings) -> int:
     return search_settings.filterSettings.maximumSize * 1_000_000
 
 
-def get_search(search_settings: SearchSettings, query: Optional[str], card_types: list[CardType]) -> CardSearch:
+def get_search(
+    search_settings: SearchSettings,
+    query: str | None,
+    card_types: list[CardType],
+    expansion_code: str | None = None,
+    collector_number: str | None = None,
+) -> CardSearch:
     """
     This is the core search function for MPC Autofill - queries Elasticsearch for `self` given `search_settings`
     and returns the list of corresponding `Card` identifiers.
@@ -130,6 +136,10 @@ def get_search(search_settings: SearchSettings, query: Optional[str], card_types
                 minimum_should_match=1,
             )
         )
+    if expansion_code:
+        s = s.filter("term", expansion_code=expansion_code.upper())
+    if collector_number:
+        s = s.filter("term", collector_number=collector_number)
     if search_settings.filterSettings.languages:
         s = s.filter(
             Bool(
@@ -145,9 +155,21 @@ def get_search(search_settings: SearchSettings, query: Optional[str], card_types
 
 
 @elastic_connection
-def retrieve_card_identifiers(query: Optional[str], card_type: CardType, search_settings: SearchSettings) -> list[str]:
+def retrieve_card_identifiers(
+    search_settings: SearchSettings,
+    query: str,
+    card_type: CardType,
+    expansion_code: str | None = None,
+    collector_number: str | None = None,
+) -> list[str]:
     hits_iterable = (
-        get_search(search_settings=search_settings, query=query, card_types=[card_type])
+        get_search(
+            search_settings=search_settings,
+            query=query,
+            card_types=[card_type],
+            expansion_code=expansion_code,
+            collector_number=collector_number,
+        )
         .sort({"priority": {"order": "desc"}})
         .params(preserve_order=True)
         .scan()

--- a/MPCAutofill/cardpicker/tests/__snapshots__/test_views.ambr
+++ b/MPCAutofill/cardpicker/tests/__snapshots__/test_views.ambr
@@ -192,8 +192,19 @@
   dict({
     'CARD': dict({
       'Brainstorm': dict({
-        'canonicalArtist': None,
-        'canonicalCard': None,
+        'canonicalArtist': dict({
+          'name': 'Artist 102',
+        }),
+        'canonicalCard': dict({
+          'artist': None,
+          'canonicalId': '36cd2364-d113-47d1-b2c4-b088d9eb88dd',
+          'collectorNumber': '61',
+          'expansionCode': 'ice',
+          'expansionName': 'Ice Age',
+          'identifier': '8d42d7aa-7f53-4cfc-842a-086aab2448d1',
+          'mediumThumbnailUrl': '',
+          'smallThumbnailUrl': '',
+        }),
         'cardType': 'CARD',
         'dateCreated': '1st January, 2023',
         'dateModified': '1st January, 2023',
@@ -404,8 +415,19 @@
         'example_drive_1': dict({
           'cards': list([
             dict({
-              'canonicalArtist': None,
-              'canonicalCard': None,
+              'canonicalArtist': dict({
+                'name': 'Artist 107',
+              }),
+              'canonicalCard': dict({
+                'artist': None,
+                'canonicalId': '36cd2364-d113-47d1-b2c4-b088d9eb88dd',
+                'collectorNumber': '61',
+                'expansionCode': 'ice',
+                'expansionName': 'Ice Age',
+                'identifier': '8d42d7aa-7f53-4cfc-842a-086aab2448d1',
+                'mediumThumbnailUrl': '',
+                'smallThumbnailUrl': '',
+              }),
               'cardType': 'CARD',
               'dateCreated': '1st January, 2023',
               'dateModified': '1st January, 2023',
@@ -679,8 +701,19 @@
     'json': dict({
       'cards': list([
         dict({
-          'canonicalArtist': None,
-          'canonicalCard': None,
+          'canonicalArtist': dict({
+            'name': 'Artist 109',
+          }),
+          'canonicalCard': dict({
+            'artist': None,
+            'canonicalId': '36cd2364-d113-47d1-b2c4-b088d9eb88dd',
+            'collectorNumber': '61',
+            'expansionCode': 'ice',
+            'expansionName': 'Ice Age',
+            'identifier': '8d42d7aa-7f53-4cfc-842a-086aab2448d1',
+            'mediumThumbnailUrl': '',
+            'smallThumbnailUrl': '',
+          }),
           'cardType': 'CARD',
           'dateCreated': '1st January, 2023',
           'dateModified': '1st January, 2023',
@@ -1692,6 +1725,64 @@
     'status_code': 200,
   })
 # ---
+# name: TestPostEditorSearchResults.test_filter_by_collector_number
+  dict({
+    'json': dict({
+      'results': dict({
+        'key1': list([
+          '1c4M-sK9gd0Xju0NXCPtqeTW_DQTldVU5',
+        ]),
+      }),
+    }),
+    'status_code': 200,
+  })
+# ---
+# name: TestPostEditorSearchResults.test_filter_by_collector_number_no_results
+  dict({
+    'json': dict({
+      'results': dict({
+        'key1': list([
+        ]),
+      }),
+    }),
+    'status_code': 200,
+  })
+# ---
+# name: TestPostEditorSearchResults.test_filter_by_expansion_code
+  dict({
+    'json': dict({
+      'results': dict({
+        'key1': list([
+          '1c4M-sK9gd0Xju0NXCPtqeTW_DQTldVU5',
+        ]),
+      }),
+    }),
+    'status_code': 200,
+  })
+# ---
+# name: TestPostEditorSearchResults.test_filter_by_expansion_code_and_collector_number
+  dict({
+    'json': dict({
+      'results': dict({
+        'key1': list([
+          '1c4M-sK9gd0Xju0NXCPtqeTW_DQTldVU5',
+        ]),
+      }),
+    }),
+    'status_code': 200,
+  })
+# ---
+# name: TestPostEditorSearchResults.test_filter_by_expansion_code_no_results
+  dict({
+    'json': dict({
+      'results': dict({
+        'key1': list([
+        ]),
+      }),
+    }),
+    'status_code': 200,
+  })
+# ---
 # name: TestPostEditorSearchResults.test_fuzzy_search
   dict({
     'json': dict({
@@ -2307,8 +2398,19 @@
     'json': dict({
       'cards': list([
         dict({
-          'canonicalArtist': None,
-          'canonicalCard': None,
+          'canonicalArtist': dict({
+            'name': 'Artist 67',
+          }),
+          'canonicalCard': dict({
+            'artist': None,
+            'canonicalId': '36cd2364-d113-47d1-b2c4-b088d9eb88dd',
+            'collectorNumber': '61',
+            'expansionCode': 'ice',
+            'expansionName': 'Ice Age',
+            'identifier': '8d42d7aa-7f53-4cfc-842a-086aab2448d1',
+            'mediumThumbnailUrl': '',
+            'smallThumbnailUrl': '',
+          }),
           'cardType': 'CARD',
           'dateCreated': '1st January, 2023',
           'dateModified': '1st January, 2023',
@@ -2570,8 +2672,19 @@
     'json': dict({
       'cards': list([
         dict({
-          'canonicalArtist': None,
-          'canonicalCard': None,
+          'canonicalArtist': dict({
+            'name': 'Artist 66',
+          }),
+          'canonicalCard': dict({
+            'artist': None,
+            'canonicalId': '36cd2364-d113-47d1-b2c4-b088d9eb88dd',
+            'collectorNumber': '61',
+            'expansionCode': 'ice',
+            'expansionName': 'Ice Age',
+            'identifier': '8d42d7aa-7f53-4cfc-842a-086aab2448d1',
+            'mediumThumbnailUrl': '',
+            'smallThumbnailUrl': '',
+          }),
           'cardType': 'CARD',
           'dateCreated': '1st January, 2023',
           'dateModified': '1st January, 2023',
@@ -2911,8 +3024,19 @@
     'json': dict({
       'cards': list([
         dict({
-          'canonicalArtist': None,
-          'canonicalCard': None,
+          'canonicalArtist': dict({
+            'name': 'Artist 68',
+          }),
+          'canonicalCard': dict({
+            'artist': None,
+            'canonicalId': '36cd2364-d113-47d1-b2c4-b088d9eb88dd',
+            'collectorNumber': '61',
+            'expansionCode': 'ice',
+            'expansionName': 'Ice Age',
+            'identifier': '8d42d7aa-7f53-4cfc-842a-086aab2448d1',
+            'mediumThumbnailUrl': '',
+            'smallThumbnailUrl': '',
+          }),
           'cardType': 'CARD',
           'dateCreated': '1st January, 2023',
           'dateModified': '1st January, 2023',

--- a/MPCAutofill/cardpicker/tests/conftest.py
+++ b/MPCAutofill/cardpicker/tests/conftest.py
@@ -1,4 +1,5 @@
 import datetime as dt
+import uuid
 from typing import Type
 
 import pytest
@@ -13,6 +14,8 @@ from cardpicker.integrations.game.base import GameIntegration
 from cardpicker.models import Card, CardTypes, DFCPair, Source, Tag
 from cardpicker.tests.constants import Cards, DummyIntegration, Sources
 from cardpicker.tests.factories import (
+    CanonicalCardFactory,
+    CanonicalExpansionFactory,
     CardFactory,
     DFCPairFactory,
     SourceFactory,
@@ -122,7 +125,24 @@ def all_sources(example_drive_1, example_drive_2):
 
 
 @pytest.fixture()
-def brainstorm(example_drive_1) -> Card:
+def ice_expansion(db):
+    return CanonicalExpansionFactory(
+        identifier=uuid.UUID("a4a0db50-8826-4e73-833c-3fd934375f96"), code="ice", name="Ice Age"
+    )
+
+
+@pytest.fixture()
+def brainstorm_canonical_card(ice_expansion):
+    return CanonicalCardFactory(
+        identifier=uuid.UUID("8d42d7aa-7f53-4cfc-842a-086aab2448d1"),
+        canonical_id=uuid.UUID("36cd2364-d113-47d1-b2c4-b088d9eb88dd"),
+        expansion=ice_expansion,
+        collector_number="61",
+    )
+
+
+@pytest.fixture()
+def brainstorm(example_drive_1, brainstorm_canonical_card) -> Card:
     return CardFactory(
         pk=0,
         card_type=CardTypes.CARD,
@@ -133,6 +153,7 @@ def brainstorm(example_drive_1) -> Card:
         priority=2,
         size=Cards.BRAINSTORM.value.size,
         date_created=dt.datetime(2023, 1, 1),
+        canonical_card=brainstorm_canonical_card,
     )
 
 

--- a/MPCAutofill/cardpicker/tests/test_views.py
+++ b/MPCAutofill/cardpicker/tests/test_views.py
@@ -381,6 +381,82 @@ class TestPostEditorSearchResults:
         assert response.status_code == 200
         assert len(response.json()["results"]["key1"]) == 2
 
+    def test_filter_by_expansion_code(self, client, snapshot):
+        response = client.post(
+            reverse(views.post_editor_search),
+            {
+                "searchSettings": BASE_SEARCH_SETTINGS,
+                "queries": {"key1": {"query": Cards.BRAINSTORM.value.name, "cardType": "CARD", "expansionCode": "ICE"}},
+            },
+            content_type="application/json",
+        )
+        snapshot_response(response, snapshot)
+        assert response.status_code == 200
+        assert response.json()["results"]["key1"] == [Cards.BRAINSTORM.value.identifier]
+
+    def test_filter_by_expansion_code_no_results(self, client, snapshot):
+        response = client.post(
+            reverse(views.post_editor_search),
+            {
+                "searchSettings": BASE_SEARCH_SETTINGS,
+                "queries": {"key1": {"query": Cards.BRAINSTORM.value.name, "cardType": "CARD", "expansionCode": "ZZZ"}},
+            },
+            content_type="application/json",
+        )
+        snapshot_response(response, snapshot)
+        assert response.status_code == 200
+        assert response.json()["results"]["key1"] == []
+
+    def test_filter_by_collector_number(self, client, snapshot):
+        response = client.post(
+            reverse(views.post_editor_search),
+            {
+                "searchSettings": BASE_SEARCH_SETTINGS,
+                "queries": {
+                    "key1": {"query": Cards.BRAINSTORM.value.name, "cardType": "CARD", "collectorNumber": "61"}
+                },
+            },
+            content_type="application/json",
+        )
+        snapshot_response(response, snapshot)
+        assert response.status_code == 200
+        assert response.json()["results"]["key1"] == [Cards.BRAINSTORM.value.identifier]
+
+    def test_filter_by_collector_number_no_results(self, client, snapshot):
+        response = client.post(
+            reverse(views.post_editor_search),
+            {
+                "searchSettings": BASE_SEARCH_SETTINGS,
+                "queries": {
+                    "key1": {"query": Cards.BRAINSTORM.value.name, "cardType": "CARD", "collectorNumber": "999"}
+                },
+            },
+            content_type="application/json",
+        )
+        snapshot_response(response, snapshot)
+        assert response.status_code == 200
+        assert response.json()["results"]["key1"] == []
+
+    def test_filter_by_expansion_code_and_collector_number(self, client, snapshot):
+        response = client.post(
+            reverse(views.post_editor_search),
+            {
+                "searchSettings": BASE_SEARCH_SETTINGS,
+                "queries": {
+                    "key1": {
+                        "query": Cards.BRAINSTORM.value.name,
+                        "cardType": "CARD",
+                        "expansionCode": "ICE",
+                        "collectorNumber": "61",
+                    }
+                },
+            },
+            content_type="application/json",
+        )
+        snapshot_response(response, snapshot)
+        assert response.status_code == 200
+        assert response.json()["results"]["key1"] == [Cards.BRAINSTORM.value.identifier]
+
     def test_page_equal_to_max_size(self, client, monkeypatch, snapshot):
         monkeypatch.setattr("cardpicker.views.EDITOR_SEARCH_MAX_QUERIES", 2)
         response = client.post(

--- a/MPCAutofill/cardpicker/views.py
+++ b/MPCAutofill/cardpicker/views.py
@@ -130,9 +130,11 @@ def post_editor_search(request: HttpRequest) -> HttpResponse:
     for hash_key, search_query in editor_search_request.queries.items():
         if search_query.query is not None and hash_key not in results.keys():
             hits = retrieve_card_identifiers(
+                search_settings=editor_search_request.searchSettings,
                 query=search_query.query,
                 card_type=search_query.cardType,
-                search_settings=editor_search_request.searchSettings,
+                expansion_code=search_query.expansionCode,
+                collector_number=search_query.collectorNumber,
             )
             results[hash_key] = hits
     return JsonResponse(EditorSearchResponse(results=results).model_dump())

--- a/frontend/src/common/schema_types.ts
+++ b/frontend/src/common/schema_types.ts
@@ -213,6 +213,8 @@ export interface EditorSearchRequest {
 
 export interface SearchQuery {
   cardType: CardType;
+  collectorNumber?: string;
+  expansionCode?: string;
   query: null | string;
 }
 
@@ -1168,6 +1170,8 @@ const typeMap: any = {
   SearchQuery: o(
     [
       { json: "cardType", js: "cardType", typ: r("CardType") },
+      { json: "collectorNumber", js: "collectorNumber", typ: u(undefined, "") },
+      { json: "expansionCode", js: "expansionCode", typ: u(undefined, "") },
       { json: "query", js: "query", typ: u(null, "") },
     ],
     false

--- a/schemas/schemas/SearchQuery.json
+++ b/schemas/schemas/SearchQuery.json
@@ -8,6 +8,12 @@
     },
     "cardType": {
       "$ref": "./CardType.json"
+    },
+    "expansionCode": {
+      "type": "string"
+    },
+    "collectorNumber": {
+      "type": "string"
     }
   },
   "required": ["query", "cardType"],


### PR DESCRIPTION
# Description

* PR 2/n for allowing per-search query filters on canonical card expansion code + collector number
* Exposing `expansionCode` and `collectorNumber` in the `SearchQuery` structure + indexing these fields in elasticsearch

# Checklist

- [x] I have installed `pre-commit` and installed the hooks with `pre-commit install` before creating any commits.
- [x] I have updated any related tests for code I modified or added new tests where appropriate.
- [x] I have manually tested my changes as follows:
  - manually tested against WIP frontend changes
- [ ] I have updated any relevant documentation or created new documentation where appropriate.
  - None required