### PR TITLE
Search filter by expansion code and collector number - frontend

### DIFF
--- a/frontend/src/common/processing.test.ts
+++ b/frontend/src/common/processing.test.ts
@@ -8,8 +8,8 @@ import {
 import {
   parseCSVFileAsLines,
   processLine,
-  processPrefix,
   processQuery,
+  processSearchQuery,
   processStringAsMultipleLines,
   sanitiseWhitespace,
   standardiseURL,
@@ -60,22 +60,67 @@ test("query with numbers is processed correctly", () => {
   );
 });
 
-test("prefix is processed correctly", () => {
-  expect(processPrefix("t:goblin")).toStrictEqual({
-    cardType: Token,
-    query: "goblin",
-  });
-});
-
-test("empty prefix is processed correctly", () => {
-  expect(processPrefix("soldier")).toStrictEqual({
-    cardType: Card,
-    query: "soldier",
-  });
+test.each([
+  {
+    input: "goblin",
+    expectedOutput: {
+      query: "goblin",
+      cardType: CardType.Card,
+      expansionCode: undefined,
+      collectorNumber: undefined,
+    },
+  },
+  {
+    input: "t:goblin",
+    expectedOutput: {
+      query: "goblin",
+      cardType: CardType.Token,
+      expansionCode: undefined,
+      collectorNumber: undefined,
+    },
+  },
+  {
+    input: "b:goblin",
+    expectedOutput: {
+      query: "goblin",
+      cardType: CardType.Cardback,
+      expansionCode: undefined,
+      collectorNumber: undefined,
+    },
+  },
+  {
+    input: "goblin (AKH)",
+    expectedOutput: {
+      query: "goblin",
+      cardType: CardType.Card,
+      expansionCode: "AKH",
+      collectorNumber: undefined,
+    },
+  },
+  {
+    input: "goblin (AKH) 123",
+    expectedOutput: {
+      query: "goblin",
+      cardType: CardType.Card,
+      expansionCode: "AKH",
+      collectorNumber: "123",
+    },
+  },
+  {
+    input: "t:goblin (AKH) abcdef",
+    expectedOutput: {
+      query: "goblin",
+      cardType: CardType.Token,
+      expansionCode: "AKH",
+      collectorNumber: "abcdef",
+    },
+  },
+])("processSearchQuery", ({ input, expectedOutput }) => {
+  expect(processSearchQuery(input)).toEqual(expectedOutput);
 });
 
 test("line that doesn't specify quantity is processed correctly", () => {
-  expect(processLine("opt", dfcPairs, false)).toStrictEqual([
+  expect(processLine("opt", dfcPairs, false)).toEqual([
     1,
     {
       query: { cardType: Card, query: "opt" },
@@ -87,7 +132,7 @@ test("line that doesn't specify quantity is processed correctly", () => {
 });
 
 test("line that doesn't specify quantity but name begins with X is processed correctly", () => {
-  expect(processLine("xenagos the reveler", dfcPairs, false)).toStrictEqual([
+  expect(processLine("xenagos the reveler", dfcPairs, false)).toEqual([
     1,
     {
       query: { cardType: Card, query: "xenagos the reveler" },
@@ -99,10 +144,15 @@ test("line that doesn't specify quantity but name begins with X is processed cor
 });
 
 test("non-dfc line is processed correctly", () => {
-  expect(processLine("3x Lightning Bolt", dfcPairs, false)).toStrictEqual([
+  expect(processLine("3x Lightning Bolt", dfcPairs, false)).toEqual([
     3,
     {
-      query: { cardType: Card, query: "lightning bolt" },
+      query: {
+        cardType: Card,
+        query: "lightning bolt",
+        expansionCode: undefined,
+        collectorNumber: undefined,
+      },
       selectedImage: undefined,
       selected: false,
     },
@@ -111,10 +161,15 @@ test("non-dfc line is processed correctly", () => {
 });
 
 test("non-dfc cardback line is processed correctly", () => {
-  expect(processLine("3x b:Black Lotus", dfcPairs, false)).toStrictEqual([
+  expect(processLine("3x b:Black Lotus", dfcPairs, false)).toEqual([
     3,
     {
-      query: { cardType: Cardback, query: "black lotus" },
+      query: {
+        cardType: Cardback,
+        query: "black lotus",
+        expansionCode: undefined,
+        collectorNumber: undefined,
+      },
       selectedImage: undefined,
       selected: false,
     },
@@ -123,9 +178,7 @@ test("non-dfc cardback line is processed correctly", () => {
 });
 
 test("manually specified front and back line is processed correctly", () => {
-  expect(
-    processLine(`5 Opt${FaceSeparator}Char`, dfcPairs, false)
-  ).toStrictEqual([
+  expect(processLine(`5 Opt${FaceSeparator}Char`, dfcPairs, false)).toEqual([
     5,
     {
       query: { cardType: Card, query: "opt" },
@@ -141,9 +194,7 @@ test("manually specified front and back line is processed correctly", () => {
 });
 
 test("line that matches to dfc pair is processed correctly", () => {
-  expect(
-    processLine("2 Huntmaster of the Fells", dfcPairs, false)
-  ).toStrictEqual([
+  expect(processLine("2 Huntmaster of the Fells", dfcPairs, false)).toEqual([
     2,
     {
       query: { cardType: Card, query: "huntmaster of the fells" },
@@ -159,7 +210,7 @@ test("line that matches to dfc pair is processed correctly", () => {
 });
 
 test("line that fuzzy matches to dfc pair is processed correctly", () => {
-  expect(processLine("2 bat", { batman: "ratman" }, true)).toStrictEqual([
+  expect(processLine("2 bat", { batman: "ratman" }, true)).toEqual([
     2,
     {
       query: { cardType: Card, query: "bat" },
@@ -175,7 +226,7 @@ test("line that fuzzy matches to dfc pair is processed correctly", () => {
 });
 
 test("line that doesn't fuzzy match to dfc pair is processed correctly", () => {
-  expect(processLine("2 cat", { batman: "ratman" }, true)).toStrictEqual([
+  expect(processLine("2 cat", { batman: "ratman" }, true)).toEqual([
     2,
     {
       query: { cardType: Card, query: "cat" },
@@ -189,7 +240,7 @@ test("line that doesn't fuzzy match to dfc pair is processed correctly", () => {
 test("line that fuzzy matches ambiguously to dfc pair is processed correctly", () => {
   expect(
     processLine("2 bat", { batman: "ratman", batwoman: "ratwoman" }, true)
-  ).toStrictEqual([
+  ).toEqual([
     2,
     {
       query: { cardType: Card, query: "bat" },
@@ -207,7 +258,7 @@ test("line that matches to dfc pair but a back is also manually specified is pro
       dfcPairs,
       false
     )
-  ).toStrictEqual([
+  ).toEqual([
     2,
     {
       query: { cardType: Card, query: "huntmaster of the fells" },
@@ -231,16 +282,26 @@ test("a card name that's a subset of a DFC pair's front is not matched", () => {
       },
       false
     )
-  ).toStrictEqual([
+  ).toEqual([
     [
       1,
       {
-        query: { cardType: Card, query: "elesh norn" },
+        query: {
+          cardType: Card,
+          query: "elesh norn",
+          expansionCode: undefined,
+          collectorNumber: undefined,
+        },
         selectedImage: undefined,
         selected: false,
       },
       {
-        query: { cardType: Card, query: "the argent etchings" },
+        query: {
+          cardType: Card,
+          query: "the argent etchings",
+          expansionCode: undefined,
+          collectorNumber: undefined,
+        },
         selectedImage: undefined,
         selected: false,
       },
@@ -248,7 +309,12 @@ test("a card name that's a subset of a DFC pair's front is not matched", () => {
     [
       1,
       {
-        query: { cardType: Card, query: "elesh norn grand cenobite" },
+        query: {
+          cardType: Card,
+          query: "elesh norn grand cenobite",
+          expansionCode: undefined,
+          collectorNumber: undefined,
+        },
         selectedImage: undefined,
         selected: false,
       },
@@ -258,7 +324,7 @@ test("a card name that's a subset of a DFC pair's front is not matched", () => {
 });
 
 test("line that requests 0 of a card is processed correctly", () => {
-  expect(processLine("0 opt", dfcPairs, false)).toStrictEqual([
+  expect(processLine("0 opt", dfcPairs, false)).toEqual([
     0,
     {
       query: { cardType: Card, query: "opt" },
@@ -270,7 +336,7 @@ test("line that requests 0 of a card is processed correctly", () => {
 });
 
 test("line that requests -1 of a card is processed correctly", () => {
-  expect(processLine("-1 opt", dfcPairs, false)).toStrictEqual([
+  expect(processLine("-1 opt", dfcPairs, false)).toEqual([
     1,
     {
       query: { cardType: Card, query: "-1 opt" },
@@ -288,7 +354,7 @@ test("multiple lines processed correctly", () => {
       dfcPairs,
       false
     )
-  ).toStrictEqual([
+  ).toEqual([
     [
       1,
       {
@@ -317,7 +383,7 @@ test("multiple lines processed correctly", () => {
 test("a line specifying the selected image ID for the front is processed correctly", () => {
   expect(
     processLine(`opt${SelectedImageSeparator}xyz`, dfcPairs, false)
-  ).toStrictEqual([
+  ).toEqual([
     1,
     {
       query: { cardType: Card, query: "opt" },
@@ -335,7 +401,7 @@ test("a line specifying the selected image ID for both faces is processed correc
       dfcPairs,
       false
     )
-  ).toStrictEqual([
+  ).toEqual([
     2,
     {
       query: { cardType: Card, query: "opt" },
@@ -427,7 +493,7 @@ describe("file path-like identifier handling", () => {
       ],
     },
   ])("%s", ({ line, expectedResult }) => {
-    expect(processLine(line, {}, false)).toStrictEqual(expectedResult);
+    expect(processLine(line, {}, false)).toEqual(expectedResult);
   });
 });
 
@@ -446,7 +512,7 @@ describe("toSearchable", () => {
     { input: "Kodama’s Reach", expectedOutput: "kodamas reach" },
     { input: "消灭邪物", expectedOutput: "消灭邪物" },
   ])("%s", ({ input, expectedOutput }) => {
-    expect(toSearchable(input)).toStrictEqual(expectedOutput);
+    expect(toSearchable(input)).toEqual(expectedOutput);
   });
 });
 
@@ -472,7 +538,7 @@ test.each([
 ])("CSV is parsed correctly", () => {
   const csv =
     "Quantity, Front, Front ID, Back, Back ID\n2, opt, xyz, char, abcd";
-  expect(parseCSVFileAsLines(csv)).toStrictEqual([
+  expect(parseCSVFileAsLines(csv)).toEqual([
     `2 opt${SelectedImageSeparator}xyz${FaceSeparator}char${SelectedImageSeparator}abcd`,
   ]);
 });

--- a/frontend/src/common/processing.ts
+++ b/frontend/src/common/processing.ts
@@ -29,6 +29,8 @@ import {
   SlotProjectMembers,
 } from "@/common/types";
 
+import { CardType } from "./schema_types";
+
 /**
  * Clean any instances of doubled-up whitespace from `text`.
  */
@@ -63,26 +65,39 @@ export function processQuery(query: string): string {
 }
 
 /**
- * Identify the prefix of a query. For example, `query`="t:goblin" would yield
- *   {query: "goblin", cardType: TOKEN}.
+ * Unpack `query` into its constituents.
+ *
+ * Inputs to this function are unpacked according to the below schema. For example, consider `t:opt (XYZ) 123`:
+ *       4x        :    opt     (        123          )         123
+ * └─ card type ──┘ └─ query ──┘ └─ expansion code ──┘ └─ collector number ──┘
+ *
+ * If a card type prefix is not specified, we assume `CARD`.
  */
-export function processPrefix(query: string): SearchQuery {
-  for (const [prefix, cardType] of Object.entries(CardTypePrefixes)) {
-    if (
-      prefix !== "" &&
-      query
-        .trimStart()
-        .toLowerCase()
-        .startsWith(`${prefix}${CardTypeSeparator}`)
-    ) {
-      return {
-        query: processQuery(query.trimStart().slice(prefix.length + 1)),
-        cardType: cardType,
-      };
-    }
+export const processSearchQuery = (query: string): SearchQuery => {
+  const prefixPattern = Object.keys(CardTypePrefixes)
+    .filter((prefix) => prefix !== "")
+    .join("|");
+  const regex = new RegExp(
+    `^(?:(${prefixPattern})\\:)?(.*?)(?:\\((.+)\\)(.*))?$`
+  );
+
+  const match = query.match(regex);
+
+  if (match === null) {
+    // should realistically never hit this case
+    return {
+      query: query,
+      cardType: CardType.Card,
+    };
   }
-  return { query: processQuery(query), cardType: CardTypePrefixes[""] };
-}
+
+  return {
+    cardType: CardTypePrefixes[match[1] ?? ""],
+    query: processQuery(match[2]),
+    expansionCode: match[3]?.toUpperCase()?.trim() || undefined,
+    collectorNumber: match[4]?.trim() || undefined,
+  };
+};
 
 const getPhrasesNotAllowedInIdentifiers = (): Array<string> => [
   SelectedImageSeparator,
@@ -193,14 +208,14 @@ export function processLine(
   let frontQuery: SearchQuery | null = null;
   let frontSelectedImage: string | undefined = undefined;
   if (frontRawQuery != null && (frontRawQuery[0] ?? "").length > 0) {
-    frontQuery = processPrefix(frontRawQuery[0]);
+    frontQuery = processSearchQuery(frontRawQuery[0]);
     frontSelectedImage = frontRawQuery[1] ?? undefined;
   }
 
   let backQuery: SearchQuery | null = null;
   let backSelectedImage: string | undefined = undefined;
   if (backRawQuery != null && (backRawQuery[0] ?? "").length > 0) {
-    backQuery = processPrefix(backRawQuery[0]);
+    backQuery = processSearchQuery(backRawQuery[0]);
     backSelectedImage = backRawQuery[1] ?? undefined;
   } else if (frontQuery != null && frontQuery?.query != null) {
     const dfcBackQuery = getDfcBack(frontQuery.query, dfcPairs, fuzzySearch);
@@ -408,5 +423,34 @@ export const fnv1aHash = (input: string): number => {
   return hash;
 };
 
+const stringifySearchQuery = (searchQuery: SearchQuery): string =>
+  `cardType=${searchQuery.cardType}
+  &query=${searchQuery.query ?? "null"}
+  &expansionCode=${searchQuery.expansionCode ?? "null"}
+  &collectorNumber=${searchQuery.collectorNumber ?? "null"}`;
+
 export const computeSearchQueryHashKey = (searchQuery: SearchQuery): string =>
-  fnv1aHash(JSON.stringify(searchQuery)).toString();
+  fnv1aHash(stringifySearchQuery(searchQuery)).toString();
+
+export const areSearchQueriesEqual = (
+  a: SearchQuery | null | undefined,
+  b: SearchQuery | null | undefined
+): boolean => {
+  if (!a && !b) {
+    return true;
+  }
+  if (!a || !b) {
+    return false;
+  }
+  return (
+    a.query === b.query &&
+    a.cardType === b.cardType &&
+    a.expansionCode === b.expansionCode &&
+    a.collectorNumber === b.collectorNumber
+  );
+  // return JSON.stringify(a) === JSON.stringify(b);
+};
+
+export const doesSearchQueryFilterOnPrinting = (
+  searchQuery: SearchQuery | undefined | null
+) => searchQuery?.expansionCode || searchQuery?.collectorNumber;

--- a/frontend/src/features/bulkManagement/SelectedImagesRibbon.tsx
+++ b/frontend/src/features/bulkManagement/SelectedImagesRibbon.tsx
@@ -24,12 +24,14 @@ import { useCardDocumentsByIdentifier } from "@/store/slices/cardDocumentsSlice"
 import { showChangeQueryModal } from "@/store/slices/modalsSlice";
 import {
   bulkAlignMemberSelection,
+  bulkRemovePrintingFilter,
   bulkSetMemberSelection,
   clearQueries,
   deleteSlots,
   selectAllSelectedProjectMembersHaveTheSameQuery,
   selectAllSlotsForActiveFace,
   selectAnySelectedImagesDownloadable,
+  selectAnySelectedImagesFilteredOnPrinting,
   selectIsProjectEmpty,
   selectSelectedSlots,
   selectUniqueCardIdentifiersInSlots,
@@ -152,6 +154,8 @@ function ChangeSelectedImageSelectedImages({
           state,
           query?.query,
           query?.cardType,
+          query?.expansionCode,
+          query?.collectorNumber,
           slots[0][0]
         )
       : undefined
@@ -176,6 +180,32 @@ function ChangeSelectedImageSelectedImages({
       )}
     </>
   ) : null;
+}
+
+function UnfilterSelectedImageQueriesOnPrintings({
+  slots,
+  inDropdown,
+}: {
+  slots: Slots;
+  inDropdown: boolean;
+}) {
+  const dispatch = useAppDispatch();
+
+  const handleUnfilterQueries = (): void => {
+    dispatch(bulkRemovePrintingFilter({ slots }));
+  };
+  const anySelectedImagesFilteredOnPrinting = useAppSelector((state) =>
+    selectAnySelectedImagesFilteredOnPrinting(state, slots)
+  );
+
+  return (
+    slots.length > 0 &&
+    anySelectedImagesFilteredOnPrinting && (
+      <RibbonButton onClick={handleUnfilterQueries} inDropdown={inDropdown}>
+        <RightPaddedIcon bootstrapIconName="filter" /> Unfilter Printing
+      </RibbonButton>
+    )
+  );
 }
 
 /**
@@ -302,6 +332,7 @@ type OptionKey =
   | "selectSimilar"
   | "selectAll"
   | "changeSelectedImageSelectedImages"
+  | "unfilterSelectedImageQueriesOnPrintings"
   | "changeSelectedImageQueries"
   | "clearSelectedImageQueries"
   | "downloadSelectedImages"
@@ -312,6 +343,9 @@ export function SelectedImagesRibbon() {
   const isProjectEmpty = useAppSelector(selectIsProjectEmpty);
   const anySelectedImagesDownloadable = useAppSelector((state) =>
     selectAnySelectedImagesDownloadable(state, slots)
+  );
+  const anySelectedImagesFilteredOnPrinting = useAppSelector((state) =>
+    selectAnySelectedImagesFilteredOnPrinting(state, slots)
   );
 
   const dispatch = useAppDispatch();
@@ -329,6 +363,14 @@ export function SelectedImagesRibbon() {
       case "changeSelectedImageSelectedImages":
         return (
           <ChangeSelectedImageSelectedImages
+            key={key}
+            slots={slots}
+            inDropdown={inDropdown}
+          />
+        );
+      case "unfilterSelectedImageQueriesOnPrintings":
+        return (
+          <UnfilterSelectedImageQueriesOnPrintings
             key={key}
             slots={slots}
             inDropdown={inDropdown}
@@ -371,6 +413,9 @@ export function SelectedImagesRibbon() {
   const validOptions: Array<OptionKey> = [
     ...((slots.length > 0
       ? ["changeSelectedImageSelectedImages", "changeSelectedImageQueries"]
+      : []) as Array<OptionKey>),
+    ...((slots.length > 0 && anySelectedImagesFilteredOnPrinting
+      ? ["unfilterSelectedImageQueriesOnPrintings"]
       : []) as Array<OptionKey>),
     ...((slots.length > 0 && anySelectedImagesDownloadable
       ? ["downloadSelectedImages"]

--- a/frontend/src/features/card/CardSlot.tsx
+++ b/frontend/src/features/card/CardSlot.tsx
@@ -11,6 +11,10 @@ import React, { memo, useState } from "react";
 import Dropdown from "react-bootstrap/Dropdown";
 
 import {
+  areSearchQueriesEqual,
+  doesSearchQueryFilterOnPrinting,
+} from "@/common/processing";
+import {
   Faces,
   SearchQuery,
   useAppDispatch,
@@ -24,6 +28,7 @@ import { GridSelectorModal } from "@/features/gridSelector/GridSelectorModal";
 import { showChangeQueryModal } from "@/store/slices/modalsSlice";
 import {
   bulkAlignMemberSelection,
+  bulkRemovePrintingFilter,
   deleteSlots,
   duplicateSlot,
   expandSelection,
@@ -94,8 +99,19 @@ const CardGridContextMenu = ({
   slot,
 }: CardSlotProps) => {
   const dispatch = useAppDispatch();
+  const handleShowChangeSelectedImageQueriesModal = () => {
+    dispatch(
+      showChangeQueryModal({
+        slots: [[face, slot]],
+        query: searchQuery?.query ?? null,
+      })
+    );
+  };
   const deleteThisSlot = () => {
     dispatch(deleteSlots({ slots: [slot] }));
+  };
+  const removePrintingFilter = () => {
+    dispatch(bulkRemovePrintingFilter({ slots: [[face, slot]] }));
   };
   const duplicateThisSlot = () => {
     dispatch(duplicateSlot({ slot: slot, quantity: 1 }));
@@ -106,11 +122,19 @@ const CardGridContextMenu = ({
         <i className="bi bi-three-dots" />
       </Dropdown.Toggle>
       <Dropdown.Menu>
-        <Dropdown.Item onClick={deleteThisSlot}>
-          <RightPaddedIcon bootstrapIconName="x-circle" /> Delete
+        <Dropdown.Item onClick={handleShowChangeSelectedImageQueriesModal}>
+          <RightPaddedIcon bootstrapIconName="arrow-repeat" /> Change Query
         </Dropdown.Item>
         <Dropdown.Item onClick={duplicateThisSlot}>
           <RightPaddedIcon bootstrapIconName="copy" /> Duplicate
+        </Dropdown.Item>
+        {doesSearchQueryFilterOnPrinting(searchQuery) && (
+          <Dropdown.Item onClick={removePrintingFilter}>
+            <RightPaddedIcon bootstrapIconName="filter" /> Unfilter Printing
+          </Dropdown.Item>
+        )}
+        <Dropdown.Item onClick={deleteThisSlot}>
+          <RightPaddedIcon bootstrapIconName="x-circle" /> Delete
         </Dropdown.Item>
       </Dropdown.Menu>
     </Dropdown>
@@ -129,6 +153,8 @@ export function CardSlot({ id, searchQuery, face, slot }: CardSlotProps) {
       state,
       searchQuery?.query,
       searchQuery?.cardType,
+      searchQuery?.expansionCode,
+      searchQuery?.collectorNumber,
       face
     )
   );
@@ -143,10 +169,7 @@ export function CardSlot({ id, searchQuery, face, slot }: CardSlotProps) {
   const modifySelectedSlots =
     selectedSlots.length > 1 &&
     projectMember?.selected &&
-    selectedQuery != null &&
-    // can't use object equality check here
-    selectedQuery.query === searchQuery?.query &&
-    selectedQuery.cardType === searchQuery?.cardType;
+    areSearchQueriesEqual(selectedQuery, searchQuery);
   const slotsToModify: Array<[Faces, number]> = modifySelectedSlots
     ? selectedSlots
     : [[face, slot]];

--- a/frontend/src/features/import/ImportXML.tsx
+++ b/frontend/src/features/import/ImportXML.tsx
@@ -23,7 +23,7 @@ import {
   ToggleButtonHeight,
 } from "@/common/constants";
 import { TextFileDropzone } from "@/common/dropzone";
-import { processPrefix } from "@/common/processing";
+import { processSearchQuery } from "@/common/processing";
 import { useAppDispatch, useAppSelector } from "@/common/types";
 import { Cardstock, SlotProjectMembers } from "@/common/types";
 import { RightPaddedIcon } from "@/components/icon";
@@ -97,7 +97,7 @@ export function ImportXML({ onImportComplete }: ImportXMLProps) {
         if (slotsText == null) {
           continue;
         }
-        const searchQuery = processPrefix(
+        const searchQuery = processSearchQuery(
           backCardElement.getElementsByTagName("query")[0].textContent ?? ""
         );
         slotsText
@@ -123,7 +123,7 @@ export function ImportXML({ onImportComplete }: ImportXMLProps) {
       if (slotsText == null) {
         continue;
       }
-      const searchQuery = processPrefix(
+      const searchQuery = processSearchQuery(
         frontCardElement.getElementsByTagName("query")[0].textContent ?? ""
       );
 

--- a/frontend/src/store/listenerMiddleware.ts
+++ b/frontend/src/store/listenerMiddleware.ts
@@ -34,6 +34,7 @@ import {
 import { recordInvalidIdentifier } from "@/store/slices/invalidIdentifiersSlice";
 import {
   addMembers,
+  bulkRemovePrintingFilter,
   selectProjectCardback,
   setQueries,
   setSelectedCardback,
@@ -164,7 +165,7 @@ startAppListening({
 });
 
 startAppListening({
-  matcher: isAnyOf(addMembers, setQueries),
+  matcher: isAnyOf(addMembers, setQueries, bulkRemovePrintingFilter),
   /**
    * Fetch card documents whenever new members are added to the project or search results are cleared.
    */
@@ -243,6 +244,8 @@ startAppListening({
           state,
           searchQuery?.query,
           searchQuery?.cardType,
+          searchQuery?.expansionCode,
+          searchQuery?.collectorNumber,
           face
         ) ?? [];
       const newSelectedImage =
@@ -284,6 +287,8 @@ startAppListening({
               state,
               searchQuery?.query,
               searchQuery?.cardType,
+              searchQuery?.expansionCode,
+              searchQuery?.collectorNumber,
               face
             );
           if (searchResultsForQueryOrDefault != null) {

--- a/frontend/src/store/slices/projectSlice.ts
+++ b/frontend/src/store/slices/projectSlice.ts
@@ -7,8 +7,10 @@ import { createSelector, PayloadAction } from "@reduxjs/toolkit";
 import { Card, Cardback } from "@/common/constants";
 import { Back, Front, ProjectMaxSize } from "@/common/constants";
 import {
+  areSearchQueriesEqual,
   computeSearchQueryHashKey,
-  processPrefix,
+  doesSearchQueryFilterOnPrinting,
+  processSearchQuery,
   toSearchable,
 } from "@/common/processing";
 import { SourceType } from "@/common/schema_types";
@@ -105,7 +107,7 @@ export const projectSlice = createAppSlice({
       state,
       action: PayloadAction<{ query: string; slots: Array<[Faces, number]> }>
     ) => {
-      const newQuery = processPrefix(action.payload.query);
+      const newQuery = processSearchQuery(action.payload.query);
       for (const [face, slot] of action.payload.slots) {
         if (state.members[slot][face] == null) {
           state.members[slot][face] = {
@@ -236,7 +238,27 @@ export const projectSlice = createAppSlice({
           state.members[slot][face]!.selected = action.payload.selectedStatus;
         }
       }
-      state.mostRecentlySelectedSlot = null;
+      state.mostRecentlySelectedSlot = null; // deselect
+    },
+    bulkRemovePrintingFilter: (
+      state,
+      action: PayloadAction<{
+        slots: Array<[Faces, number]>;
+      }>
+    ) => {
+      for (const [face, slot] of action.payload.slots) {
+        if (state.members[slot][face] != null) {
+          state.members[slot][face].query = {
+            // query: state.members[slot][face].query.query,
+            // cardType: state.members[slot][face].query.cardType,
+            ...state.members[slot][face].query,
+            expansionCode: undefined,
+            collectorNumber: undefined,
+          };
+          state.members[slot][face].selected = false;
+        }
+      }
+      state.mostRecentlySelectedSlot = null; // deselect
     },
     bulkAlignMemberSelection: (
       state,
@@ -251,11 +273,10 @@ export const projectSlice = createAppSlice({
       if (selectedMember != null) {
         for (const [slot, projectMember] of state.members.entries()) {
           if (
-            projectMember[action.payload.face] != null &&
-            projectMember[action.payload.face]?.query?.query ===
-              selectedMember.query?.query &&
-            projectMember[action.payload.face]?.query?.cardType ===
-              selectedMember.query?.cardType
+            areSearchQueriesEqual(
+              projectMember[action.payload.face]?.query,
+              selectedMember.query
+            )
           ) {
             projectMember[action.payload.face]!.selected =
               selectedMember.selected;
@@ -329,6 +350,7 @@ export const {
   toggleMemberSelection,
   expandSelection,
   bulkSetMemberSelection,
+  bulkRemovePrintingFilter,
   bulkAlignMemberSelection,
   deleteSlots,
   moveSlot,
@@ -490,12 +512,8 @@ export const selectAllSelectedProjectMembersHaveTheSameQuery = createSelector(
     const projectMembers = slots.map((slot) =>
       getProjectMember(members, ...slot)
     );
-    return projectMembers.every(
-      (projectMember) =>
-        (firstQuery?.query == null && projectMember?.query?.query == null) ||
-        (firstQuery != null &&
-          projectMember?.query?.query == firstQuery.query &&
-          projectMember?.query?.cardType == firstQuery.cardType)
+    return projectMembers.every((projectMember) =>
+      areSearchQueriesEqual(firstQuery, projectMember?.query)
     )
       ? firstQuery
       : undefined;
@@ -559,6 +577,20 @@ export const selectAnySelectedImagesDownloadable = createSelector(
       getProjectMember(members, ...slot)
     );
     return anyImagesDownloadable(projectMembers, cardDocuments);
+  }
+);
+
+export const selectAnySelectedImagesFilteredOnPrinting = createSelector(
+  (state: RootState, slots: Slots) => state.project.members,
+  (state: RootState, slots: Slots) => state.cardDocuments.cardDocuments,
+  (state: RootState, slots: Slots) => slots,
+  (members, cardDocuments, slots) => {
+    const projectMembers = slots.map((slot) =>
+      getProjectMember(members, ...slot)
+    );
+    return projectMembers.some(
+      (member) => member?.query && doesSearchQueryFilterOnPrinting(member.query)
+    );
   }
 );
 

--- a/frontend/src/store/slices/searchResultsSlice.ts
+++ b/frontend/src/store/slices/searchResultsSlice.ts
@@ -181,40 +181,80 @@ const defaultEmptySearchResults: Array<string> = [];
  * Handle the fallback logic where cardbacks with no query use the common cardback's list of cards.
  */
 export const selectSearchResultsForQueryOrDefault = createSelector(
+  // TODO: this pattern is awful
   (
     state: RootState,
     query: string | null | undefined,
     cardType: CardType | undefined,
+    expansionCode: string | undefined,
+    collectorNumber: string | undefined,
     face: Faces
   ) => state.searchResults.searchResults,
   (
     state: RootState,
     query: string | null | undefined,
     cardType: CardType | undefined,
+    expansionCode: string | undefined,
+    collectorNumber: string | undefined,
     face: Faces
   ) => query,
   (
     state: RootState,
     query: string | null | undefined,
     cardType: CardType | undefined,
+    expansionCode: string | undefined,
+    collectorNumber: string | undefined,
     face: Faces
   ) => cardType,
   (
     state: RootState,
     query: string | null | undefined,
     cardType: CardType | undefined,
+    expansionCode: string | undefined,
+    collectorNumber: string | undefined,
+    face: Faces
+  ) => expansionCode,
+  (
+    state: RootState,
+    query: string | null | undefined,
+    cardType: CardType | undefined,
+    expansionCode: string | undefined,
+    collectorNumber: string | undefined,
+    face: Faces
+  ) => collectorNumber,
+  (
+    state: RootState,
+    query: string | null | undefined,
+    cardType: CardType | undefined,
+    expansionCode: string | undefined,
+    collectorNumber: string | undefined,
     face: Faces
   ) => face,
   (
     state: RootState,
     query: string | null | undefined,
     cardType: CardType | undefined,
+    expansionCode: string | undefined,
+    collectorNumber: string | undefined,
     face: Faces
   ) => selectCardbacks(state),
-  (searchResults, query, cardType, face, cardbacks) =>
+  (
+    searchResults,
+    query,
+    cardType,
+    expansionCode,
+    collectorNumber,
+    face,
+    cardbacks
+  ) =>
     query != null && query.length > 0 && cardType !== undefined
       ? searchResults[
-          computeSearchQueryHashKey({ query: query, cardType: cardType })
+          computeSearchQueryHashKey({
+            query,
+            cardType,
+            expansionCode,
+            collectorNumber,
+          })
         ]
       : face === Back
       ? cardbacks


### PR DESCRIPTION
# Description

* PR 3/3 for allowing per-search query filters on canonical card expansion code + collector number
* Extends the syntax for search queries to be like
```
<quantity>x <card name> (<expansion code>) <collector number>
```
e.g.
```
1x Lightning Bolt (M10) 146
```
* sketched out some basic UI elements to allow removing these per-printing filters from in-place slots, likely to iterate on the UX over the coming weeks - e.g. likely need to add some visual cue that a slot is filtered on a specific printing
* Resolves #173, #315

# Checklist

- [x] I have installed `pre-commit` and installed the hooks with `pre-commit install` before creating any commits.
- [x] I have updated any related tests for code I modified or added new tests where appropriate.
- [x] I have manually tested my changes as follows:
  - manually exercised against a bunch of test cards
- [ ] I have updated any relevant documentation or created new documentation where appropriate.
  - later (TM)