### PR TITLE
Fix toSearchable to not strip mid-string "the" (completes #460)

### DIFF
--- a/frontend/src/common/processing.test.ts
+++ b/frontend/src/common/processing.test.ts
@@ -501,7 +501,10 @@ describe("toSearchable", () => {
   test.each([
     { input: "Lightning Bolt", expectedOutput: "lightning bolt" },
     { input: " Lightning   BOLT ", expectedOutput: "lightning bolt" },
-    { input: "Adanto, the First Fort", expectedOutput: "adanto first fort" },
+    {
+      input: "Adanto, the First Fort",
+      expectedOutput: "adanto the first fort",
+    },
     { input: "Black Lotus (Masterpiece)", expectedOutput: "black lotus" }, // brackets removal
     {
       input: "Black Lotus (Masterpiece, But With Punctuation! )",

--- a/frontend/src/common/processing.ts
+++ b/frontend/src/common/processing.ts
@@ -389,11 +389,9 @@ export const toSearchable = (inputString: string): string =>
       .toLowerCase()
       .replaceAll(/[\(\[].*?[\)\]]/g, "")
       .replace("-", " ")
-      .replace(" the ", " ")
       .replace("’", "'")
       .replaceAll(/[!"#\$%&'\(\)\*\+,-\.\/:;<=>\?@\[\]\^_`{\|}~\/]/g, "") // remove punctuation
       .replaceAll(/[0123456789]/g, "") // remove digits
-      .replaceAll(/^the (.*$)/g, "$1") // remove "the " at start of string
       // remove accents - match elasticsearch `asciifolding` filter. https://stackoverflow.com/a/37511463/13021511
       .normalize("NFD")
       .replace(/\p{Diacritic}/gu, "")


### PR DESCRIPTION
# Description

## Problem

PR #460 fixed `to_searchable()` in the backend (`search/sanitisation.py`) so it stops stripping the word "the" out of the middle of card names (issue #435) — e.g. "Adanto, the First Fort" was being searched as "adanto first fort" instead of the correct "adanto the first fort".

The frontend has its own hand-maintained copy of the same sanitisation logic in `frontend/src/common/processing.ts` (used by the Local Folder / offline search backend), and it never got the same fix. It still has the identical bug:

    .replace(" the ", " ")
    ...
    .replaceAll(/^the (.*$)/g, "$1") // remove "the " at start of string

The first strips a mid-string "the", the second strips a leading one — so any card name containing "the" is still mangled client-side even though the backend now handles it correctly.

## Fix

Remove the same two lines #460 removed from the backend's `to_searchable()`, so the frontend's copy stays in sync.

## Tests

`processing.test.ts` had a `toSearchable` test case asserting the old, buggy output as correct:

    { input: "Adanto, the First Fort", expectedOutput: "adanto first fort" },

Updated it to expect the correct output ("adanto the first fort"). Ran the full suite locally against this branch: `npx jest src/common/processing.test.ts` — 49/49 passing, `npx prettier@2.7.1 --check` on both changed files — clean, `tsc --noEmit` — clean.

result: Confirmed the bug live on unmodified upstream code (ran the original test against upstream/master's actual 3c717d2a, saw it assert the buggy "adanto first fort" output), ran pre-commit against the two changed files (all hooks pass, zero modifications), and updated the PR checklist to reflect that honestly — full PR title/description ready to paste at the compare URL.

# Checklist

- [x] I have installed `pre-commit` and installed the hooks with `pre-commit install` before creating any commits.
- [x] I have updated any related tests for code I modified or added new tests where appropriate.
- [x] I have manually tested my changes as follows:
  - `npx jest src/common/processing.test.ts` (49/49 passing), `npx prettier@2.7.1 --check` on both changed files, `tsc --noEmit`, and `pre-commit run` on both changed files — all clean.
- [x] I have updated any relevant documentation or created new documentation where appropriate. (no docs are affected by this fix)