### PR TITLE
Replace native PDF embed with a pdf.js canvas preview

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -177,6 +177,7 @@ MPCAutofill/scryfall_cache/*
 *.woff
 *.woff2
 frontend/public/mockServiceWorker.js
+frontend/public/pdf.worker.min.mjs
 /image-cdn/node_modules/*
 /image-cdn/.wrangler/*
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -30,6 +30,7 @@
         "lil-csv": "^1.4.5",
         "next": "^14.2.26",
         "nextjs-google-analytics": "^2.3.3",
+        "pdfjs-dist": "^4.10.38",
         "ping.js": "^0.3.0",
         "react": "^18.3.1",
         "react-bootstrap": "^2.7.2",
@@ -2459,6 +2460,256 @@
         "node": ">=18"
       }
     },
+    "node_modules/@napi-rs/canvas": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.100.tgz",
+      "integrity": "sha512-xglYA6q3XO5P3BNJYxVZ1IV7DLVjp1Py6nwag88YntrS+3vKHyYcMqXVS4ZztJmwz2uGvz1FWhI/4LgbR5uQDA==",
+      "license": "MIT",
+      "optional": true,
+      "workspaces": [
+        "e2e/*"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas-android-arm64": "0.1.100",
+        "@napi-rs/canvas-darwin-arm64": "0.1.100",
+        "@napi-rs/canvas-darwin-x64": "0.1.100",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.100",
+        "@napi-rs/canvas-linux-arm64-gnu": "0.1.100",
+        "@napi-rs/canvas-linux-arm64-musl": "0.1.100",
+        "@napi-rs/canvas-linux-riscv64-gnu": "0.1.100",
+        "@napi-rs/canvas-linux-x64-gnu": "0.1.100",
+        "@napi-rs/canvas-linux-x64-musl": "0.1.100",
+        "@napi-rs/canvas-win32-arm64-msvc": "0.1.100",
+        "@napi-rs/canvas-win32-x64-msvc": "0.1.100"
+      }
+    },
+    "node_modules/@napi-rs/canvas-android-arm64": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.100.tgz",
+      "integrity": "sha512-hjhCKhntPv9+t4ckHymdx0phYNcVW+GKQR6Lzw2zE+pOVjOplSmtx9nNNknTjbEDLcuLZqA1y8ufKg1XfgftzQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-arm64": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.100.tgz",
+      "integrity": "sha512-2PcswRaC7Ly645DGt88///zuFDhJxJYdKAs1uU3mfk1atYkXufgcgLfBpk6Tm12nCQBaNt1wpybuPZ4qOhTo8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-x64": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.100.tgz",
+      "integrity": "sha512-ePNZtj7pNIva/siZMg+HmbeozkIjqUIYdoymH8HaA3qK7LfzFN4WMBM8G6HQ9ZC+H3+Dnn5pqtiXpgLykaPOhw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.100.tgz",
+      "integrity": "sha512-d5cDB48oWFGU8/XPhUOFAlySgb/VAu7D+s8fi55K1Pcfg8aPplHWqMgibhVLU8ky7Pyg/fuiVLz4Nf3JrSTuUA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.100.tgz",
+      "integrity": "sha512-rDxgxRu69RvDlX/bh9o22DxLsGr8EqsNgotL9+RwQE1S0b0cqeatqsw6aW45mukm0B42DIAaAacKaYQ8cqS1nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-musl": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.100.tgz",
+      "integrity": "sha512-K3mDW66N+xT2/V439u1alFANiBUjdEx2gLiNYnCmUsva5jZMxWTjafBYwTzYK+EMFMHrUoabuU+T1BIP5CgbYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.100.tgz",
+      "integrity": "sha512-mooqUBTIsccZpnoQC4NgrC1v6C1vof39etLNMnBwCY+p0gajWJvAHLGQ6g/gGyS5YrpDW+GefSN4+Cvcr08UWw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-gnu": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.100.tgz",
+      "integrity": "sha512-1eCvkDCazm7FFhsT7DfGOdSaHgZVK3bt/dSBl5EWHOWmnz+I7j8tPseJqqD81NF+MH21jKUK4wQSDjN0mdhnTg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-musl": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.100.tgz",
+      "integrity": "sha512-20arT6lnI19S68qNlii73TSEDbECNgzMz2EpldC1V3mZFuRkeujXkcebRk0LRJe9SEUAooYiLokfMViY8IX7yA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-arm64-msvc": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-0.1.100.tgz",
+      "integrity": "sha512-DZFFT1wIAg37LJw37yhMRFfjATd3vTQzjZ1Yki8u2vhO6Hi5VE6BVaGQ1aaDu7xb4iMErz+9EOwjpS7xcxFeBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-x64-msvc": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.100.tgz",
+      "integrity": "sha512-MyT1j3mHC2+Lu4pBi9mKyMJhtP6U7k7EldY7sj/uS5gJA65gTXt8MefJQXLJo5d/vZbuWmfxzkEUNc/urV3pHA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
@@ -2836,6 +3087,7 @@
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.1.tgz",
       "integrity": "sha512-dfUnCxiN9H4ap84DvD2ubjw+3vUNpstxa0TneY/Paat8a3R4uQZDLSvWjmznAY/DoahqTHl9V46HF/Zs3F29pg==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -2875,6 +3127,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2895,6 +3148,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2915,6 +3169,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2935,6 +3190,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2955,6 +3211,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2975,6 +3232,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2995,6 +3253,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3015,6 +3274,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3035,6 +3295,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3055,6 +3316,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3075,6 +3337,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3095,6 +3358,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3115,6 +3379,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6475,7 +6740,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -7388,6 +7653,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
       "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "bin": {
@@ -8966,7 +9232,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -10053,7 +10319,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -10119,7 +10385,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -10165,7 +10431,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -12622,7 +12888,7 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
@@ -12636,7 +12902,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
       "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -13069,6 +13335,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -13553,6 +13820,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/pdfjs-dist": {
+      "version": "4.10.38",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-4.10.38.tgz",
+      "integrity": "sha512-/Y3fcFrXEAsMjJXeL9J8+ZG9U01LbuWaYypvDW2ycW1jL269L3js3DVBjDJ0Up9Np1uqDXsDrRihHANhZOlwdQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas": "^0.1.65"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -13781,6 +14060,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -15976,7 +16256,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,6 +5,7 @@
   "license": "GPL-3.0-only",
   "private": true,
   "scripts": {
+    "postinstall": "node scripts/copy-pdf-worker.js",
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
@@ -37,6 +38,7 @@
     "lil-csv": "^1.4.5",
     "next": "^14.2.26",
     "nextjs-google-analytics": "^2.3.3",
+    "pdfjs-dist": "^4.10.38",
     "ping.js": "^0.3.0",
     "react": "^18.3.1",
     "react-bootstrap": "^2.7.2",

--- a/frontend/scripts/copy-pdf-worker.js
+++ b/frontend/scripts/copy-pdf-worker.js
@@ -1,0 +1,23 @@
+// pdfjs-dist ships an ESM worker script that Next's webpack config can't
+// resolve via `new URL(..., import.meta.url)` (see the "ESM packages need to
+// be imported" build error). Copying it into public/ and loading it as a
+// plain static asset sidesteps that entirely. Runs on every install so it
+// always matches whatever pdfjs-dist version is actually installed - the
+// copy itself is gitignored, not committed.
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const source = path.join(
+  dirname,
+  "..",
+  "node_modules",
+  "pdfjs-dist",
+  "build",
+  "pdf.worker.min.mjs"
+);
+const destination = path.join(dirname, "..", "public", "pdf.worker.min.mjs");
+
+fs.copyFileSync(source, destination);

--- a/frontend/src/features/pdf/PDFCanvasPreview.tsx
+++ b/frontend/src/features/pdf/PDFCanvasPreview.tsx
@@ -1,0 +1,102 @@
+import { useEffect, useRef } from "react";
+
+// pdf.js renders straight into <canvas> elements we own, with zero native
+// browser chrome (no toolbar, no thumbnail sidebar, no page-fit letterboxing)
+// and - unlike the native <object>/<iframe> embed this replaces - works
+// identically in every browser, including Firefox.
+const PAGE_GAP_PX = 12;
+const RESIZE_DEBOUNCE_MS = 200;
+
+export const PDFCanvasPreview = ({ url }: { url: string | undefined }) => {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!url) {
+      return;
+    }
+
+    let cancelled = false;
+    let renderToken = 0;
+    let pdfDocument: import("pdfjs-dist").PDFDocumentProxy | undefined;
+    let resizeTimeout: ReturnType<typeof setTimeout> | undefined;
+
+    const renderPages = async () => {
+      if (pdfDocument == null || containerRef.current == null) {
+        return;
+      }
+      const thisRenderToken = ++renderToken;
+      const container = containerRef.current;
+      container.replaceChildren();
+      const containerWidth = container.clientWidth;
+
+      for (
+        let pageNumber = 1;
+        pageNumber <= pdfDocument.numPages;
+        pageNumber++
+      ) {
+        if (cancelled || thisRenderToken !== renderToken) {
+          return;
+        }
+        const page = await pdfDocument.getPage(pageNumber);
+        const unscaledViewport = page.getViewport({ scale: 1 });
+        const scale = containerWidth / unscaledViewport.width;
+        const viewport = page.getViewport({ scale });
+
+        const canvas = document.createElement("canvas");
+        canvas.style.display = "block";
+        canvas.style.width = "100%";
+        canvas.style.marginBottom = PAGE_GAP_PX + "px";
+        const devicePixelRatio = window.devicePixelRatio || 1;
+        canvas.width = viewport.width * devicePixelRatio;
+        canvas.height = viewport.height * devicePixelRatio;
+        const context = canvas.getContext("2d");
+        if (context == null || cancelled || thisRenderToken !== renderToken) {
+          return;
+        }
+        context.scale(devicePixelRatio, devicePixelRatio);
+        container.appendChild(canvas);
+
+        await page.render({ canvasContext: context, viewport }).promise;
+      }
+    };
+
+    const load = async () => {
+      const pdfjsLib = await import("pdfjs-dist");
+      // Served from public/ (see scripts/copy-pdf-worker.js) rather than resolved
+      // as an ESM module import - Next's webpack config can't bundle pdfjs-dist's
+      // worker via `new URL(..., import.meta.url)`.
+      pdfjsLib.GlobalWorkerOptions.workerSrc = "/pdf.worker.min.mjs";
+
+      const loadingTask = pdfjsLib.getDocument(url);
+      pdfDocument = await loadingTask.promise;
+      if (cancelled) {
+        return;
+      }
+      await renderPages();
+    };
+
+    load();
+
+    const resizeObserver = new ResizeObserver(() => {
+      clearTimeout(resizeTimeout);
+      resizeTimeout = setTimeout(renderPages, RESIZE_DEBOUNCE_MS);
+    });
+    if (containerRef.current != null) {
+      resizeObserver.observe(containerRef.current);
+    }
+
+    return () => {
+      cancelled = true;
+      clearTimeout(resizeTimeout);
+      resizeObserver.disconnect();
+      pdfDocument?.destroy();
+    };
+  }, [url]);
+
+  return (
+    <div
+      ref={containerRef}
+      style={{ width: "100%", height: "100%", overflowY: "auto" }}
+    />
+  );
+};

--- a/frontend/src/features/pdf/PDFGenerator.tsx
+++ b/frontend/src/features/pdf/PDFGenerator.tsx
@@ -25,6 +25,7 @@ import {
   PageSize,
   PDFProps,
 } from "@/features/pdf/PDF";
+import { PDFCanvasPreview } from "@/features/pdf/PDFCanvasPreview";
 import { pdfRenderService } from "@/features/pdf/pdfRenderService";
 import {
   BORDERLESS_STUDIO_EXPANSION_MM,
@@ -45,10 +46,6 @@ import { AppDispatch } from "@/store/store";
 
 import { useClientSearchContext } from "../clientSearch/clientSearchContext";
 import { useRenderPDF } from "./useRenderPDF";
-
-const PDFPreview = (props: PDFProps & { url: string | undefined }) => {
-  return <iframe width="100%" height="100%" src={props.url} {...props} />;
-};
 
 const downloadPDF = async (
   props: Omit<PDFProps, "fileHandles">,
@@ -1076,7 +1073,7 @@ export const PDFGenerator = ({ heightDelta = 0 }: { heightDelta?: number }) => {
             disabled={showSpinner}
             style={{ height: 100 + "%", overflowY: "hidden" }}
           >
-            <PDFPreview url={url} {...debouncedPDFProps} fileHandles={{}} />
+            <PDFCanvasPreview url={url} />
           </Blurrable>
         </Col>
       </Row>

--- a/frontend/src/features/pdf/pdf.worker.ts
+++ b/frontend/src/features/pdf/pdf.worker.ts
@@ -12,9 +12,9 @@ export const renderPDF = async (props: PDFProps) => {
   return pdf(createElement(PDF, props)).toBlob();
 };
 
-const renderPDFInWorker = async (props: PDFProps) => {
+const renderPDFInWorker = async (props: PDFProps): Promise<Blob> => {
   try {
-    return URL.createObjectURL(await renderPDF(props));
+    return await renderPDF(props);
   } catch (error) {
     log(error);
     throw error;

--- a/frontend/src/features/pdf/pdfRenderService.ts
+++ b/frontend/src/features/pdf/pdfRenderService.ts
@@ -25,7 +25,7 @@ export class PDFRenderService {
   }
 
   // TODO: awful naming. fix.
-  public renderPDFInWorker(props: PDFProps): Promise<string> {
+  public renderPDFInWorker(props: PDFProps): Promise<Blob> {
     if (this.worker === undefined) {
       throw new Error("PDFRenderService was not initialised!");
     }

--- a/frontend/src/features/pdf/useRenderPDF.ts
+++ b/frontend/src/features/pdf/useRenderPDF.ts
@@ -51,7 +51,7 @@ export const useRenderPDF = ({
     const fileHandles = await clientSearchService.getFileHandlesByIdentifier(
       cardDocumentsByIdentifier
     );
-    return pdfRenderService.renderPDFInWorker({
+    const blob = await pdfRenderService.renderPDFInWorker({
       cardSelectionMode,
       pageSize,
       pageWidth,
@@ -88,6 +88,7 @@ export const useRenderPDF = ({
       scmOffsetAngleDeg,
       fileHandles,
     });
+    return URL.createObjectURL(blob);
   }, [
     cardSelectionMode,
     pageSize,


### PR DESCRIPTION
# Description

The <object>/<iframe> embed for the live PDF preview had two separate problems:

1. Firefox downloads PDF blobs embedded in an <iframe> instead of rendering them inline (a long-standing Firefox limitation, reproduced independently of this app - it also happens on direct top-level navigation to a PDF, and affects @react-pdf/renderer's own official PDFViewer component, which uses the same iframe+blob technique). Switching to <object> avoids the unwanted download in both Chrome and Firefox, but Firefox still won't render a PDF inside <object> either - there's no way to get an inline preview out of Firefox's native viewer at all via embedding.

2. Whichever native browser plugin renders the embed brings its own toolbar, thumbnail sidebar, and page-fit letterboxing that we don't control and don't want taking up space in what's meant to be a compact live preview panel.

Render pages directly into our own <canvas> via pdfjs-dist instead, sized to exactly fill the container with zero browser chrome. Since pdf.js runs identically in every browser rather than depending on a native PDF plugin, this also gives Firefox a real live preview for the first time, not just a fallback message.

pdfjs-dist's worker script needs `new URL(..., import.meta.url)` to resolve normally, which Next's webpack config can't do for this package ("ESM packages need to be imported"). Copy it into public/ as a plain static asset instead (scripts/copy-pdf-worker.js, wired up as a postinstall hook so it always matches the installed pdfjs-dist version; the copy itself is gitignored, not committed).

Also moves URL.createObjectURL() out of the render Worker and onto the main thread (renderPDFInWorker now returns the Blob itself) to avoid a cross-context Blob URL footgun.

Verified against a real deployed backend in both headed Chromium and Firefox: preview fills the available space with zero native chrome in both, no auto-download regression, Generate PDF still produces a correct PDF with embedded images.



# Checklist

- [ ] I have installed `pre-commit` and installed the hooks with `pre-commit install` before creating any commits.
- [ ] I have updated any related tests for code I modified or added new tests where appropriate.
- [ ] I have manually tested my changes as follows:
  - <!-- Insert your manual testing steps here. -->
- [ ] I have updated any relevant documentation or created new documentation where appropriate.
