### PR TITLE
Feat/scm pdf templates

### DIFF
--- a/frontend/src/features/pdf/PDF.tsx
+++ b/frontend/src/features/pdf/PDF.tsx
@@ -7,9 +7,14 @@ import {
   CardWidthMM,
   CornerRadiusMM,
 } from "@/common/constants";
-import { getBucketImageURL, getWorkerImageURL } from "@/common/image";
-import { SourceType } from "@/common/schema_types";
 import { CardDocument, SlotProjectMembers } from "@/common/types";
+import { getPDFImageURL, PDFImageQuality } from "@/features/pdf/pdfImage";
+import {
+  ScmPaperSize,
+  ScmRegistration,
+  ScmVariant,
+} from "@/features/pdf/scm/scmLayout";
+import { SCMPDF } from "@/features/pdf/scm/SCMPDF";
 
 const PDFContext = createContext<PDFProps | undefined>(undefined);
 
@@ -241,47 +246,22 @@ export interface PDFProps {
   cardDocumentsByIdentifier: { [identifier: string]: CardDocument };
   projectMembers: Array<SlotProjectMembers>;
   projectCardback: string | undefined;
-  imageQuality: "small-thumbnail" | "large-thumbnail" | "full-resolution";
+  imageQuality: PDFImageQuality;
   imageDPI: number | undefined;
   jpgQuality: number;
   fileHandles: { [identifier: string]: FileSystemFileHandle };
+  // SCM (Silhouette Card Maker) mode. When scmMode is true, the standard
+  // parametric layout above is ignored in favour of an SCM-template-compatible
+  // layout with registration marks (see scm/SCMPDF.tsx).
+  scmMode: boolean;
+  scmPaperSize: ScmPaperSize;
+  scmVariant: ScmVariant;
+  scmRegistration: ScmRegistration;
+  scmDuplex: boolean;
+  scmOffsetXPx: number;
+  scmOffsetYPx: number;
+  scmOffsetAngleDeg: number;
 }
-
-const getPDFImageURL = async (
-  cardDocument: CardDocument,
-  imageQuality: "small-thumbnail" | "large-thumbnail" | "full-resolution",
-  dpi: number | undefined,
-  jpgQuality: number,
-  fileHandles: { [identifier: string]: FileSystemFileHandle }
-): Promise<string | Blob | undefined> => {
-  switch (cardDocument.sourceType) {
-    case SourceType.GoogleDrive:
-      switch (imageQuality) {
-        case "small-thumbnail":
-          return getBucketImageURL(cardDocument, "small");
-        case "large-thumbnail":
-          return getBucketImageURL(cardDocument, "large");
-        case "full-resolution":
-          return getWorkerImageURL(cardDocument, "full", dpi, jpgQuality);
-        default:
-          throw new Error(`invalid imageQuality ${imageQuality}`);
-      }
-
-    case SourceType.LocalFile:
-      const handle = fileHandles[cardDocument.identifier];
-      if (handle !== undefined) {
-        return URL.createObjectURL(await handle.getFile());
-      } else {
-        throw new Error(
-          `could not get handle for file ${cardDocument.identifier}`
-        );
-      }
-    default:
-      throw new Error(
-        `cannot get PDF thumbnail URL for card ${cardDocument.identifier}`
-      );
-  }
-};
 
 interface PDFCardThumbnailProps {
   cardDocument: CardDocument;
@@ -933,6 +913,27 @@ const CardSelectionModeToPaginator: {
 };
 
 export const PDF = (props: PDFProps) => {
+  if (props.scmMode) {
+    return (
+      <SCMPDF
+        scmPaperSize={props.scmPaperSize}
+        scmVariant={props.scmVariant}
+        scmRegistration={props.scmRegistration}
+        scmDuplex={props.scmDuplex}
+        scmOffsetXPx={props.scmOffsetXPx}
+        scmOffsetYPx={props.scmOffsetYPx}
+        scmOffsetAngleDeg={props.scmOffsetAngleDeg}
+        cardDocumentsByIdentifier={props.cardDocumentsByIdentifier}
+        projectMembers={props.projectMembers}
+        projectCardback={props.projectCardback}
+        imageQuality={props.imageQuality}
+        imageDPI={props.imageDPI}
+        jpgQuality={props.jpgQuality}
+        fileHandles={props.fileHandles}
+      />
+    );
+  }
+
   const size = getPageSizeMM(props.pageSize, props.pageWidth, props.pageHeight);
 
   const containerWidth = calculateCardContainerWidth(

--- a/frontend/src/features/pdf/PDF.tsx
+++ b/frontend/src/features/pdf/PDF.tsx
@@ -258,8 +258,8 @@ export interface PDFProps {
   scmVariant: ScmVariant;
   scmRegistration: ScmRegistration;
   scmDuplex: boolean;
-  scmOffsetXPx: number;
-  scmOffsetYPx: number;
+  scmOffsetXMM: number;
+  scmOffsetYMM: number;
   scmOffsetAngleDeg: number;
 }
 
@@ -920,8 +920,8 @@ export const PDF = (props: PDFProps) => {
         scmVariant={props.scmVariant}
         scmRegistration={props.scmRegistration}
         scmDuplex={props.scmDuplex}
-        scmOffsetXPx={props.scmOffsetXPx}
-        scmOffsetYPx={props.scmOffsetYPx}
+        scmOffsetXMM={props.scmOffsetXMM}
+        scmOffsetYMM={props.scmOffsetYMM}
         scmOffsetAngleDeg={props.scmOffsetAngleDeg}
         cardDocumentsByIdentifier={props.cardDocumentsByIdentifier}
         projectMembers={props.projectMembers}

--- a/frontend/src/features/pdf/PDFGenerator.tsx
+++ b/frontend/src/features/pdf/PDFGenerator.tsx
@@ -26,6 +26,14 @@ import {
   PDFProps,
 } from "@/features/pdf/PDF";
 import { pdfRenderService } from "@/features/pdf/pdfRenderService";
+import {
+  BORDERLESS_STUDIO_EXPANSION_MM,
+  ScmPaperLabels,
+  ScmPaperSize,
+  ScmRegistration,
+  scmTemplateName,
+  ScmVariant,
+} from "@/features/pdf/scm/scmLayout";
 import { useCardDocumentsByIdentifier } from "@/store/slices/cardDocumentsSlice";
 import {
   selectProjectCardback,
@@ -618,6 +626,180 @@ const SpacingAndMarginsSettings = ({
   );
 };
 
+interface SCMSettingsProps {
+  scmPaperSize: ScmPaperSize;
+  setScmPaperSize: (value: ScmPaperSize) => void;
+  scmVariant: ScmVariant;
+  setScmVariant: (value: ScmVariant) => void;
+  scmRegistration: ScmRegistration;
+  setScmRegistration: (value: ScmRegistration) => void;
+  scmDuplex: boolean;
+  setScmDuplex: (value: boolean) => void;
+  scmOffsetXPx: number | undefined;
+  setScmOffsetXPx: (value: number | undefined) => void;
+  scmOffsetYPx: number | undefined;
+  setScmOffsetYPx: (value: number | undefined) => void;
+  scmOffsetAngleDeg: number | undefined;
+  setScmOffsetAngleDeg: (value: number | undefined) => void;
+}
+
+const SCMSettings = ({
+  scmPaperSize,
+  setScmPaperSize,
+  scmVariant,
+  setScmVariant,
+  scmRegistration,
+  setScmRegistration,
+  scmDuplex,
+  setScmDuplex,
+  scmOffsetXPx,
+  setScmOffsetXPx,
+  scmOffsetYPx,
+  setScmOffsetYPx,
+  scmOffsetAngleDeg,
+  setScmOffsetAngleDeg,
+}: SCMSettingsProps) => {
+  const [expanded, setExpanded] = useState<boolean>(true);
+
+  const paperSizeOptions = useMemo(
+    () =>
+      Object.keys(ScmPaperLabels).map((value) => ({
+        value,
+        label: ScmPaperLabels[value as ScmPaperSize],
+        checked: value === scmPaperSize,
+      })),
+    [scmPaperSize]
+  );
+
+  const isBorderless = scmVariant === "borderless";
+
+  return (
+    <AutofillCollapse
+      expanded={expanded}
+      onClick={() => setExpanded(!expanded)}
+      zIndex={15}
+      title="Silhouette Template"
+    >
+      <Container className="p-2">
+        <Row>
+          <Col xs={12}>
+            <Form.Label>Paper size</Form.Label>
+            <StyledDropdownTreeSelect
+              data={paperSizeOptions}
+              onChange={(currentNode) =>
+                setScmPaperSize(currentNode.value as ScmPaperSize)
+              }
+              mode="radioSelect"
+              inlineSearchInput
+            />
+          </Col>
+        </Row>
+        <Form.Label>Template</Form.Label>
+        <Toggle
+          onClick={() =>
+            setScmVariant(isBorderless ? "default" : "borderless")
+          }
+          on="Borderless"
+          onClassName="flex-centre"
+          off="Normal"
+          offClassName="flex-centre"
+          onstyle="success"
+          offstyle="info"
+          width={100 + "%"}
+          size="md"
+          height={ToggleButtonHeight + "px"}
+          active={isBorderless}
+        />
+        <Form.Label>Registration marks</Form.Label>
+        <Toggle
+          onClick={() => setScmRegistration(scmRegistration === 3 ? 4 : 3)}
+          on="4 Corner (Cameo 5)"
+          onClassName="flex-centre"
+          off="3 Corner"
+          offClassName="flex-centre"
+          onstyle="success"
+          offstyle="info"
+          width={100 + "%"}
+          size="md"
+          height={ToggleButtonHeight + "px"}
+          active={scmRegistration === 4}
+        />
+        <Form.Label>Sides</Form.Label>
+        <Toggle
+          onClick={() => setScmDuplex(!scmDuplex)}
+          on="Duplex (front + back)"
+          onClassName="flex-centre"
+          off="Fronts only"
+          offClassName="flex-centre"
+          onstyle="success"
+          offstyle="info"
+          width={100 + "%"}
+          size="md"
+          height={ToggleButtonHeight + "px"}
+          active={scmDuplex}
+        />
+        <hr />
+        <p className="mb-1">
+          Load this cutting template in Silhouette Studio:
+        </p>
+        <p className="mb-1">
+          <a
+            href="https://github.com/Alan-Cha/silhouette-card-maker/tree/main/cutting_templates"
+            target="_blank"
+            rel="noreferrer"
+          >
+            <code>{scmTemplateName(scmPaperSize, scmVariant)}</code>
+          </a>
+        </p>
+        {isBorderless && (
+          <p className="text-muted" style={{ fontSize: "0.85em" }}>
+            Borderless: in Silhouette Studio, set a custom page size{" "}
+            <b>{BORDERLESS_STUDIO_EXPANSION_MM}mm larger</b> in each dimension
+            than the real paper so the registration marks land at the correct
+            inset.
+          </p>
+        )}
+        {scmDuplex && (
+          <Row className="mt-1">
+            <Col xs={12}>
+              <Form.Label>Back alignment offset</Form.Label>
+              <p className="text-muted mb-1" style={{ fontSize: "0.8em" }}>
+                Pixels at 300 DPI (1px ≈ 0.085mm), matching SCM&apos;s{" "}
+                <code>offset_pdf</code> values. X+ = right, Y+ = up, angle+ =
+                clockwise, relative to the back page.
+              </p>
+            </Col>
+            <Col xs={6}>
+              <NumericField
+                label="Offset X (px)"
+                value={scmOffsetXPx}
+                setValue={setScmOffsetXPx}
+                step={1}
+              />
+            </Col>
+            <Col xs={6}>
+              <NumericField
+                label="Offset Y (px)"
+                value={scmOffsetYPx}
+                setValue={setScmOffsetYPx}
+                step={1}
+              />
+            </Col>
+            <Col xs={6} className="mt-1">
+              <NumericField
+                label="Angle (°)"
+                value={scmOffsetAngleDeg}
+                setValue={setScmOffsetAngleDeg}
+                step={0.1}
+              />
+            </Col>
+          </Row>
+        )}
+      </Container>
+    </AutofillCollapse>
+  );
+};
+
 export const PDFGenerator = ({ heightDelta = 0 }: { heightDelta?: number }) => {
   const dispatch = useAppDispatch();
   const [cardSpacingRowMM, setCardSpacingRowMM] = useState<number | undefined>(
@@ -646,6 +828,18 @@ export const PDFGenerator = ({ heightDelta = 0 }: { heightDelta?: number }) => {
     number | undefined
   >(0.2);
   const [cutLineColor, setCutLineColor] = useState<string>("#FF0000");
+
+  // SCM (Silhouette Card Maker) mode state.
+  const [scmMode, setScmMode] = useState<boolean>(false);
+  const [scmPaperSize, setScmPaperSize] = useState<ScmPaperSize>("letter");
+  const [scmVariant, setScmVariant] = useState<ScmVariant>("default");
+  const [scmRegistration, setScmRegistration] = useState<ScmRegistration>(3);
+  const [scmDuplex, setScmDuplex] = useState<boolean>(true);
+  const [scmOffsetXPx, setScmOffsetXPx] = useState<number | undefined>(0);
+  const [scmOffsetYPx, setScmOffsetYPx] = useState<number | undefined>(0);
+  const [scmOffsetAngleDeg, setScmOffsetAngleDeg] = useState<
+    number | undefined
+  >(0);
 
   const { clientSearchService } = useClientSearchContext();
   const projectMembers = useAppSelector(selectProjectMembers);
@@ -695,6 +889,14 @@ export const PDFGenerator = ({ heightDelta = 0 }: { heightDelta?: number }) => {
     cardDocumentsByIdentifier: cardDocumentsByIdentifier,
     projectMembers: projectMembers,
     projectCardback: projectCardback,
+    scmMode: scmMode,
+    scmPaperSize: scmPaperSize,
+    scmVariant: scmVariant,
+    scmRegistration: scmRegistration,
+    scmDuplex: scmDuplex,
+    scmOffsetXPx: scmOffsetXPx ?? 0,
+    scmOffsetYPx: scmOffsetYPx ?? 0,
+    scmOffsetAngleDeg: scmOffsetAngleDeg ?? 0,
     // the following settings don't matter for previewing and should remain stable to prevent unnecessary re-renders.
     imageQuality: "small-thumbnail",
     imageDPI: undefined,
@@ -749,62 +951,117 @@ export const PDFGenerator = ({ heightDelta = 0 }: { heightDelta?: number }) => {
             </li>
           </ol>
           <hr />
-          <PageSizeSettings
-            pageWidth={pageWidth}
-            setPageWidth={setPageWidth}
-            pageHeight={pageHeight}
-            setPageHeight={setPageHeight}
-            pageSize={pageSize}
-            setPageSize={setPageSize}
+          <Form.Label>Silhouette (SCM) cutting mode</Form.Label>
+          <Toggle
+            onClick={() => setScmMode(!scmMode)}
+            on="On"
+            onClassName="flex-centre"
+            off="Off"
+            offClassName="flex-centre"
+            onstyle="success"
+            offstyle="info"
+            width={100 + "%"}
+            size="md"
+            height={ToggleButtonHeight + "px"}
+            active={scmMode}
           />
-          <CardSelectionSettings
-            cardSelectionMode={cardSelectionMode}
-            setCardSelectionMode={setCardSelectionMode}
-          />
-          <CardQualitySettings
-            imageDPI={imageDPI}
-            setImageDPI={setImageDPI}
-            jpgQuality={jpgQuality}
-            setJPGQuality={setJPGQuality}
-          />
-          <EdgeSettings
-            bleedEdgeMM={bleedEdgeMM}
-            setBleedEdgeMM={setBleedEdgeMM}
-            roundCorners={roundCorners}
-            setRoundCorners={setRoundCorners}
-          />
-          <CutLinesSettings
-            drawCardCutLines={drawCardCutLines}
-            setDrawCardCutLines={setDrawCardCutLines}
-            drawPageCutLines={drawPageCutLines}
-            setDrawPageCutLines={setDrawPageCutLines}
-            cutLineShape={cutLineShape}
-            setCutLineShape={setCutLineShape}
-            cutLinePlacement={cutLinePlacement}
-            setCutLinePlacement={setCutLinePlacement}
-            cutLineLengthMM={cutLineLengthMM}
-            setCutLineLengthMM={setCutLineLengthMM}
-            cutLineOffsetMM={cutLineOffsetMM}
-            setCutLineOffsetMM={setCutLineOffsetMM}
-            cutLineThicknessMM={cutLineThicknessMM}
-            setCutLineThicknessMM={setCutLineThicknessMM}
-            cutLineColor={cutLineColor}
-            setCutLineColor={setCutLineColor}
-          />
-          <SpacingAndMarginsSettings
-            cardSpacingRowMM={cardSpacingRowMM}
-            setCardSpacingRowMM={setCardSpacingRowMM}
-            cardSpacingColMM={cardSpacingColMM}
-            setCardSpacingColMM={setCardSpacingColMM}
-            pageMarginTopMM={pageMarginTopMM}
-            setPageMarginTopMM={setPageMarginTopMM}
-            pageMarginBottomMM={pageMarginBottomMM}
-            setPageMarginBottomMM={setPageMarginBottomMM}
-            pageMarginLeftMM={pageMarginLeftMM}
-            setPageMarginLeftMM={setPageMarginLeftMM}
-            pageMarginRightMM={pageMarginRightMM}
-            setPageMarginRightMM={setPageMarginRightMM}
-          />
+          <p className="text-muted mt-1" style={{ fontSize: "0.85em" }}>
+            Generate a PDF with registration marks compatible with{" "}
+            <a
+              href="https://github.com/Alan-Cha/silhouette-card-maker"
+              target="_blank"
+              rel="noreferrer"
+            >
+              silhouette-card-maker
+            </a>{" "}
+            cutting templates (standard 63×88mm cards).
+          </p>
+          <hr />
+          {scmMode ? (
+            <>
+              <SCMSettings
+                scmPaperSize={scmPaperSize}
+                setScmPaperSize={setScmPaperSize}
+                scmVariant={scmVariant}
+                setScmVariant={setScmVariant}
+                scmRegistration={scmRegistration}
+                setScmRegistration={setScmRegistration}
+                scmDuplex={scmDuplex}
+                setScmDuplex={setScmDuplex}
+                scmOffsetXPx={scmOffsetXPx}
+                setScmOffsetXPx={setScmOffsetXPx}
+                scmOffsetYPx={scmOffsetYPx}
+                setScmOffsetYPx={setScmOffsetYPx}
+                scmOffsetAngleDeg={scmOffsetAngleDeg}
+                setScmOffsetAngleDeg={setScmOffsetAngleDeg}
+              />
+              <CardQualitySettings
+                imageDPI={imageDPI}
+                setImageDPI={setImageDPI}
+                jpgQuality={jpgQuality}
+                setJPGQuality={setJPGQuality}
+              />
+            </>
+          ) : (
+            <>
+              <PageSizeSettings
+                pageWidth={pageWidth}
+                setPageWidth={setPageWidth}
+                pageHeight={pageHeight}
+                setPageHeight={setPageHeight}
+                pageSize={pageSize}
+                setPageSize={setPageSize}
+              />
+              <CardSelectionSettings
+                cardSelectionMode={cardSelectionMode}
+                setCardSelectionMode={setCardSelectionMode}
+              />
+              <CardQualitySettings
+                imageDPI={imageDPI}
+                setImageDPI={setImageDPI}
+                jpgQuality={jpgQuality}
+                setJPGQuality={setJPGQuality}
+              />
+              <EdgeSettings
+                bleedEdgeMM={bleedEdgeMM}
+                setBleedEdgeMM={setBleedEdgeMM}
+                roundCorners={roundCorners}
+                setRoundCorners={setRoundCorners}
+              />
+              <CutLinesSettings
+                drawCardCutLines={drawCardCutLines}
+                setDrawCardCutLines={setDrawCardCutLines}
+                drawPageCutLines={drawPageCutLines}
+                setDrawPageCutLines={setDrawPageCutLines}
+                cutLineShape={cutLineShape}
+                setCutLineShape={setCutLineShape}
+                cutLinePlacement={cutLinePlacement}
+                setCutLinePlacement={setCutLinePlacement}
+                cutLineLengthMM={cutLineLengthMM}
+                setCutLineLengthMM={setCutLineLengthMM}
+                cutLineOffsetMM={cutLineOffsetMM}
+                setCutLineOffsetMM={setCutLineOffsetMM}
+                cutLineThicknessMM={cutLineThicknessMM}
+                setCutLineThicknessMM={setCutLineThicknessMM}
+                cutLineColor={cutLineColor}
+                setCutLineColor={setCutLineColor}
+              />
+              <SpacingAndMarginsSettings
+                cardSpacingRowMM={cardSpacingRowMM}
+                setCardSpacingRowMM={setCardSpacingRowMM}
+                cardSpacingColMM={cardSpacingColMM}
+                setCardSpacingColMM={setCardSpacingColMM}
+                pageMarginTopMM={pageMarginTopMM}
+                setPageMarginTopMM={setPageMarginTopMM}
+                pageMarginBottomMM={pageMarginBottomMM}
+                setPageMarginBottomMM={setPageMarginBottomMM}
+                pageMarginLeftMM={pageMarginLeftMM}
+                setPageMarginLeftMM={setPageMarginLeftMM}
+                pageMarginRightMM={pageMarginRightMM}
+                setPageMarginRightMM={setPageMarginRightMM}
+              />
+            </>
+          )}
           <hr />
           <div className="d-grid gap-0">
             <Button onClick={downloadPDF} disabled={isDownloading}>

--- a/frontend/src/features/pdf/PDFGenerator.tsx
+++ b/frontend/src/features/pdf/PDFGenerator.tsx
@@ -696,9 +696,7 @@ const SCMSettings = ({
         </Row>
         <Form.Label>Template</Form.Label>
         <Toggle
-          onClick={() =>
-            setScmVariant(isBorderless ? "default" : "borderless")
-          }
+          onClick={() => setScmVariant(isBorderless ? "default" : "borderless")}
           on="Borderless"
           onClassName="flex-centre"
           off="Normal"
@@ -739,9 +737,7 @@ const SCMSettings = ({
           active={scmDuplex}
         />
         <hr />
-        <p className="mb-1">
-          Load this cutting template in Silhouette Studio:
-        </p>
+        <p className="mb-1">Load this cutting template in Silhouette Studio:</p>
         <p className="mb-1">
           <a
             href="https://github.com/Alan-Cha/silhouette-card-maker/tree/main/cutting_templates"

--- a/frontend/src/features/pdf/PDFGenerator.tsx
+++ b/frontend/src/features/pdf/PDFGenerator.tsx
@@ -28,6 +28,7 @@ import {
 import { pdfRenderService } from "@/features/pdf/pdfRenderService";
 import {
   BORDERLESS_STUDIO_EXPANSION_MM,
+  scmOffsetMMToPx,
   ScmPaperLabels,
   ScmPaperSize,
   ScmRegistration,
@@ -635,10 +636,10 @@ interface SCMSettingsProps {
   setScmRegistration: (value: ScmRegistration) => void;
   scmDuplex: boolean;
   setScmDuplex: (value: boolean) => void;
-  scmOffsetXPx: number | undefined;
-  setScmOffsetXPx: (value: number | undefined) => void;
-  scmOffsetYPx: number | undefined;
-  setScmOffsetYPx: (value: number | undefined) => void;
+  scmOffsetXMM: number | undefined;
+  setScmOffsetXMM: (value: number | undefined) => void;
+  scmOffsetYMM: number | undefined;
+  setScmOffsetYMM: (value: number | undefined) => void;
   scmOffsetAngleDeg: number | undefined;
   setScmOffsetAngleDeg: (value: number | undefined) => void;
 }
@@ -652,10 +653,10 @@ const SCMSettings = ({
   setScmRegistration,
   scmDuplex,
   setScmDuplex,
-  scmOffsetXPx,
-  setScmOffsetXPx,
-  scmOffsetYPx,
-  setScmOffsetYPx,
+  scmOffsetXMM,
+  setScmOffsetXMM,
+  scmOffsetYMM,
+  setScmOffsetYMM,
   scmOffsetAngleDeg,
   setScmOffsetAngleDeg,
 }: SCMSettingsProps) => {
@@ -760,25 +761,27 @@ const SCMSettings = ({
             <Col xs={12}>
               <Form.Label>Back alignment offset</Form.Label>
               <p className="text-muted mb-1" style={{ fontSize: "0.8em" }}>
-                Pixels at 300 DPI (1px ≈ 0.085mm), matching SCM&apos;s{" "}
-                <code>offset_pdf</code> values. X+ = right, Y+ = up, angle+ =
-                clockwise, relative to the back page.
+                Millimetres. X+ = right, Y+ = up, angle+ = clockwise, relative
+                to the back page. SCM&apos;s <code>offset_pdf</code> uses pixels
+                at 300 DPI — your offsets ≈{" "}
+                <b>{scmOffsetMMToPx(scmOffsetXMM ?? 0)}</b>,{" "}
+                <b>{scmOffsetMMToPx(scmOffsetYMM ?? 0)}</b> px.
               </p>
             </Col>
             <Col xs={6}>
               <NumericField
-                label="Offset X (px)"
-                value={scmOffsetXPx}
-                setValue={setScmOffsetXPx}
-                step={1}
+                label="Offset X (mm)"
+                value={scmOffsetXMM}
+                setValue={setScmOffsetXMM}
+                step={0.1}
               />
             </Col>
             <Col xs={6}>
               <NumericField
-                label="Offset Y (px)"
-                value={scmOffsetYPx}
-                setValue={setScmOffsetYPx}
-                step={1}
+                label="Offset Y (mm)"
+                value={scmOffsetYMM}
+                setValue={setScmOffsetYMM}
+                step={0.1}
               />
             </Col>
             <Col xs={6} className="mt-1">
@@ -831,8 +834,8 @@ export const PDFGenerator = ({ heightDelta = 0 }: { heightDelta?: number }) => {
   const [scmVariant, setScmVariant] = useState<ScmVariant>("default");
   const [scmRegistration, setScmRegistration] = useState<ScmRegistration>(3);
   const [scmDuplex, setScmDuplex] = useState<boolean>(true);
-  const [scmOffsetXPx, setScmOffsetXPx] = useState<number | undefined>(0);
-  const [scmOffsetYPx, setScmOffsetYPx] = useState<number | undefined>(0);
+  const [scmOffsetXMM, setScmOffsetXMM] = useState<number | undefined>(0);
+  const [scmOffsetYMM, setScmOffsetYMM] = useState<number | undefined>(0);
   const [scmOffsetAngleDeg, setScmOffsetAngleDeg] = useState<
     number | undefined
   >(0);
@@ -890,8 +893,8 @@ export const PDFGenerator = ({ heightDelta = 0 }: { heightDelta?: number }) => {
     scmVariant: scmVariant,
     scmRegistration: scmRegistration,
     scmDuplex: scmDuplex,
-    scmOffsetXPx: scmOffsetXPx ?? 0,
-    scmOffsetYPx: scmOffsetYPx ?? 0,
+    scmOffsetXMM: scmOffsetXMM ?? 0,
+    scmOffsetYMM: scmOffsetYMM ?? 0,
     scmOffsetAngleDeg: scmOffsetAngleDeg ?? 0,
     // the following settings don't matter for previewing and should remain stable to prevent unnecessary re-renders.
     imageQuality: "small-thumbnail",
@@ -984,10 +987,10 @@ export const PDFGenerator = ({ heightDelta = 0 }: { heightDelta?: number }) => {
                 setScmRegistration={setScmRegistration}
                 scmDuplex={scmDuplex}
                 setScmDuplex={setScmDuplex}
-                scmOffsetXPx={scmOffsetXPx}
-                setScmOffsetXPx={setScmOffsetXPx}
-                scmOffsetYPx={scmOffsetYPx}
-                setScmOffsetYPx={setScmOffsetYPx}
+                scmOffsetXMM={scmOffsetXMM}
+                setScmOffsetXMM={setScmOffsetXMM}
+                scmOffsetYMM={scmOffsetYMM}
+                setScmOffsetYMM={setScmOffsetYMM}
                 scmOffsetAngleDeg={scmOffsetAngleDeg}
                 setScmOffsetAngleDeg={setScmOffsetAngleDeg}
               />

--- a/frontend/src/features/pdf/pdfImage.ts
+++ b/frontend/src/features/pdf/pdfImage.ts
@@ -1,0 +1,49 @@
+import { getBucketImageURL, getWorkerImageURL } from "@/common/image";
+import { SourceType } from "@/common/schema_types";
+import { CardDocument } from "@/common/types";
+
+export type PDFImageQuality =
+  | "small-thumbnail"
+  | "large-thumbnail"
+  | "full-resolution";
+
+/**
+ * Resolve the image source for a card in a PDF, honouring the requested quality
+ * tier and the card's source (Google Drive bucket/worker, or a local file).
+ * Shared by the standard PDF render path and the SCM render path.
+ */
+export const getPDFImageURL = async (
+  cardDocument: CardDocument,
+  imageQuality: PDFImageQuality,
+  dpi: number | undefined,
+  jpgQuality: number,
+  fileHandles: { [identifier: string]: FileSystemFileHandle }
+): Promise<string | Blob | undefined> => {
+  switch (cardDocument.sourceType) {
+    case SourceType.GoogleDrive:
+      switch (imageQuality) {
+        case "small-thumbnail":
+          return getBucketImageURL(cardDocument, "small");
+        case "large-thumbnail":
+          return getBucketImageURL(cardDocument, "large");
+        case "full-resolution":
+          return getWorkerImageURL(cardDocument, "full", dpi, jpgQuality);
+        default:
+          throw new Error(`invalid imageQuality ${imageQuality}`);
+      }
+
+    case SourceType.LocalFile:
+      const handle = fileHandles[cardDocument.identifier];
+      if (handle !== undefined) {
+        return URL.createObjectURL(await handle.getFile());
+      } else {
+        throw new Error(
+          `could not get handle for file ${cardDocument.identifier}`
+        );
+      }
+    default:
+      throw new Error(
+        `cannot get PDF thumbnail URL for card ${cardDocument.identifier}`
+      );
+  }
+};

--- a/frontend/src/features/pdf/scm/SCMPDF.tsx
+++ b/frontend/src/features/pdf/scm/SCMPDF.tsx
@@ -1,0 +1,331 @@
+import { Document, Image, Page, View } from "@react-pdf/renderer";
+import React from "react";
+
+import { BleedEdgeMM } from "@/common/constants";
+import { CardDocument } from "@/common/types";
+import { getPDFImageURL, PDFImageQuality } from "@/features/pdf/pdfImage";
+import {
+  CARD_DISTANCE_MM,
+  generateScmLayout,
+  getRegistrationMarks,
+  ScmLayout,
+  ScmPaperSize,
+  ScmRect,
+  ScmRegistration,
+  ScmVariant,
+} from "@/features/pdf/scm/scmLayout";
+
+// SCM expresses calibration offsets in pixels at the 300-PPI baseline (see
+// utilities.offset_images / offset_pdf.py, where the value is an int applied as
+// `x * ppi / 300` pixels). react-pdf transforms are in points, so convert
+// px@300 -> pt: 1px @ 300dpi = 72/300 pt.
+const PX300_TO_PT = 72 / 300;
+
+/** SCM places cards with ~0.625mm bleed between neighbours (half of the 1.25mm
+ * card distance). We show at most that much of the MPC source bleed. */
+const SCM_BLEED_MM = Math.min(BleedEdgeMM, CARD_DISTANCE_MM / 2);
+
+export interface SCMPDFProps {
+  scmPaperSize: ScmPaperSize;
+  scmVariant: ScmVariant;
+  scmRegistration: ScmRegistration;
+  scmDuplex: boolean;
+  /** Back-page calibration offsets in pixels at 300 PPI (matches SCM). */
+  scmOffsetXPx: number;
+  scmOffsetYPx: number;
+  scmOffsetAngleDeg: number;
+  cardDocumentsByIdentifier: { [identifier: string]: CardDocument };
+  projectMembers: Array<{
+    front: { selectedImage?: string } | null;
+    back: { selectedImage?: string } | null;
+  }>;
+  projectCardback: string | undefined;
+  imageQuality: PDFImageQuality;
+  imageDPI: number | undefined;
+  jpgQuality: number;
+  fileHandles: { [identifier: string]: FileSystemFileHandle };
+}
+
+interface CardPair {
+  front: CardDocument;
+  back: CardDocument | undefined;
+}
+
+const chunk = <T,>(arr: Array<T>, size: number): Array<Array<T>> => {
+  const result: Array<Array<T>> = [];
+  for (let i = 0; i < arr.length; i += size) result.push(arr.slice(i, i + size));
+  return result;
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// A single card image clipped to its slot, with a sliver of bleed overflowing
+// into the inter-card gap. MPC source images already contain BleedEdgeMM of
+// bleed around the 63x88 trim; we clip to show only SCM_BLEED_MM of it.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const SCMCard = ({
+  cardDocument,
+  x,
+  y,
+  cardWidthMM,
+  cardHeightMM,
+  rotate180,
+  imageQuality,
+  imageDPI,
+  jpgQuality,
+  fileHandles,
+}: {
+  cardDocument: CardDocument;
+  x: number;
+  y: number;
+  cardWidthMM: number;
+  cardHeightMM: number;
+  rotate180: boolean;
+  imageQuality: PDFImageQuality;
+  imageDPI: number | undefined;
+  jpgQuality: number;
+  fileHandles: { [identifier: string]: FileSystemFileHandle };
+}) => {
+  const boxW = cardWidthMM + 2 * SCM_BLEED_MM;
+  const boxH = cardHeightMM + 2 * SCM_BLEED_MM;
+  // The full source image (trim + BleedEdgeMM bleed) is positioned so its trim
+  // aligns with the slot; the excess bleed overflows and is clipped by the box.
+  const imgLeft = SCM_BLEED_MM - BleedEdgeMM;
+  const imgTop = SCM_BLEED_MM - BleedEdgeMM;
+  const imgW = cardWidthMM + 2 * BleedEdgeMM;
+  const imgH = cardHeightMM + 2 * BleedEdgeMM;
+
+  return (
+    <View
+      style={{
+        position: "absolute" as const,
+        left: x - SCM_BLEED_MM + "mm",
+        top: y - SCM_BLEED_MM + "mm",
+        width: boxW + "mm",
+        height: boxH + "mm",
+        overflow: "hidden",
+      }}
+    >
+      <Image
+        src={async () =>
+          getPDFImageURL(
+            cardDocument,
+            imageQuality,
+            imageDPI,
+            jpgQuality,
+            fileHandles
+          )
+        }
+        style={
+          {
+            position: "absolute" as const,
+            left: imgLeft + "mm",
+            top: imgTop + "mm",
+            width: imgW + "mm",
+            height: imgH + "mm",
+            ...(rotate180 ? { transform: "rotate(180deg)" } : {}),
+          } as const
+        }
+      />
+    </View>
+  );
+};
+
+const Mark = ({ rect }: { rect: ScmRect }) => (
+  <View
+    style={{
+      position: "absolute" as const,
+      left: rect.x + "mm",
+      top: rect.y + "mm",
+      width: rect.w + "mm",
+      height: rect.h + "mm",
+      backgroundColor: "black",
+    }}
+  />
+);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// One page of content (registration marks + cards) in the un-rotated oriented
+// coordinate space. Fronts go in reading order; backs are mirrored per SCM's
+// duplex flip (mirror rows + rotate 180 for landscape, mirror cols for portrait)
+// so cuts align after flipping the sheet along its long edge.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const PageContent = ({
+  layout,
+  registration,
+  cards,
+  isBack,
+  imageProps,
+}: {
+  layout: ScmLayout;
+  registration: ScmRegistration;
+  cards: CardPair[];
+  isBack: boolean;
+  imageProps: {
+    imageQuality: PDFImageQuality;
+    imageDPI: number | undefined;
+    jpgQuality: number;
+    fileHandles: { [identifier: string]: FileSystemFileHandle };
+  };
+}) => {
+  const { cols, rows, slotsMM, cardWidthMM, cardHeightMM, orientation } = layout;
+  const marks = getRegistrationMarks(layout, registration);
+
+  const backSlotIndex = (i: number): number => {
+    const row = Math.floor(i / cols);
+    const col = i % cols;
+    const r = orientation === "landscape" ? rows - 1 - row : row;
+    const c = orientation === "portrait" ? cols - 1 - col : col;
+    return r * cols + c;
+  };
+
+  return (
+    <View
+      style={{
+        position: "absolute" as const,
+        left: 0,
+        top: 0,
+        width: layout.pageWidthMM + "mm",
+        height: layout.pageHeightMM + "mm",
+      }}
+    >
+      {marks.squares.map((rect, i) => (
+        <Mark key={`sq-${i}`} rect={rect} />
+      ))}
+      {marks.lines.map((rect, i) => (
+        <Mark key={`ln-${i}`} rect={rect} />
+      ))}
+      {cards.map((pair, i) => {
+        const doc = isBack ? pair.back : pair.front;
+        if (!doc) return null;
+        const slot = isBack ? slotsMM[backSlotIndex(i)] : slotsMM[i];
+        if (!slot) return null;
+        return (
+          <SCMCard
+            key={`card-${i}`}
+            cardDocument={doc}
+            x={slot.x}
+            y={slot.y}
+            cardWidthMM={cardWidthMM}
+            cardHeightMM={cardHeightMM}
+            rotate180={isBack && orientation === "landscape"}
+            {...imageProps}
+          />
+        );
+      })}
+    </View>
+  );
+};
+
+export const SCMPDF = (props: SCMPDFProps) => {
+  const layout = generateScmLayout(props.scmPaperSize, props.scmVariant);
+  const cardsPerPage = layout.rows * layout.cols;
+
+  // SCM always emits landscape pages; portrait layouts are rotated 90° clockwise
+  // (matching PIL rotate(-90)). Rotating the whole page rotates each card's art
+  // and outline together, so cut cards remain upright.
+  const isPortrait = layout.orientation === "portrait";
+  const pageOutWMM = isPortrait ? layout.pageHeightMM : layout.pageWidthMM;
+  const pageOutHMM = isPortrait ? layout.pageWidthMM : layout.pageHeightMM;
+
+  const docs = props.cardDocumentsByIdentifier;
+  const resolve = (id?: string): CardDocument | undefined =>
+    id ? docs[id] : undefined;
+
+  const cards: CardPair[] = props.projectMembers
+    .map((m): CardPair | undefined => {
+      const front = resolve(m.front?.selectedImage);
+      if (!front) return undefined;
+      const back = resolve(m.back?.selectedImage ?? props.projectCardback);
+      return { front, back };
+    })
+    .filter((c): c is CardPair => c !== undefined);
+
+  const pageGroups = cards.length > 0 ? chunk(cards, cardsPerPage) : [[]];
+
+  const imageProps = {
+    imageQuality: props.imageQuality,
+    imageDPI: props.imageDPI,
+    jpgQuality: props.jpgQuality,
+    fileHandles: props.fileHandles,
+  };
+
+  const offsetActive =
+    props.scmOffsetXPx !== 0 ||
+    props.scmOffsetYPx !== 0 ||
+    props.scmOffsetAngleDeg !== 0;
+
+  // Offset (back pages only): mirror SCM offset_images — shift the back-page
+  // raster by (-x, +y) px@300 then rotate by the angle about the page centre.
+  // In react-pdf transform space, translate is applied before rotate (CSS
+  // right-to-left), matching SCM's "offset then rotate". Signs match SCM's
+  // ImageChops.offset(-x, +y): translateX(-x) = left, translateY(+y) = down.
+  const backTransform = offsetActive
+    ? `rotate(${props.scmOffsetAngleDeg}deg) translateX(${
+        -props.scmOffsetXPx * PX300_TO_PT
+      }) translateY(${props.scmOffsetYPx * PX300_TO_PT})`
+    : undefined;
+
+  const renderPage = (cardsForPage: CardPair[], isBack: boolean, key: string) => {
+    const content = (
+      <PageContent
+        layout={layout}
+        registration={props.scmRegistration}
+        cards={cardsForPage}
+        isBack={isBack}
+        imageProps={imageProps}
+      />
+    );
+
+    // Rotate portrait content to landscape output, centred on the page.
+    const oriented = isPortrait ? (
+      <View
+        style={{
+          position: "absolute" as const,
+          left: pageOutWMM / 2 - layout.pageWidthMM / 2 + "mm",
+          top: pageOutHMM / 2 - layout.pageHeightMM / 2 + "mm",
+          width: layout.pageWidthMM + "mm",
+          height: layout.pageHeightMM + "mm",
+          transform: "rotate(90deg)",
+        }}
+      >
+        {content}
+      </View>
+    ) : (
+      content
+    );
+
+    return (
+      <Page
+        key={key}
+        size={{ width: pageOutWMM + "mm", height: pageOutHMM + "mm" }}
+      >
+        <View
+          style={{
+            position: "absolute" as const,
+            left: 0,
+            top: 0,
+            width: pageOutWMM + "mm",
+            height: pageOutHMM + "mm",
+            ...(isBack && backTransform ? { transform: backTransform } : {}),
+          }}
+        >
+          {oriented}
+        </View>
+      </Page>
+    );
+  };
+
+  return (
+    <Document pageMode="useThumbs">
+      {pageGroups.flatMap((group, i) => {
+        const pages = [renderPage(group, false, `front-${i}`)];
+        if (props.scmDuplex) {
+          pages.push(renderPage(group, true, `back-${i}`));
+        }
+        return pages;
+      })}
+    </Document>
+  );
+};

--- a/frontend/src/features/pdf/scm/SCMPDF.tsx
+++ b/frontend/src/features/pdf/scm/SCMPDF.tsx
@@ -15,11 +15,10 @@ import {
   ScmVariant,
 } from "@/features/pdf/scm/scmLayout";
 
-// SCM expresses calibration offsets in pixels at the 300-PPI baseline (see
-// utilities.offset_images / offset_pdf.py, where the value is an int applied as
-// `x * ppi / 300` pixels). react-pdf transforms are in points, so convert
-// px@300 -> pt: 1px @ 300dpi = 72/300 pt.
-const PX300_TO_PT = 72 / 300;
+// Offsets are entered in millimetres; react-pdf transforms are in points.
+// (SCM's offset_pdf uses px @ 300 PPI — see scmOffsetPxToMM in scmLayout.ts to
+// convert SCM calibration values to mm.)
+const MM_TO_PT = 72 / 25.4;
 
 /** SCM places cards with ~0.625mm bleed between neighbours (half of the 1.25mm
  * card distance). We show at most that much of the MPC source bleed. */
@@ -30,9 +29,9 @@ export interface SCMPDFProps {
   scmVariant: ScmVariant;
   scmRegistration: ScmRegistration;
   scmDuplex: boolean;
-  /** Back-page calibration offsets in pixels at 300 PPI (matches SCM). */
-  scmOffsetXPx: number;
-  scmOffsetYPx: number;
+  /** Back-page calibration offsets in millimetres. */
+  scmOffsetXMM: number;
+  scmOffsetYMM: number;
   scmOffsetAngleDeg: number;
   cardDocumentsByIdentifier: { [identifier: string]: CardDocument };
   projectMembers: Array<{
@@ -254,19 +253,19 @@ export const SCMPDF = (props: SCMPDFProps) => {
   };
 
   const offsetActive =
-    props.scmOffsetXPx !== 0 ||
-    props.scmOffsetYPx !== 0 ||
+    props.scmOffsetXMM !== 0 ||
+    props.scmOffsetYMM !== 0 ||
     props.scmOffsetAngleDeg !== 0;
 
   // Offset (back pages only): mirror SCM offset_images — shift the back-page
-  // raster by (-x, +y) px@300 then rotate by the angle about the page centre.
-  // In react-pdf transform space, translate is applied before rotate (CSS
+  // raster by (-x, +y) then rotate by the angle about the page centre. In
+  // react-pdf transform space, translate is applied before rotate (CSS
   // right-to-left), matching SCM's "offset then rotate". Signs match SCM's
   // ImageChops.offset(-x, +y): translateX(-x) = left, translateY(+y) = down.
   const backTransform = offsetActive
     ? `rotate(${props.scmOffsetAngleDeg}deg) translateX(${
-        -props.scmOffsetXPx * PX300_TO_PT
-      }) translateY(${props.scmOffsetYPx * PX300_TO_PT})`
+        -props.scmOffsetXMM * MM_TO_PT
+      }) translateY(${props.scmOffsetYMM * MM_TO_PT})`
     : undefined;
 
   const renderPage = (

--- a/frontend/src/features/pdf/scm/SCMPDF.tsx
+++ b/frontend/src/features/pdf/scm/SCMPDF.tsx
@@ -53,7 +53,8 @@ interface CardPair {
 
 const chunk = <T,>(arr: Array<T>, size: number): Array<Array<T>> => {
   const result: Array<Array<T>> = [];
-  for (let i = 0; i < arr.length; i += size) result.push(arr.slice(i, i + size));
+  for (let i = 0; i < arr.length; i += size)
+    result.push(arr.slice(i, i + size));
   return result;
 };
 
@@ -169,7 +170,8 @@ const PageContent = ({
     fileHandles: { [identifier: string]: FileSystemFileHandle };
   };
 }) => {
-  const { cols, rows, slotsMM, cardWidthMM, cardHeightMM, orientation } = layout;
+  const { cols, rows, slotsMM, cardWidthMM, cardHeightMM, orientation } =
+    layout;
   const marks = getRegistrationMarks(layout, registration);
 
   const backSlotIndex = (i: number): number => {
@@ -267,7 +269,11 @@ export const SCMPDF = (props: SCMPDFProps) => {
       }) translateY(${props.scmOffsetYPx * PX300_TO_PT})`
     : undefined;
 
-  const renderPage = (cardsForPage: CardPair[], isBack: boolean, key: string) => {
+  const renderPage = (
+    cardsForPage: CardPair[],
+    isBack: boolean,
+    key: string
+  ) => {
     const content = (
       <PageContent
         layout={layout}

--- a/frontend/src/features/pdf/scm/scmLayout.test.ts
+++ b/frontend/src/features/pdf/scm/scmLayout.test.ts
@@ -1,6 +1,8 @@
 import {
   generateScmLayout,
   getRegistrationMarks,
+  scmOffsetMMToPx,
+  scmOffsetPxToMM,
   ScmPaperSize,
   scmTemplateName,
   ScmVariant,
@@ -126,6 +128,18 @@ describe("getRegistrationMarks", () => {
       w: t,
       h: L + t / 2,
     });
+  });
+});
+
+describe("SCM offset conversion helpers", () => {
+  it("converts SCM offset pixels (300 PPI) to mm", () => {
+    expect(scmOffsetPxToMM(300)).toBeCloseTo(25.4, 6);
+    expect(scmOffsetPxToMM(12)).toBeCloseTo(1.016, 3);
+  });
+  it("converts mm to the equivalent SCM offset pixels (integer)", () => {
+    expect(scmOffsetMMToPx(25.4)).toBe(300);
+    expect(scmOffsetMMToPx(1)).toBe(12); // round(11.81)
+    expect(scmOffsetMMToPx(0)).toBe(0);
   });
 });
 

--- a/frontend/src/features/pdf/scm/scmLayout.test.ts
+++ b/frontend/src/features/pdf/scm/scmLayout.test.ts
@@ -60,22 +60,72 @@ describe("generateScmLayout", () => {
 });
 
 describe("getRegistrationMarks", () => {
+  // Geometry confirmed against SCM's real generate_reg_mark output at 300 PPI:
+  // bars centred on the inset line (outer edge at inset - t/2), projecting caps
+  // (arm length L + t/2, fully-filled corner), and a (5 + t)mm filled square.
+  const t = 1; // REG_THICKNESS_MM
+  const square = 5; // REG_SQUARE_MM
+
   it("3-corner has one square + two L-marks (4 strokes)", () => {
     const layout = generateScmLayout("letter", "default");
     const marks = getRegistrationMarks(layout, 3);
+    const inset = layout.insetMM;
+    const L = layout.registrationLengthMM;
+
     expect(marks.squares).toHaveLength(1);
     expect(marks.lines).toHaveLength(4);
-    expect(marks.squares[0]).toMatchObject({
-      x: layout.insetMM,
-      y: layout.insetMM,
+
+    // Square: (5 + t)mm, top-left at inset - t/2.
+    expect(marks.squares[0]).toEqual({
+      x: inset - t / 2,
+      y: inset - t / 2,
+      w: square + t,
+      h: square + t,
+    });
+
+    // Top-right L is one of the two L-marks. Its arms must share a filled corner
+    // (both reach the outer tip) and be L + t/2 long, t thick.
+    const W = layout.pageWidthMM;
+    const cx = W - inset;
+    // horizontal arm extends inward (left); outer cap projects to cx + t/2.
+    expect(marks.lines).toContainEqual({
+      x: cx - L,
+      y: inset - t / 2,
+      w: L + t / 2,
+      h: t,
+    });
+    // vertical arm centred on cx, extends down; outer cap projects up to inset - t/2.
+    expect(marks.lines).toContainEqual({
+      x: cx - t / 2,
+      y: inset - t / 2,
+      w: t,
+      h: L + t / 2,
     });
   });
 
   it("4-corner has no square + four L-marks (8 strokes)", () => {
     const layout = generateScmLayout("letter", "default");
     const marks = getRegistrationMarks(layout, 4);
+    const inset = layout.insetMM;
+    const L = layout.registrationLengthMM;
+
     expect(marks.squares).toHaveLength(0);
     expect(marks.lines).toHaveLength(8);
+
+    // Top-left L: both arms start at the outer tip (inset - t/2, inset - t/2),
+    // so the corner is fully filled (no notch).
+    expect(marks.lines).toContainEqual({
+      x: inset - t / 2,
+      y: inset - t / 2,
+      w: L + t / 2,
+      h: t,
+    });
+    expect(marks.lines).toContainEqual({
+      x: inset - t / 2,
+      y: inset - t / 2,
+      w: t,
+      h: L + t / 2,
+    });
   });
 });
 

--- a/frontend/src/features/pdf/scm/scmLayout.test.ts
+++ b/frontend/src/features/pdf/scm/scmLayout.test.ts
@@ -1,0 +1,91 @@
+import {
+  generateScmLayout,
+  getRegistrationMarks,
+  ScmPaperSize,
+  scmTemplateName,
+  ScmVariant,
+} from "@/features/pdf/scm/scmLayout";
+
+// Expected grids come straight from SCM's own assets/layouts.json
+// (layouts[paper][standard][variant].num_rows / num_cols). Reproducing them
+// proves our port of page_manager.generate_layout is faithful.
+const EXPECTED: {
+  paper: ScmPaperSize;
+  variant: ScmVariant;
+  rows: number;
+  cols: number;
+}[] = [
+  { paper: "letter", variant: "default", rows: 2, cols: 4 },
+  { paper: "letter", variant: "borderless", rows: 3, cols: 3 },
+  { paper: "tabloid", variant: "default", rows: 4, cols: 4 },
+  { paper: "tabloid", variant: "borderless", rows: 3, cols: 6 },
+  { paper: "a4", variant: "default", rows: 2, cols: 4 },
+  { paper: "a4", variant: "borderless", rows: 3, cols: 3 },
+  { paper: "a3", variant: "default", rows: 3, cols: 6 },
+  { paper: "a3", variant: "borderless", rows: 3, cols: 6 },
+  { paper: "arch_b", variant: "default", rows: 3, cols: 6 },
+  { paper: "arch_b", variant: "borderless", rows: 3, cols: 7 },
+];
+
+describe("generateScmLayout", () => {
+  it.each(EXPECTED)(
+    "computes the SCM grid for $paper/$variant ($rows x $cols)",
+    ({ paper, variant, rows, cols }) => {
+      const layout = generateScmLayout(paper, variant);
+      expect({ rows: layout.rows, cols: layout.cols }).toEqual({ rows, cols });
+      expect(layout.slotsMM).toHaveLength(rows * cols);
+    }
+  );
+
+  it("places slots within the page bounds and outside the corner inset", () => {
+    const layout = generateScmLayout("letter", "default");
+    for (const slot of layout.slotsMM) {
+      expect(slot.x).toBeGreaterThanOrEqual(layout.insetMM);
+      expect(slot.y).toBeGreaterThanOrEqual(layout.insetMM);
+      expect(slot.x + layout.cardWidthMM).toBeLessThanOrEqual(
+        layout.pageWidthMM - layout.insetMM
+      );
+      expect(slot.y + layout.cardHeightMM).toBeLessThanOrEqual(
+        layout.pageHeightMM - layout.insetMM
+      );
+    }
+  });
+
+  it("uses landscape page dims for landscape and swapped dims for portrait", () => {
+    const landscape = generateScmLayout("letter", "default");
+    expect(landscape.pageWidthMM).toBeGreaterThan(landscape.pageHeightMM);
+    const portrait = generateScmLayout("letter", "borderless");
+    expect(portrait.pageHeightMM).toBeGreaterThan(portrait.pageWidthMM);
+  });
+});
+
+describe("getRegistrationMarks", () => {
+  it("3-corner has one square + two L-marks (4 strokes)", () => {
+    const layout = generateScmLayout("letter", "default");
+    const marks = getRegistrationMarks(layout, 3);
+    expect(marks.squares).toHaveLength(1);
+    expect(marks.lines).toHaveLength(4);
+    expect(marks.squares[0]).toMatchObject({
+      x: layout.insetMM,
+      y: layout.insetMM,
+    });
+  });
+
+  it("4-corner has no square + four L-marks (8 strokes)", () => {
+    const layout = generateScmLayout("letter", "default");
+    const marks = getRegistrationMarks(layout, 4);
+    expect(marks.squares).toHaveLength(0);
+    expect(marks.lines).toHaveLength(8);
+  });
+});
+
+describe("scmTemplateName", () => {
+  it("omits 'default' and includes version", () => {
+    expect(scmTemplateName("letter", "default")).toBe("letter-standard-v6");
+  });
+  it("includes the borderless variant", () => {
+    expect(scmTemplateName("a4", "borderless")).toBe(
+      "a4-standard-borderless-v2"
+    );
+  });
+});

--- a/frontend/src/features/pdf/scm/scmLayout.ts
+++ b/frontend/src/features/pdf/scm/scmLayout.ts
@@ -394,8 +394,16 @@ export const generateScmLayout = (
 //
 // Returned in top-left-origin mm, relative to the (un-rotated) oriented page.
 // matplotlib uses a bottom-left origin upstream; here everything is converted to
-// react-pdf's top-left origin. L-arms are centred on their nominal axis (drawn as
-// Line2D upstream); the square is a filled rectangle anchored at the inset corner.
+// react-pdf's top-left origin.
+//
+// Geometry verified by running SCM's real generate_reg_mark at 300 PPI:
+//   - L-arm bars are CENTRED on the inset line (centreline at `inset`), so their
+//     outer edge sits at `inset - t/2`, not at `inset`.
+//   - matplotlib Line2D uses *projecting* caps (extend t/2 past each endpoint),
+//     so the two arms form a fully-filled square corner and each arm's total
+//     length is `L + t/2` (centreline `L - t/2` + a t/2 cap at each end).
+//   - The 3-corner filled square is drawn 5mm with a 1mm centred border, giving
+//     an effective `(5 + t) = 6mm` square whose top-left is at `inset - t/2`.
 // ─────────────────────────────────────────────────────────────────────────────
 
 export interface ScmRect {
@@ -419,25 +427,27 @@ export const getRegistrationMarks = (
 ): ScmRegistrationMarks => {
   const { pageWidthMM: W, pageHeightMM: H, insetMM: inset } = layout;
   const t = REG_THICKNESS_MM;
+  const half = t / 2;
   const L = layout.registrationLengthMM;
-  const arm = L - t / 2; // upstream draws arm length = length - thickness/2
 
   const squares: ScmRect[] = [];
   const lines: ScmRect[] = [];
 
-  // Horizontal arm from an inner corner (cx, cy) going inward by `dir` (+1/-1).
-  const hArm = (cx: number, cy: number, dir: 1 | -1): ScmRect => ({
-    x: dir === 1 ? cx : cx - arm,
-    y: cy - t / 2,
-    w: arm,
+  // Horizontal arm from an inner corner (cx, cy) extending inward by sx (+1/-1).
+  // Centred on y = cy; spans the inset line outward by t/2 (projecting cap) and
+  // inward to cy + sx*L, for a total length of L + t/2.
+  const hArm = (cx: number, cy: number, sx: 1 | -1): ScmRect => ({
+    x: sx === 1 ? cx - half : cx - L,
+    y: cy - half,
+    w: L + half,
     h: t,
   });
-  // Vertical arm from an inner corner (cx, cy) going inward by `dir` (+1/-1).
-  const vArm = (cx: number, cy: number, dir: 1 | -1): ScmRect => ({
-    x: cx - t / 2,
-    y: dir === 1 ? cy : cy - arm,
+  // Vertical arm from an inner corner (cx, cy) extending inward by sy (+1/-1).
+  const vArm = (cx: number, cy: number, sy: 1 | -1): ScmRect => ({
+    x: cx - half,
+    y: sy === 1 ? cy - half : cy - L,
     w: t,
-    h: arm,
+    h: L + half,
   });
 
   const corners = {
@@ -458,8 +468,14 @@ export const getRegistrationMarks = (
   };
 
   if (registration === 3) {
-    // Top-left filled square anchored at the inset corner.
-    squares.push({ x: inset, y: inset, w: REG_SQUARE_MM, h: REG_SQUARE_MM });
+    // Top-left filled square: 5mm fill + 1mm centred border = (5 + t)mm square
+    // whose top-left sits at (inset - t/2), centred on the inset corner point.
+    squares.push({
+      x: inset - half,
+      y: inset - half,
+      w: REG_SQUARE_MM + t,
+      h: REG_SQUARE_MM + t,
+    });
     addL(corners.bottomLeft);
     addL(corners.topRight);
   } else {

--- a/frontend/src/features/pdf/scm/scmLayout.ts
+++ b/frontend/src/features/pdf/scm/scmLayout.ts
@@ -1,0 +1,463 @@
+/**
+ * Faithful TypeScript port of silhouette-card-maker's (SCM) layout geometry.
+ *
+ * The cut positions in SCM's official Silhouette Studio templates (.studio3) are
+ * fixed, so this mode must reproduce SCM's card-grid and registration-mark
+ * positions exactly. We replicate the upstream math (size_convert.py,
+ * page_manager.py, the relevant parts of utilities.py / layouts.json) including
+ * the integer-pixel rounding at 300 PPI, then convert pixels -> millimetres for
+ * react-pdf via `pxToMM`.
+ *
+ * Upstream reference: https://github.com/Alan-Cha/silhouette-card-maker
+ */
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Constants (mirrors layouts.json defaults + page_manager.py)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** SCM computes every layout at this baseline resolution. */
+export const SCM_PPI = 300;
+
+/** Card "distance" / spacing between cards. Equivalent to ~0.625mm bleed/edge. */
+export const CARD_DISTANCE_MM = 1.25;
+
+/** Inset (paper edge -> registration marks). */
+export const DEFAULT_INSET_MM = 10;
+export const BORDERLESS_INSET_MM = 3.5;
+
+/** Corner exclusion zone = default reg length (5mm) + REG_PADDING (1.5mm). */
+export const CORNER_EXCLUSION_MM = 6.5;
+
+/** Registration mark line thickness. */
+export const REG_THICKNESS_MM = 1;
+
+/** Filled black registration square (3-corner pattern, top-left). */
+export const REG_SQUARE_MM = 5;
+
+/** Registration mark length is clamped to this range by page_manager.py. */
+export const MIN_REG_LENGTH_MM = 5;
+export const MAX_REG_LENGTH_MM = 20;
+
+/** Silhouette Studio enforces a 10mm minimum inset; borderless gets around this
+ * by declaring a larger paper size. Each paper dimension grows by this much. */
+export const BORDERLESS_STUDIO_EXPANSION_MM =
+  (DEFAULT_INSET_MM - BORDERLESS_INSET_MM) * 2; // 13mm
+
+/** Standard card (a.k.a. euro_poker) — the only card size this mode supports.
+ * Matches MPC's CardWidthMM / CardHeightMM. */
+export const SCM_CARD_WIDTH_MM = 63;
+export const SCM_CARD_HEIGHT_MM = 88;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Paper sizes — stored landscape (width >= height), in mm, like layouts.json.
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const ScmPaperSize = {
+  letter: "letter",
+  tabloid: "tabloid",
+  a4: "a4",
+  a3: "a3",
+  arch_b: "arch_b",
+} as const;
+export type ScmPaperSize = keyof typeof ScmPaperSize;
+
+export const ScmPaperLabels: { [k in ScmPaperSize]: string } = {
+  letter: 'Letter (8.5 × 11")',
+  tabloid: 'Tabloid (11 × 17")',
+  a4: "A4 (210 × 297mm)",
+  a3: "A3 (297 × 420mm)",
+  arch_b: 'Arch B (12 × 18")',
+};
+
+const IN_MM = 25.4;
+
+/** Landscape paper dimensions in mm: [width, height] with width >= height. */
+export const SCM_PAPER_MM: { [k in ScmPaperSize]: [number, number] } = {
+  letter: [11 * IN_MM, 8.5 * IN_MM], // 279.4 x 215.9
+  tabloid: [17 * IN_MM, 11 * IN_MM], // 431.8 x 279.4
+  a4: [297, 210],
+  a3: [420, 297],
+  arch_b: [18 * IN_MM, 12 * IN_MM], // 457.2 x 304.8
+};
+
+export const ScmVariant = {
+  default: "default",
+  borderless: "borderless",
+} as const;
+export type ScmVariant = keyof typeof ScmVariant;
+
+export type ScmOrientation = "portrait" | "landscape";
+
+/** Registration pattern: 3-corner (default) or 4-corner (Cameo 5 Alpha). */
+export type ScmRegistration = 3 | 4;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Standard-card layout table (subset of layouts.json -> layouts[paper][standard]).
+// `version` selects which .studio3 cutting template the user must load.
+// `regLength` is the displayed L-mark length (clamped to [5,20]).
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface ScmLayoutEntry {
+  orientation: ScmOrientation;
+  version: number;
+  regLengthMM: number;
+}
+
+export const SCM_STANDARD_LAYOUTS: {
+  [paper in ScmPaperSize]: { [variant in ScmVariant]: ScmLayoutEntry };
+} = {
+  letter: {
+    default: { orientation: "landscape", version: 6, regLengthMM: 8.04 },
+    borderless: { orientation: "portrait", version: 2, regLengthMM: 7.45 },
+  },
+  tabloid: {
+    default: { orientation: "portrait", version: 5, regLengthMM: 26.84 },
+    borderless: { orientation: "landscape", version: 2, regLengthMM: 18.97 },
+  },
+  a4: {
+    default: { orientation: "landscape", version: 5, regLengthMM: 9.4 },
+    borderless: { orientation: "portrait", version: 2, regLengthMM: 10.5 },
+  },
+  a3: {
+    default: { orientation: "landscape", version: 5, regLengthMM: 6.6 },
+    borderless: { orientation: "landscape", version: 2, regLengthMM: 13.63 },
+  },
+  arch_b: {
+    default: { orientation: "landscape", version: 4, regLengthMM: 25.15 },
+    borderless: { orientation: "landscape", version: 2, regLengthMM: 14.9 },
+  },
+};
+
+/** Compose SCM's template name: which .studio3 cutting file to load. */
+export const scmTemplateName = (
+  paper: ScmPaperSize,
+  variant: ScmVariant
+): string => {
+  const { version } = SCM_STANDARD_LAYOUTS[paper][variant];
+  return variant === "default"
+    ? `${paper}-standard-v${version}`
+    : `${paper}-standard-${variant}-v${version}`;
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Unit conversion (mirrors size_convert.py, with Python-style banker's rounding)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Python's round() uses round-half-to-even. JS Math.round rounds half up.
+ * Replicate banker's rounding so pixel math matches SCM exactly. */
+export const pyRound = (value: number): number => {
+  const floor = Math.floor(value);
+  const diff = value - floor;
+  if (diff < 0.5) return floor;
+  if (diff > 0.5) return floor + 1;
+  // Exactly .5 -> round to even.
+  return floor % 2 === 0 ? floor : floor + 1;
+};
+
+/** mm -> integer pixels at the given ppi (size_convert.size_to_pixel). */
+export const mmToPixel = (mm: number, ppi: number = SCM_PPI): number =>
+  pyRound((mm / IN_MM) * ppi);
+
+/** integer pixels -> mm (used to feed react-pdf, which works in mm). */
+export const pxToMM = (px: number, ppi: number = SCM_PPI): number =>
+  (px * IN_MM) / ppi;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Layout computation (mirrors page_manager.py)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** page_manager.normalize_page_size — portrait swaps page dims; cards never swap. */
+const normalizePageSize = (
+  orientation: ScmOrientation,
+  w: number,
+  h: number
+): [number, number] => (orientation === "portrait" ? [h, w] : [w, h]);
+
+/** page_manager.compute_grid_fit */
+const computeGridFit = (usable: number, card: number, bleed: number): number => {
+  if (usable <= 0) return 0;
+  return Math.max(0, Math.floor((usable + bleed) / (card + bleed)));
+};
+
+interface MarginResult {
+  cols: number;
+  rows: number;
+  marginX: number;
+  marginY: number;
+  usableW: number;
+  usableH: number;
+}
+
+/** page_manager.select_best_margins — strict corner-exclusion rule. */
+const selectBestMargins = (
+  pageW: number,
+  pageH: number,
+  cardW: number,
+  cardH: number,
+  bleed: number,
+  inset: number,
+  cornerLen: number
+): MarginResult => {
+  const strategies: [number, number][] = [
+    [inset, inset],
+    [inset + cornerLen, inset],
+    [inset, inset + cornerLen],
+  ];
+
+  let best: MarginResult | null = null;
+  let bestCount = 0;
+
+  const recordIfValid = (
+    cols: number,
+    rows: number,
+    marginX: number,
+    marginY: number,
+    usableW: number,
+    usableH: number
+  ) => {
+    if (cols <= 0 || rows <= 0) return;
+    const gridWidth = cols * cardW + (cols + 1) * bleed;
+    const gridHeight = rows * cardH + (rows + 1) * bleed;
+    const gapX = marginX + (usableW - gridWidth) / 2 - inset;
+    const gapY = marginY + (usableH - gridHeight) / 2 - inset;
+    if (gapX < cornerLen && gapY < cornerLen) return;
+    const count = cols * rows;
+    if (count > bestCount) {
+      bestCount = count;
+      best = { cols, rows, marginX, marginY, usableW, usableH };
+    }
+  };
+
+  for (const [marginX, marginY] of strategies) {
+    const usableW = pageW - 2 * marginX;
+    const usableH = pageH - 2 * marginY;
+
+    const maxCols = computeGridFit(usableW, cardW, bleed);
+    const maxRows = computeGridFit(usableH, cardH, bleed);
+
+    if (maxCols === 0 || maxRows === 0) continue;
+
+    recordIfValid(maxCols, maxRows, marginX, marginY, usableW, usableH);
+
+    const colsClear = Math.max(
+      0,
+      Math.floor(
+        (usableW - bleed - 2 * (cornerLen - marginX + inset)) / (cardW + bleed)
+      )
+    );
+    const rowsClear = Math.max(
+      0,
+      Math.floor(
+        (usableH - bleed - 2 * (cornerLen - marginY + inset)) / (cardH + bleed)
+      )
+    );
+    recordIfValid(colsClear, maxRows, marginX, marginY, usableW, usableH);
+    recordIfValid(maxCols, rowsClear, marginX, marginY, usableW, usableH);
+  }
+
+  if (best === null) {
+    throw new Error(
+      "No valid SCM layout fits without intruding into corner exclusion zones."
+    );
+  }
+  return best;
+};
+
+/** page_manager.compute_card_positions — centre the grid in the usable area. */
+const computeCardPositions = (
+  cols: number,
+  rows: number,
+  cardW: number,
+  cardH: number,
+  bleed: number,
+  marginX: number,
+  marginY: number,
+  usableW: number,
+  usableH: number
+): { xPos: number[]; yPos: number[] } => {
+  const gridWidth = cols * cardW + (cols + 1) * bleed;
+  const gridHeight = rows * cardH + (rows + 1) * bleed;
+
+  const startX = pyRound(marginX + (usableW - gridWidth) / 2 + bleed);
+  const startY = pyRound(marginY + (usableH - gridHeight) / 2 + bleed);
+
+  const xPos = Array.from({ length: cols }, (_, i) => startX + i * (cardW + bleed));
+  const yPos = Array.from({ length: rows }, (_, j) => startY + j * (cardH + bleed));
+
+  return { xPos, yPos };
+};
+
+export interface ScmLayout {
+  /** Oriented page size in mm (NOT yet rotated to landscape output). */
+  pageWidthMM: number;
+  pageHeightMM: number;
+  orientation: ScmOrientation;
+  cols: number;
+  rows: number;
+  /** Card slot size (trim) in mm — always upright 63 x 88. */
+  cardWidthMM: number;
+  cardHeightMM: number;
+  /** Top-left of each card slot, mm, in reading order (row-major). */
+  slotsMM: { x: number; y: number }[];
+  insetMM: number;
+  variant: ScmVariant;
+  registrationLengthMM: number;
+}
+
+/**
+ * Compute the full SCM layout for a standard card on the given paper/variant.
+ * Pixel math is done at SCM_PPI then converted to mm.
+ */
+export const generateScmLayout = (
+  paper: ScmPaperSize,
+  variant: ScmVariant
+): ScmLayout => {
+  const entry = SCM_STANDARD_LAYOUTS[paper][variant];
+  const orientation = entry.orientation;
+  const insetMM =
+    variant === "borderless" ? BORDERLESS_INSET_MM : DEFAULT_INSET_MM;
+
+  const [paperWLandscapeMM, paperHLandscapeMM] = SCM_PAPER_MM[paper];
+
+  // Convert to integer pixels (matches generate_layout).
+  let pageWpx = mmToPixel(paperWLandscapeMM);
+  let pageHpx = mmToPixel(paperHLandscapeMM);
+  const cardWpx = mmToPixel(SCM_CARD_WIDTH_MM);
+  const cardHpx = mmToPixel(SCM_CARD_HEIGHT_MM);
+  const bleedPx = mmToPixel(CARD_DISTANCE_MM);
+  const insetPx = mmToPixel(insetMM);
+  const cornerPx = mmToPixel(CORNER_EXCLUSION_MM);
+
+  [pageWpx, pageHpx] = normalizePageSize(orientation, pageWpx, pageHpx);
+
+  const { cols, rows, marginX, marginY, usableW, usableH } = selectBestMargins(
+    pageWpx,
+    pageHpx,
+    cardWpx,
+    cardHpx,
+    bleedPx,
+    insetPx,
+    cornerPx
+  );
+
+  const { xPos, yPos } = computeCardPositions(
+    cols,
+    rows,
+    cardWpx,
+    cardHpx,
+    bleedPx,
+    marginX,
+    marginY,
+    usableW,
+    usableH
+  );
+
+  const slotsMM: { x: number; y: number }[] = [];
+  for (let r = 0; r < rows; r++) {
+    for (let c = 0; c < cols; c++) {
+      slotsMM.push({ x: pxToMM(xPos[c]), y: pxToMM(yPos[r]) });
+    }
+  }
+
+  const clampedRegLength = Math.max(
+    MIN_REG_LENGTH_MM,
+    Math.min(entry.regLengthMM, MAX_REG_LENGTH_MM)
+  );
+
+  return {
+    pageWidthMM: pxToMM(pageWpx),
+    pageHeightMM: pxToMM(pageHpx),
+    orientation,
+    cols,
+    rows,
+    cardWidthMM: pxToMM(cardWpx),
+    cardHeightMM: pxToMM(cardHpx),
+    slotsMM,
+    insetMM,
+    variant,
+    registrationLengthMM: clampedRegLength,
+  };
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Registration marks (mirrors page_manager.generate_reg_mark)
+//
+// Returned in top-left-origin mm, relative to the (un-rotated) oriented page.
+// matplotlib uses a bottom-left origin upstream; here everything is converted to
+// react-pdf's top-left origin. L-arms are centred on their nominal axis (drawn as
+// Line2D upstream); the square is a filled rectangle anchored at the inset corner.
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface ScmRect {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+export interface ScmRegistrationMarks {
+  /** Filled squares (3-corner pattern has one at the top-left). */
+  squares: ScmRect[];
+  /** L-arm strokes (horizontal + vertical bars). */
+  lines: ScmRect[];
+}
+
+/** Build the registration marks for a layout in top-left-origin mm. */
+export const getRegistrationMarks = (
+  layout: ScmLayout,
+  registration: ScmRegistration
+): ScmRegistrationMarks => {
+  const { pageWidthMM: W, pageHeightMM: H, insetMM: inset } = layout;
+  const t = REG_THICKNESS_MM;
+  const L = layout.registrationLengthMM;
+  const arm = L - t / 2; // upstream draws arm length = length - thickness/2
+
+  const squares: ScmRect[] = [];
+  const lines: ScmRect[] = [];
+
+  // Horizontal arm from an inner corner (cx, cy) going inward by `dir` (+1/-1).
+  const hArm = (cx: number, cy: number, dir: 1 | -1): ScmRect => ({
+    x: dir === 1 ? cx : cx - arm,
+    y: cy - t / 2,
+    w: arm,
+    h: t,
+  });
+  // Vertical arm from an inner corner (cx, cy) going inward by `dir` (+1/-1).
+  const vArm = (cx: number, cy: number, dir: 1 | -1): ScmRect => ({
+    x: cx - t / 2,
+    y: dir === 1 ? cy : cy - arm,
+    w: t,
+    h: arm,
+  });
+
+  const corners = {
+    topLeft: { x: inset, y: inset, hDir: 1 as const, vDir: 1 as const },
+    topRight: { x: W - inset, y: inset, hDir: -1 as const, vDir: 1 as const },
+    bottomLeft: { x: inset, y: H - inset, hDir: 1 as const, vDir: -1 as const },
+    bottomRight: {
+      x: W - inset,
+      y: H - inset,
+      hDir: -1 as const,
+      vDir: -1 as const,
+    },
+  };
+
+  const addL = (c: { x: number; y: number; hDir: 1 | -1; vDir: 1 | -1 }) => {
+    lines.push(hArm(c.x, c.y, c.hDir));
+    lines.push(vArm(c.x, c.y, c.vDir));
+  };
+
+  if (registration === 3) {
+    // Top-left filled square anchored at the inset corner.
+    squares.push({ x: inset, y: inset, w: REG_SQUARE_MM, h: REG_SQUARE_MM });
+    addL(corners.bottomLeft);
+    addL(corners.topRight);
+  } else {
+    addL(corners.topLeft);
+    addL(corners.topRight);
+    addL(corners.bottomLeft);
+    addL(corners.bottomRight);
+  }
+
+  return { squares, lines };
+};

--- a/frontend/src/features/pdf/scm/scmLayout.ts
+++ b/frontend/src/features/pdf/scm/scmLayout.ts
@@ -163,6 +163,20 @@ export const pxToMM = (px: number, ppi: number = SCM_PPI): number =>
   (px * IN_MM) / ppi;
 
 // ─────────────────────────────────────────────────────────────────────────────
+// SCM calibration-offset conversion helpers.
+//
+// SCM's offset_pdf / offset_images express the back-page X/Y calibration offset
+// in PIXELS at the 300-PPI baseline (integer values). Our UI takes the offset in
+// millimetres, so these convert between the two for users porting SCM values.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Convert an SCM offset value (px @ 300 PPI) to millimetres. */
+export const scmOffsetPxToMM = (px: number): number => pxToMM(px);
+
+/** Convert a millimetre offset to the equivalent SCM offset value (px @ 300 PPI). */
+export const scmOffsetMMToPx = (mm: number): number => mmToPixel(mm);
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Layout computation (mirrors page_manager.py)
 // ─────────────────────────────────────────────────────────────────────────────
 

--- a/frontend/src/features/pdf/scm/scmLayout.ts
+++ b/frontend/src/features/pdf/scm/scmLayout.ts
@@ -174,7 +174,11 @@ const normalizePageSize = (
 ): [number, number] => (orientation === "portrait" ? [h, w] : [w, h]);
 
 /** page_manager.compute_grid_fit */
-const computeGridFit = (usable: number, card: number, bleed: number): number => {
+const computeGridFit = (
+  usable: number,
+  card: number,
+  bleed: number
+): number => {
   if (usable <= 0) return 0;
   return Math.max(0, Math.floor((usable + bleed) / (card + bleed)));
 };
@@ -281,8 +285,14 @@ const computeCardPositions = (
   const startX = pyRound(marginX + (usableW - gridWidth) / 2 + bleed);
   const startY = pyRound(marginY + (usableH - gridHeight) / 2 + bleed);
 
-  const xPos = Array.from({ length: cols }, (_, i) => startX + i * (cardW + bleed));
-  const yPos = Array.from({ length: rows }, (_, j) => startY + j * (cardH + bleed));
+  const xPos = Array.from(
+    { length: cols },
+    (_, i) => startX + i * (cardW + bleed)
+  );
+  const yPos = Array.from(
+    { length: rows },
+    (_, j) => startY + j * (cardH + bleed)
+  );
 
   return { xPos, yPos };
 };

--- a/frontend/src/features/pdf/useRenderPDF.ts
+++ b/frontend/src/features/pdf/useRenderPDF.ts
@@ -33,6 +33,14 @@ export const useRenderPDF = ({
   imageQuality,
   imageDPI,
   jpgQuality,
+  scmMode,
+  scmPaperSize,
+  scmVariant,
+  scmRegistration,
+  scmDuplex,
+  scmOffsetXPx,
+  scmOffsetYPx,
+  scmOffsetAngleDeg,
 }: Omit<PDFProps, "fileHandles">) => {
   const { clientSearchService } = useClientSearchContext();
   const {
@@ -70,6 +78,14 @@ export const useRenderPDF = ({
       imageQuality,
       imageDPI,
       jpgQuality,
+      scmMode,
+      scmPaperSize,
+      scmVariant,
+      scmRegistration,
+      scmDuplex,
+      scmOffsetXPx,
+      scmOffsetYPx,
+      scmOffsetAngleDeg,
       fileHandles,
     });
   }, [
@@ -98,6 +114,14 @@ export const useRenderPDF = ({
     imageQuality,
     imageDPI,
     jpgQuality,
+    scmMode,
+    scmPaperSize,
+    scmVariant,
+    scmRegistration,
+    scmDuplex,
+    scmOffsetXPx,
+    scmOffsetYPx,
+    scmOffsetAngleDeg,
   ]);
 
   useEffect(() => (url ? () => URL.revokeObjectURL(url) : undefined), [url]);

--- a/frontend/src/features/pdf/useRenderPDF.ts
+++ b/frontend/src/features/pdf/useRenderPDF.ts
@@ -38,8 +38,8 @@ export const useRenderPDF = ({
   scmVariant,
   scmRegistration,
   scmDuplex,
-  scmOffsetXPx,
-  scmOffsetYPx,
+  scmOffsetXMM,
+  scmOffsetYMM,
   scmOffsetAngleDeg,
 }: Omit<PDFProps, "fileHandles">) => {
   const { clientSearchService } = useClientSearchContext();
@@ -83,8 +83,8 @@ export const useRenderPDF = ({
       scmVariant,
       scmRegistration,
       scmDuplex,
-      scmOffsetXPx,
-      scmOffsetYPx,
+      scmOffsetXMM,
+      scmOffsetYMM,
       scmOffsetAngleDeg,
       fileHandles,
     });
@@ -119,8 +119,8 @@ export const useRenderPDF = ({
     scmVariant,
     scmRegistration,
     scmDuplex,
-    scmOffsetXPx,
-    scmOffsetYPx,
+    scmOffsetXMM,
+    scmOffsetYMM,
     scmOffsetAngleDeg,
   ]);
 


### PR DESCRIPTION
# Description

Adds a **Silhouette (SCM) cutting mode** to the client-side PDF generator. It
produces PDFs with registration marks compatible with the official
[silhouette-card-maker](https://github.com/Alan-Cha/silhouette-card-maker)
Silhouette Studio cutting templates (`.studio3`), so standard 63×88mm cards can
be cut automatically.

- Faithful TS port of SCM's layout math (`size_convert.py` + `page_manager.py`)
  computed at 300 PPI with banker's rounding, then converted to mm for react-pdf.
- All 5 SCM paper sizes (Letter, Tabloid, A4, A3, Arch B), Normal + Borderless
  variants, and 3- and 4-corner registration patterns.
- Duplex (front + mirrored back) and fronts-only, plus back-page X/Y/angle
  calibration offsets in px @ 300 DPI, matching SCM's `offset_pdf`.
- New SCM mode lives behind a toggle; the standard parametric PDF path is
  unchanged.

New files: `scm/scmLayout.ts`, `scm/SCMPDF.tsx`, `scm/scmLayout.test.ts`,
`pdfImage.ts` (shared image helper). Modified: `PDF.tsx`, `PDFGenerator.tsx`,
`useRenderPDF.ts`.

# Checklist

- [x] I have installed `pre-commit` and installed the hooks with `pre-commit install` before creating any commits.
- [x] I have updated any related tests for code I modified or added new tests where appropriate.
- [x] I have manually tested my changes as follows:
  - Connected the local frontend to the public backend and added standard cards.
  - Toggled SCM mode and cycled all 5 paper sizes × Normal/Borderless × 3/4-corner
    registration; verified in the live preview that marks sit at the correct
    inset, the grid clears the corner exclusion zones, the card count matches
    SCM's `layouts.json`, the duplex back page is mirrored, and the offset
    controls nudge the back page.
  - Ran `npx tsc --noEmit`, `npm test` (150 passing), and `npm run lint` (clean).
- [x] I have updated any relevant documentation or created new documentation where appropriate.
  - N/A: no in-repo docs cover the PDF generator; user-facing guidance is the
    in-app help text (mode description, resolved template name, borderless
    Studio-expansion note, offset units).
