### PR TITLE
Route PDF thumbnail-quality images through the worker, not the bucket

### DIFF
--- a/frontend/src/features/pdf/pdfImage.test.ts
+++ b/frontend/src/features/pdf/pdfImage.test.ts
@@ -1,0 +1,32 @@
+import { cardDocument1 } from "@/common/test-constants";
+import { getPDFImageURL } from "@/features/pdf/pdfImage";
+
+// getImageWorkerURL/getImageBucketURL read these directly from process.env,
+// which is how the real app configures them (baked in at build time).
+const OLD_ENV = process.env;
+beforeEach(() => {
+  process.env = {
+    ...OLD_ENV,
+    NEXT_PUBLIC_IMAGE_WORKER_URL: "https://cdn.example.com",
+    NEXT_PUBLIC_IMAGE_BUCKET_URL: "https://bucket.example.com",
+  };
+});
+afterEach(() => {
+  process.env = OLD_ENV;
+});
+
+test.each(["small-thumbnail", "large-thumbnail", "full-resolution"] as const)(
+  "routes %s through the image worker rather than the bucket",
+  async (imageQuality) => {
+    const url = await getPDFImageURL(
+      cardDocument1,
+      imageQuality,
+      undefined,
+      100,
+      {}
+    );
+
+    expect(url).toEqual(expect.stringContaining("cdn.example.com"));
+    expect(url).not.toEqual(expect.stringContaining("bucket.example.com"));
+  }
+);

--- a/frontend/src/features/pdf/pdfImage.ts
+++ b/frontend/src/features/pdf/pdfImage.ts
@@ -1,4 +1,4 @@
-import { getBucketImageURL, getWorkerImageURL } from "@/common/image";
+import { getWorkerImageURL } from "@/common/image";
 import { SourceType } from "@/common/schema_types";
 import { CardDocument } from "@/common/types";
 
@@ -9,7 +9,7 @@ export type PDFImageQuality =
 
 /**
  * Resolve the image source for a card in a PDF, honouring the requested quality
- * tier and the card's source (Google Drive bucket/worker, or a local file).
+ * tier and the card's source (Google Drive image worker, or a local file).
  * Shared by the standard PDF render path and the SCM render path.
  */
 export const getPDFImageURL = async (
@@ -23,9 +23,19 @@ export const getPDFImageURL = async (
     case SourceType.GoogleDrive:
       switch (imageQuality) {
         case "small-thumbnail":
-          return getBucketImageURL(cardDocument, "small");
+          return getWorkerImageURL(
+            cardDocument,
+            "small",
+            undefined,
+            jpgQuality
+          );
         case "large-thumbnail":
-          return getBucketImageURL(cardDocument, "large");
+          return getWorkerImageURL(
+            cardDocument,
+            "large",
+            undefined,
+            jpgQuality
+          );
         case "full-resolution":
           return getWorkerImageURL(cardDocument, "full", dpi, jpgQuality);
         default:


### PR DESCRIPTION
# Description

getPDFImageURL used getBucketImageURL for small/large (preview) quality and getWorkerImageURL only for full-resolution (the actual downloaded PDF). The bucket is a precomputed R2 cache populated by real site traffic (Card.tsx's normal browsing thumbnail fetches populate it as a side effect) - so it works fine for any card that's ever been browsed normally, but 404s for a card that's only ever been touched via PDF generation (e.g. a freshly-added card previewed immediately, or a deployment/environment where the bucket hasn't been warmed at all). In that case the PDF's live preview and low-quality thumbnail tiers silently render nothing - @react-pdf/renderer just omits the image rather than erroring - leaving only cut lines with no obvious cause.

Route small/large through the worker as well, which proxies live from Google Drive and works unconditionally rather than depending on the bucket already being warm.

Worth noting the tradeoff explicitly: this trades a cheap R2 read for a live Google Drive proxy request on every PDF preview render (which already debounces on prop changes, so it's not on every keystroke, but it is on every settings change). On a bucket that's reliably warm from organic traffic this is a straight regression in request volume for a bug that rarely manifests - I'm not confident this is the right tradeoff at this project's scale, so treat this one as a discussion starter rather than an obviously-correct fix. Happy to close this if the bucket is reliably warm enough in practice that this isn't worth the extra worker load.

Add a regression test for getPDFImageURL covering all three quality tiers, since there wasn't one before; confirmed it fails against the pre-fix code (small/large resolve to the bucket URL) and passes after.



# Checklist

- [ ] I have installed `pre-commit` and installed the hooks with `pre-commit install` before creating any commits.
- [ ] I have updated any related tests for code I modified or added new tests where appropriate.
- [ ] I have manually tested my changes as follows:
  - <!-- Insert your manual testing steps here. -->
- [ ] I have updated any relevant documentation or created new documentation where appropriate.
