### PR TITLE
Lazy-load PDFGenerator to fix phantom PDF download on editor open

### DIFF
--- a/frontend/src/components/ProjectEditor.tsx
+++ b/frontend/src/components/ProjectEditor.tsx
@@ -202,7 +202,7 @@ function ProjectEditor() {
           <Tab.Pane eventKey="editor">
             <ChooseArtPanel setEditorPanel={setEditorPanel} />
           </Tab.Pane>
-          <Tab.Pane eventKey="finished">
+          <Tab.Pane eventKey="finished" mountOnEnter>
             <PrintPanel />
           </Tab.Pane>
         </Tab.Content>

--- a/frontend/src/features/export/FinishedMyProject.tsx
+++ b/frontend/src/features/export/FinishedMyProject.tsx
@@ -1,4 +1,5 @@
 import styled from "@emotion/styled";
+import dynamic from "next/dynamic";
 import React, { useState } from "react";
 import Alert from "react-bootstrap/Alert";
 import Button from "react-bootstrap/Button";
@@ -28,7 +29,12 @@ import { showModal } from "@/store/slices/modalsSlice";
 import { selectIsProjectEmpty } from "@/store/slices/projectSlice";
 
 import { MobileStatus } from "../mobile/MobileStatus";
-import { PDFGenerator } from "../pdf/PDFGenerator";
+
+const PDFGenerator = dynamic(
+  () => import("../pdf/PDFGenerator").then((mod) => mod.PDFGenerator),
+  { ssr: false }
+);
+
 interface ExitModal {
   show: boolean;
   handleClose: {
@@ -317,7 +323,7 @@ export function FinishedMyProject() {
           <Tab.Pane eventKey="mpc">
             <MakePlayingCardsInstructions />
           </Tab.Pane>
-          <Tab.Pane eventKey="pdf">
+          <Tab.Pane eventKey="pdf" mountOnEnter>
             <PDFGenerator
               heightDelta={
                 NavPillButtonHeight + NavUnderlineButtonHeight + NavbarHeight

--- a/frontend/src/features/export/FinishedMyProject.tsx
+++ b/frontend/src/features/export/FinishedMyProject.tsx
@@ -1,5 +1,4 @@
 import styled from "@emotion/styled";
-import dynamic from "next/dynamic";
 import React, { useState } from "react";
 import Alert from "react-bootstrap/Alert";
 import Button from "react-bootstrap/Button";
@@ -29,11 +28,7 @@ import { showModal } from "@/store/slices/modalsSlice";
 import { selectIsProjectEmpty } from "@/store/slices/projectSlice";
 
 import { MobileStatus } from "../mobile/MobileStatus";
-
-const PDFGenerator = dynamic(
-  () => import("../pdf/PDFGenerator").then((mod) => mod.PDFGenerator),
-  { ssr: false }
-);
+import { PDFGenerator } from "../pdf/PDFGenerator";
 
 interface ExitModal {
   show: boolean;

--- a/frontend/src/features/pdf/PDFGeneratorModal.tsx
+++ b/frontend/src/features/pdf/PDFGeneratorModal.tsx
@@ -1,9 +1,14 @@
+import dynamic from "next/dynamic";
 import React from "react";
 import Button from "react-bootstrap/Button";
 import Modal from "react-bootstrap/Modal";
 
 import { ModalFooterHeight, ModalHeaderHeight } from "@/common/constants";
-import { PDFGenerator } from "@/features/pdf/PDFGenerator";
+
+const PDFGenerator = dynamic(
+  () => import("@/features/pdf/PDFGenerator").then((mod) => mod.PDFGenerator),
+  { ssr: false }
+);
 
 interface PDFGeneratorProps {
   show: boolean;
@@ -20,7 +25,9 @@ export function PDFGeneratorModal({ show, handleClose }: PDFGeneratorProps) {
         <Modal.Title>Download PDF</Modal.Title>
       </Modal.Header>
       <Modal.Body className="p-0 mx-0" style={{ overflow: "hidden" }}>
-        <PDFGenerator heightDelta={ModalHeaderHeight + ModalFooterHeight} />
+        {show && (
+          <PDFGenerator heightDelta={ModalHeaderHeight + ModalFooterHeight} />
+        )}
       </Modal.Body>
       <Modal.Footer>
         <Button variant="secondary" onClick={handleClose}>


### PR DESCRIPTION
The PDF editor was triggering a phantom PDF download the moment you opened the page, before ever touching the PDF tab in Firefox.

Turned out @react-pdf/renderer loads a Yoga WASM binary as soon as its module is imported, not when it's actually rendered — and PDFGeneratorModal statically imported PDFGenerator, so it evaluated immediately on editor page load regardless of whether the modal was open. 

The {show && <PDFGenerator/>} check in the modal only skipped rendering, not the import. FinishedMyProject (a separate route) mounts all its Tab.Panes into the DOM by default too (react-bootstrap needs mountOnEnter to opt out), so its PDF tab was mounting unconditionally whenever that page loaded.

Fix: switch PDFGeneratorModal's import to next/dynamic({ ssr: false }) so the module isn't evaluated until first render, and add mountOnEnter to the two Tab.Panes that were mounting it unconditionally (in ProjectEditor and FinishedMyProject). Confirmed the Yoga/WASM chunk no longer shows up in the editor's initial script list.


