### PR TITLE
Add typeable artist filtering to the Explore page

### DIFF
--- a/MPCAutofill/cardpicker/documents.py
+++ b/MPCAutofill/cardpicker/documents.py
@@ -26,6 +26,7 @@ class CardSearch(Document):
     tags = fields.KeywordField()  # all elasticsearch fields support arrays by default
     expansion_code = fields.KeywordField(attr="get_expansion_code")
     collector_number = fields.KeywordField(attr="get_collector_number")
+    artist = fields.KeywordField(attr="get_canonical_artist_name")
 
     class Index:
         # name of the elasticsearch index
@@ -39,4 +40,8 @@ class CardSearch(Document):
 
     def get_queryset(self) -> QuerySet[Card]:
         # https://django-elasticsearch-dsl.readthedocs.io/en/latest/fields.html#handle-relationship-with-nestedfield-objectfield
-        return super().get_queryset().select_related("canonical_card", "canonical_card__expansion")
+        return (
+            super()
+            .get_queryset()
+            .select_related("canonical_card", "canonical_card__expansion", "canonical_card__artist", "canonical_artist")
+        )

--- a/MPCAutofill/cardpicker/models.py
+++ b/MPCAutofill/cardpicker/models.py
@@ -353,6 +353,12 @@ class Card(models.Model):
     def get_collector_number(self) -> str | None:
         return self.canonical_card.collector_number if self.canonical_card else None
 
+    def get_canonical_artist_name(self) -> str | None:
+        # mirrors the canonicalArtist resolution in `serialise`
+        if self.canonical_artist:
+            return self.canonical_artist.name
+        return self.canonical_card.artist.name if self.canonical_card else None
+
     class Meta:
         ordering = ["-priority"]
 

--- a/MPCAutofill/cardpicker/schema_types.py
+++ b/MPCAutofill/cardpicker/schema_types.py
@@ -76,6 +76,21 @@ class Game(str, Enum):
     MTG = "MTG"
 
 
+class ArtistsResponse(BaseModel):
+    artists: List[str]
+
+    @staticmethod
+    def from_dict(obj: Any) -> "ArtistsResponse":
+        assert isinstance(obj, dict)
+        artists = from_list(from_str, obj.get("artists"))
+        return ArtistsResponse(artists)
+
+    def to_dict(self) -> dict:
+        result: dict = {}
+        result["artists"] = from_list(from_str, self.artists)
+        return result
+
+
 class FilterSettings(BaseModel):
     excludesTags: List[str]
     """The tags which the cards must *not* have to be included in search results"""
@@ -601,6 +616,7 @@ class ExploreSearchRequest(BaseModel):
     pageStart: int
     searchSettings: SearchSettings
     sortBy: SortBy
+    artists: Optional[List[str]] = None
     query: Optional[str] = None
 
     @staticmethod
@@ -611,8 +627,9 @@ class ExploreSearchRequest(BaseModel):
         pageStart = from_int(obj.get("pageStart"))
         searchSettings = SearchSettings.from_dict(obj.get("searchSettings"))
         sortBy = SortBy(obj.get("sortBy"))
+        artists = from_union([lambda x: from_list(from_str, x), from_none], obj.get("artists"))
         query = from_union([from_none, from_str], obj.get("query"))
-        return ExploreSearchRequest(cardTypes, pageSize, pageStart, searchSettings, sortBy, query)
+        return ExploreSearchRequest(cardTypes, pageSize, pageStart, searchSettings, sortBy, artists, query)
 
     def to_dict(self) -> dict:
         result: dict = {}
@@ -621,6 +638,8 @@ class ExploreSearchRequest(BaseModel):
         result["pageStart"] = from_int(self.pageStart)
         result["searchSettings"] = to_class(SearchSettings, self.searchSettings)
         result["sortBy"] = to_enum(SortBy, self.sortBy)
+        if self.artists is not None:
+            result["artists"] = from_union([lambda x: from_list(from_str, x), from_none], self.artists)
         result["query"] = from_union([from_none, from_str], self.query)
         return result
 
@@ -1318,6 +1337,14 @@ def Tagfromdict(s: Any) -> Tag:
 
 def Tagtodict(x: Tag) -> Any:
     return to_class(Tag, x)
+
+
+def ArtistsResponsefromdict(s: Any) -> ArtistsResponse:
+    return ArtistsResponse.from_dict(s)
+
+
+def ArtistsResponsetodict(x: ArtistsResponse) -> Any:
+    return to_class(ArtistsResponse, x)
 
 
 def CardbacksRequestfromdict(s: Any) -> CardbacksRequest:

--- a/MPCAutofill/cardpicker/search/search_functions.py
+++ b/MPCAutofill/cardpicker/search/search_functions.py
@@ -94,6 +94,7 @@ def get_search(
     card_types: list[CardType],
     expansion_code: str | None = None,
     collector_number: str | None = None,
+    artists: list[str] | None = None,
 ) -> CardSearch:
     """
     This is the core search function for MPC Autofill - queries Elasticsearch for `self` given `search_settings`
@@ -140,6 +141,8 @@ def get_search(
         s = s.filter("term", expansion_code=expansion_code.upper())
     if collector_number:
         s = s.filter("term", collector_number=collector_number)
+    if artists:
+        s = s.filter(Bool(should=Terms(artist=artists), minimum_should_match=1))
     if search_settings.filterSettings.languages:
         s = s.filter(
             Bool(

--- a/MPCAutofill/cardpicker/tests/__snapshots__/test_views.ambr
+++ b/MPCAutofill/cardpicker/tests/__snapshots__/test_views.ambr
@@ -193,7 +193,7 @@
     'CARD': dict({
       'Brainstorm': dict({
         'canonicalArtist': dict({
-          'name': 'Artist 102',
+          'name': 'Artist 0',
         }),
         'canonicalCard': dict({
           'artist': None,
@@ -416,7 +416,7 @@
           'cards': list([
             dict({
               'canonicalArtist': dict({
-                'name': 'Artist 107',
+                'name': 'Artist 0',
               }),
               'canonicalCard': dict({
                 'artist': None,
@@ -702,7 +702,7 @@
       'cards': list([
         dict({
           'canonicalArtist': dict({
-            'name': 'Artist 109',
+            'name': 'Artist 0',
           }),
           'canonicalCard': dict({
             'artist': None,
@@ -2399,7 +2399,7 @@
       'cards': list([
         dict({
           'canonicalArtist': dict({
-            'name': 'Artist 67',
+            'name': 'Artist 0',
           }),
           'canonicalCard': dict({
             'artist': None,
@@ -2673,7 +2673,7 @@
       'cards': list([
         dict({
           'canonicalArtist': dict({
-            'name': 'Artist 66',
+            'name': 'Artist 0',
           }),
           'canonicalCard': dict({
             'artist': None,
@@ -3025,7 +3025,7 @@
       'cards': list([
         dict({
           'canonicalArtist': dict({
-            'name': 'Artist 68',
+            'name': 'Artist 0',
           }),
           'canonicalCard': dict({
             'artist': None,

--- a/MPCAutofill/cardpicker/tests/conftest.py
+++ b/MPCAutofill/cardpicker/tests/conftest.py
@@ -1,7 +1,9 @@
 import datetime as dt
+import inspect
 import uuid
 from typing import Type
 
+import factory as factory_boy
 import pytest
 from pytest_elasticsearch import factories
 from testcontainers.elasticsearch import ElasticSearchContainer
@@ -12,6 +14,7 @@ from django.core.management import call_command
 
 from cardpicker.integrations.game.base import GameIntegration
 from cardpicker.models import Card, CardTypes, DFCPair, Source, Tag
+from cardpicker.tests import factories as factories_module
 from cardpicker.tests.constants import Cards, DummyIntegration, Sources
 from cardpicker.tests.factories import (
     CanonicalCardFactory,
@@ -24,6 +27,18 @@ from cardpicker.tests.factories import (
 
 POSTGRES_PORT = 47000
 ELASTICSEARCH_PORT = 9300  # this is the default expected by `elasticsearch_nooproc`
+
+
+@pytest.fixture(autouse=True)
+def reset_factory_sequences() -> None:
+    """
+    Snapshots embed sequence-generated values (e.g. "Artist 0"), so sequences must restart for every test -
+    otherwise adding or running a subset of tests shifts the numbering and breaks unrelated snapshots.
+    """
+
+    for _, factory_class in inspect.getmembers(factories_module, inspect.isclass):
+        if issubclass(factory_class, factory_boy.django.DjangoModelFactory):
+            factory_class.reset_sequence(0)
 
 
 @pytest.fixture(scope="session")

--- a/MPCAutofill/cardpicker/tests/test_integrations.py
+++ b/MPCAutofill/cardpicker/tests/test_integrations.py
@@ -107,6 +107,8 @@ class TestMTGIntegration:
 
     @pytest.mark.parametrize("url", [item.value for item in Decks], ids=[item.name.lower() for item in Decks])
     def test_valid_url(self, client, django_settings, snapshot, url: str):
+        if "moxfield" in url and not conf_settings.MOXFIELD_SECRET:
+            pytest.skip("MOXFIELD_SECRET is not configured (e.g. fork PRs and environments without credentials)")
         decklist = MTGIntegration.query_import_site(url)
         assert decklist
         assert Counter(decklist.splitlines()) == snapshot

--- a/MPCAutofill/cardpicker/tests/test_sources.py
+++ b/MPCAutofill/cardpicker/tests/test_sources.py
@@ -1,4 +1,6 @@
 import datetime as dt
+import json
+from pathlib import Path
 
 import freezegun
 import pytest
@@ -19,6 +21,16 @@ from cardpicker.tests.factories import (
 )
 
 DEFAULT_DATE = dt.datetime(2023, 1, 1)
+
+
+def google_drive_credentials_available() -> bool:
+    # mirrors the path resolution in `cardpicker.sources.api`. fork PRs and local runs without
+    # credentials get a missing or unparseable client_secrets.json, so those tests must skip.
+    try:
+        with open(Path(__file__).parent.parent.parent / "client_secrets.json") as f:
+            return bool(json.load(f))
+    except (OSError, json.JSONDecodeError):
+        return False
 
 
 class TestAPI:
@@ -354,6 +366,10 @@ class TestAPI:
 # endregion
 
 
+@pytest.mark.skipif(
+    not google_drive_credentials_available(),
+    reason="Google Drive credentials (client_secrets.json) are not available",
+)
 class TestUpdateDatabase:
     # region tests
 

--- a/MPCAutofill/cardpicker/tests/test_views.py
+++ b/MPCAutofill/cardpicker/tests/test_views.py
@@ -10,6 +10,7 @@ from syrupy import SnapshotAssertion
 from django.urls import reverse
 
 from cardpicker import views
+from cardpicker.models import Card
 from cardpicker.tests.constants import Cards, DummyImportSite, Sources
 from cardpicker.tests.factories import SourceFactory
 
@@ -643,6 +644,51 @@ class TestPostExploreSearchResults:
             expected_card.identifier for expected_card in expected_cards
         ]
 
+    def test_explore_search_filtered_by_artist(self, client):
+        brainstorm = Card.objects.get(identifier=Cards.BRAINSTORM.value.identifier)
+        artist_name = brainstorm.serialise().canonicalArtist.name
+        expected_identifiers = {
+            card.identifier
+            for card in Card.objects.all()
+            if (canonical_artist := card.serialise().canonicalArtist) is not None
+            and canonical_artist.name == artist_name
+        }
+        assert Cards.BRAINSTORM.value.identifier in expected_identifiers
+        response = client.post(
+            reverse(views.post_explore_search),
+            {
+                "searchSettings": BASE_SEARCH_SETTINGS,
+                "query": None,
+                "artists": [artist_name],
+                "cardTypes": [],
+                "sortBy": "dateCreatedDescending",
+                "pageSize": 20,
+                "pageStart": 0,
+            },
+            content_type="application/json",
+        )
+        assert response.status_code == 200
+        response_json = response.json()
+        assert response_json["count"] == len(expected_identifiers)
+        assert {item["identifier"] for item in response_json["cards"]} == expected_identifiers
+
+    def test_explore_search_with_unknown_artist_yields_no_results(self, client):
+        response = client.post(
+            reverse(views.post_explore_search),
+            {
+                "searchSettings": BASE_SEARCH_SETTINGS,
+                "query": None,
+                "artists": ["No Such Artist"],
+                "cardTypes": [],
+                "sortBy": "dateCreatedDescending",
+                "pageSize": 20,
+                "pageStart": 0,
+            },
+            content_type="application/json",
+        )
+        assert response.status_code == 200
+        assert response.json()["count"] == 0
+
     @pytest.mark.parametrize(
         "page_start, page_size, expected_cards",
         [
@@ -866,6 +912,30 @@ class TestGetLanguages:
     def test_post_request(self, client, django_settings, snapshot):
         response = client.post(reverse(views.get_languages))
         snapshot_response(response, snapshot)
+        assert response.status_code == 400
+
+
+class TestGetArtists:
+    def test_get_zero_artists(self, client, django_settings):
+        response = client.get(reverse(views.get_artists))
+        assert response.status_code == 200
+        assert response.json()["artists"] == []
+
+    def test_get_artists(self, client, populated_database):
+        expected = sorted(
+            {
+                canonical_artist.name
+                for card in Card.objects.all()
+                if (canonical_artist := card.serialise().canonicalArtist) is not None
+            }
+        )
+        assert len(expected) > 0
+        response = client.get(reverse(views.get_artists))
+        assert response.status_code == 200
+        assert response.json()["artists"] == expected
+
+    def test_post_request(self, client, django_settings):
+        response = client.post(reverse(views.get_artists))
         assert response.status_code == 400
 
 

--- a/MPCAutofill/cardpicker/urls.py
+++ b/MPCAutofill/cardpicker/urls.py
@@ -9,6 +9,7 @@ urlpatterns = [
     path("2/cards/", views.post_cards),
     path("2/sources/", views.get_sources),
     path("2/DFCPairs/", views.get_dfc_pairs),
+    path("2/artists/", views.get_artists),
     path("2/languages/", views.get_languages),
     path("2/tags/", views.get_tags),
     path("2/cardbacks/", views.post_cardbacks),

--- a/MPCAutofill/cardpicker/views.py
+++ b/MPCAutofill/cardpicker/views.py
@@ -24,7 +24,7 @@ from cardpicker.documents import CardSearch
 from cardpicker.integrations.integrations import get_configured_game_integration
 from cardpicker.integrations.patreon import get_patreon_campaign_details, get_patrons
 from cardpicker.models import Card, CardTypes, DFCPair, Source, summarise_contributions
-from cardpicker.schema_types import CardbacksRequest, CardbacksResponse
+from cardpicker.schema_types import ArtistsResponse, CardbacksRequest, CardbacksResponse
 from cardpicker.schema_types import Cards as SampleCards
 from cardpicker.schema_types import (
     CardsRequest,
@@ -211,6 +211,7 @@ def post_explore_search(request: HttpRequest) -> HttpResponse:
         search_settings=explore_search_request.searchSettings,
         query=explore_search_request.query,
         card_types=explore_search_request.cardTypes,
+        artists=explore_search_request.artists,
     ).sort(sort)
     count = s.extra(track_total_hits=True).count()
 
@@ -297,6 +298,30 @@ def get_languages(request: HttpRequest) -> HttpResponse:
             )
         ).model_dump()
     )
+
+
+@csrf_exempt
+@ErrorWrappers.to_json
+def get_artists(request: HttpRequest) -> HttpResponse:
+    """
+    Return the list of all unique canonical artist names among cards in the database.
+    """
+
+    if request.method != "GET":
+        raise BadRequestException("Expected GET request.")
+    artist_names = set(
+        Card.objects.exclude(canonical_artist=None)
+        .order_by()
+        .values_list("canonical_artist__name", flat=True)
+        .distinct()
+    ) | set(
+        Card.objects.filter(canonical_artist=None)
+        .exclude(canonical_card=None)
+        .order_by()
+        .values_list("canonical_card__artist__name", flat=True)
+        .distinct()
+    )
+    return JsonResponse(ArtistsResponse(artists=sorted(artist_names)).model_dump())
 
 
 @csrf_exempt

--- a/MPCAutofill/pytest.ini
+++ b/MPCAutofill/pytest.ini
@@ -1,2 +1,5 @@
 [pytest]
 DJANGO_SETTINGS_MODULE = MPCAutofill.settings
+# credential-dependent tests (update_database, Moxfield) skip when secrets are absent - e.g. on fork
+# PRs - which leaves their committed snapshots unused; warn rather than fail the run in that case
+addopts = --snapshot-warn-unused

--- a/frontend/src/common/schema_types.ts
+++ b/frontend/src/common/schema_types.ts
@@ -2,7 +2,7 @@
 
 // To parse this data:
 //
-//   import { Convert, Campaign, CanonicalArtist, CanonicalCard, Card, CardType, FilterSettings, Game, ImportSite, Language, NewCardsFirstPage, SearchQuery, SearchSettings, SearchTypeSettings, SortBy, Source, SourceContribution, SourceSettings, SourceType, Supporter, SupporterTier, Tag, CardbacksRequest, CardbacksResponse, CardsRequest, CardsResponse, ContributionsResponse, DFCPairsResponse, EditorSearchRequest, EditorSearchResponse, ErrorResponse, ExploreSearchRequest, ExploreSearchResponse, ImportSiteDecklistRequest, ImportSiteDecklistResponse, ImportSitesResponse, InfoResponse, LanguagesResponse, NewCardsFirstPagesResponse, NewCardsPageResponse, OldEditorSearchRequest, OldEditorSearchResponse, PatreonResponse, SampleCardsResponse, SearchEngineHealthResponse, SourcesResponse, TagsResponse } from "./file";
+//   import { Convert, Campaign, CanonicalArtist, CanonicalCard, Card, CardType, FilterSettings, Game, ImportSite, Language, NewCardsFirstPage, SearchQuery, SearchSettings, SearchTypeSettings, SortBy, Source, SourceContribution, SourceSettings, SourceType, Supporter, SupporterTier, Tag, ArtistsResponse, CardbacksRequest, CardbacksResponse, CardsRequest, CardsResponse, ContributionsResponse, DFCPairsResponse, EditorSearchRequest, EditorSearchResponse, ErrorResponse, ExploreSearchRequest, ExploreSearchResponse, ImportSiteDecklistRequest, ImportSiteDecklistResponse, ImportSitesResponse, InfoResponse, LanguagesResponse, NewCardsFirstPagesResponse, NewCardsPageResponse, OldEditorSearchRequest, OldEditorSearchResponse, PatreonResponse, SampleCardsResponse, SearchEngineHealthResponse, SourcesResponse, TagsResponse } from "./file";
 //
 //   const campaign = Convert.toCampaign(json);
 //   const canonicalArtist = Convert.toCanonicalArtist(json);
@@ -26,6 +26,7 @@
 //   const supporter = Convert.toSupporter(json);
 //   const supporterTier = Convert.toSupporterTier(json);
 //   const tag = Convert.toTag(json);
+//   const artistsResponse = Convert.toArtistsResponse(json);
 //   const cardbacksRequest = Convert.toCardbacksRequest(json);
 //   const cardbacksResponse = Convert.toCardbacksResponse(json);
 //   const cardsRequest = Convert.toCardsRequest(json);
@@ -56,1336 +57,1143 @@
 // match the expected interface, even if the JSON is valid.
 
 export enum Game {
-  Mtg = "MTG",
+    Mtg = "MTG",
+}
+
+export interface ArtistsResponse {
+    artists: string[];
 }
 
 export interface CardbacksRequest {
-  searchSettings: SearchSettings;
+    searchSettings: SearchSettings;
 }
 
 export interface SearchSettings {
-  filterSettings: FilterSettings;
-  searchTypeSettings: SearchTypeSettings;
-  sourceSettings: SourceSettings;
+    filterSettings:     FilterSettings;
+    searchTypeSettings: SearchTypeSettings;
+    sourceSettings:     SourceSettings;
 }
 
 export interface FilterSettings {
-  /**
-   * The tags which the cards must *not* have to be included in search results
-   */
-  excludesTags: string[];
-  /**
-   * The tags which the cards must have to be included in search results
-   */
-  includesTags: string[];
-  /**
-   * The language the cards have to be written in to be included in search results
-   */
-  languages: string[];
-  /**
-   * The maximum DPI that cards can have to be included in search results
-   */
-  maximumDPI: number;
-  /**
-   * The maximum filesize that cards can have to be included in search results
-   */
-  maximumSize: number;
-  /**
-   * The minimum DPI that cards must meet to be included in search results
-   */
-  minimumDPI: number;
+    /**
+     * The tags which the cards must *not* have to be included in search results
+     */
+    excludesTags: string[];
+    /**
+     * The tags which the cards must have to be included in search results
+     */
+    includesTags: string[];
+    /**
+     * The language the cards have to be written in to be included in search results
+     */
+    languages: string[];
+    /**
+     * The maximum DPI that cards can have to be included in search results
+     */
+    maximumDPI: number;
+    /**
+     * The maximum filesize that cards can have to be included in search results
+     */
+    maximumSize: number;
+    /**
+     * The minimum DPI that cards must meet to be included in search results
+     */
+    minimumDPI: number;
 }
 
 export interface SearchTypeSettings {
-  /**
-   * Whether search settings apply to cardbacks or not
-   */
-  filterCardbacks: boolean;
-  /**
-   * Whether fuzzy search is active
-   */
-  fuzzySearch: boolean;
+    /**
+     * Whether search settings apply to cardbacks or not
+     */
+    filterCardbacks: boolean;
+    /**
+     * Whether fuzzy search is active
+     */
+    fuzzySearch: boolean;
 }
 
 export interface SourceSettings {
-  /**
-   * The list of sources in the order they should be searched
-   */
-  sources: Array<Array<boolean | number>>;
+    /**
+     * The list of sources in the order they should be searched
+     */
+    sources: Array<Array<boolean | number>>;
 }
 
 export interface CardbacksResponse {
-  cardbacks: string[];
+    cardbacks: string[];
 }
 
 export interface CardsRequest {
-  cardIdentifiers: string[];
+    cardIdentifiers: string[];
 }
 
 export interface CardsResponse {
-  results: { [key: string]: Card };
+    results: { [key: string]: Card };
 }
 
 export interface Card {
-  canonicalArtist?: CanonicalArtist | null;
-  canonicalCard?: CanonicalCard | null;
-  cardType: CardType;
-  /**
-   * Created date - formatted by backend
-   */
-  dateCreated: string;
-  /**
-   * Modified date - formatted by backend
-   */
-  dateModified: string;
-  dpi: number;
-  extension: string;
-  identifier: string;
-  language: string;
-  mediumThumbnailUrl: string;
-  name: string;
-  priority: number;
-  searchq: string;
-  size: number;
-  smallThumbnailUrl: string;
-  source: string;
-  sourceExternalLink?: string;
-  sourceId: number;
-  sourceName: string;
-  sourceType?: SourceType;
-  sourceVerbose: string;
-  tags: string[];
+    canonicalArtist?: CanonicalArtist | null;
+    canonicalCard?:   CanonicalCard | null;
+    cardType:         CardType;
+    /**
+     * Created date - formatted by backend
+     */
+    dateCreated: string;
+    /**
+     * Modified date - formatted by backend
+     */
+    dateModified:        string;
+    dpi:                 number;
+    extension:           string;
+    identifier:          string;
+    language:            string;
+    mediumThumbnailUrl:  string;
+    name:                string;
+    priority:            number;
+    searchq:             string;
+    size:                number;
+    smallThumbnailUrl:   string;
+    source:              string;
+    sourceExternalLink?: string;
+    sourceId:            number;
+    sourceName:          string;
+    sourceType?:         SourceType;
+    sourceVerbose:       string;
+    tags:                string[];
 }
 
 export interface CanonicalArtist {
-  name: string;
+    name: string;
 }
 
 export interface CanonicalCard {
-  artist?: string;
-  canonicalId?: string;
-  collectorNumber: string;
-  expansionCode: string;
-  expansionName: string;
-  identifier: string;
-  mediumThumbnailUrl: string;
-  smallThumbnailUrl: string;
+    artist?:            string;
+    canonicalId?:       string;
+    collectorNumber:    string;
+    expansionCode:      string;
+    expansionName:      string;
+    identifier:         string;
+    mediumThumbnailUrl: string;
+    smallThumbnailUrl:  string;
 }
 
 export enum CardType {
-  Card = "CARD",
-  Cardback = "CARDBACK",
-  Token = "TOKEN",
+    Card = "CARD",
+    Cardback = "CARDBACK",
+    Token = "TOKEN",
 }
 
 export enum SourceType {
-  AwsS3 = "AWS S3",
-  GoogleDrive = "Google Drive",
-  LocalFile = "Local File",
+    AwsS3 = "AWS S3",
+    GoogleDrive = "Google Drive",
+    LocalFile = "Local File",
 }
 
 export interface ContributionsResponse {
-  cardCountByType: { [key: string]: number };
-  sources: SourceContribution[];
-  totalDatabaseSize: number;
+    cardCountByType:   { [key: string]: number };
+    sources:           SourceContribution[];
+    totalDatabaseSize: number;
 }
 
 export interface SourceContribution {
-  avgdpi: string;
-  description: string;
-  externalLink?: string;
-  name: string;
-  qtyCardbacks: string;
-  qtyCards: string;
-  qtyTokens: string;
-  size: string;
-  sourceType: SourceType;
+    avgdpi:        string;
+    description:   string;
+    externalLink?: string;
+    name:          string;
+    qtyCardbacks:  string;
+    qtyCards:      string;
+    qtyTokens:     string;
+    size:          string;
+    sourceType:    SourceType;
 }
 
 export interface DFCPairsResponse {
-  dfcPairs: { [key: string]: string };
+    dfcPairs: { [key: string]: string };
 }
 
 export interface EditorSearchRequest {
-  queries: { [key: string]: SearchQuery };
-  searchSettings: SearchSettings;
+    queries:        { [key: string]: SearchQuery };
+    searchSettings: SearchSettings;
 }
 
 export interface SearchQuery {
-  cardType: CardType;
-  collectorNumber?: string;
-  expansionCode?: string;
-  query: null | string;
+    cardType:         CardType;
+    collectorNumber?: string;
+    expansionCode?:   string;
+    query:            null | string;
 }
 
 export interface EditorSearchResponse {
-  results: { [key: string]: string[] };
+    results: { [key: string]: string[] };
 }
 
 export interface ErrorResponse {
-  errors?: { [key: string]: any }[];
-  message?: string;
-  name: string;
+    errors?:  { [key: string]: any }[];
+    message?: string;
+    name:     string;
 }
 
 export interface ExploreSearchRequest {
-  cardTypes: CardType[];
-  pageSize: number;
-  pageStart: number;
-  query: null | string;
-  searchSettings: SearchSettings;
-  sortBy: SortBy;
+    artists?:       string[] | null;
+    cardTypes:      CardType[];
+    pageSize:       number;
+    pageStart:      number;
+    query:          null | string;
+    searchSettings: SearchSettings;
+    sortBy:         SortBy;
 }
 
 export enum SortBy {
-  DateCreatedAscending = "dateCreatedAscending",
-  DateCreatedDescending = "dateCreatedDescending",
-  DateModifiedAscending = "dateModifiedAscending",
-  DateModifiedDescending = "dateModifiedDescending",
-  NameAscending = "nameAscending",
-  NameDescending = "nameDescending",
+    DateCreatedAscending = "dateCreatedAscending",
+    DateCreatedDescending = "dateCreatedDescending",
+    DateModifiedAscending = "dateModifiedAscending",
+    DateModifiedDescending = "dateModifiedDescending",
+    NameAscending = "nameAscending",
+    NameDescending = "nameDescending",
 }
 
 export interface ExploreSearchResponse {
-  cards: Card[];
-  count: number;
+    cards: Card[];
+    count: number;
 }
 
 export interface ImportSiteDecklistRequest {
-  url: string;
+    url: string;
 }
 
 export interface ImportSiteDecklistResponse {
-  cards: string;
+    cards: string;
 }
 
 export interface ImportSitesResponse {
-  importSites: ImportSite[];
+    importSites: ImportSite[];
 }
 
 export interface ImportSite {
-  name: string;
-  url: string;
+    name: string;
+    url:  string;
 }
 
 export interface InfoResponse {
-  info: Info;
+    info: Info;
 }
 
 export interface Info {
-  description: null | string;
-  discord: null | string;
-  email: null | string;
-  name: null | string;
-  reddit: null | string;
+    description: null | string;
+    discord:     null | string;
+    email:       null | string;
+    name:        null | string;
+    reddit:      null | string;
 }
 
 export interface LanguagesResponse {
-  languages: Language[];
+    languages: Language[];
 }
 
 export interface Language {
-  code: string;
-  name: string;
+    code: string;
+    name: string;
 }
 
 export interface NewCardsFirstPagesResponse {
-  results: { [key: string]: NewCardsFirstPage };
+    results: { [key: string]: NewCardsFirstPage };
 }
 
 export interface NewCardsFirstPage {
-  cards: Card[];
-  hits: number;
-  pages: number;
-  source: Source;
+    cards:  Card[];
+    hits:   number;
+    pages:  number;
+    source: Source;
 }
 
 export interface Source {
-  description: string;
-  externalLink?: string;
-  key: string;
-  name: string;
-  /**
-   * Primary key
-   */
-  pk: number;
-  sourceType: SourceType;
+    description:   string;
+    externalLink?: string;
+    key:           string;
+    name:          string;
+    /**
+     * Primary key
+     */
+    pk:         number;
+    sourceType: SourceType;
 }
 
 export interface NewCardsPageResponse {
-  cards: Card[];
+    cards: Card[];
 }
 
 export interface OldEditorSearchRequest {
-  queries: SearchQuery[];
-  searchSettings: SearchSettings;
+    queries:        SearchQuery[];
+    searchSettings: SearchSettings;
 }
 
 export interface OldEditorSearchResponse {
-  results: { [key: string]: { [key: string]: string[] } };
+    results: { [key: string]: { [key: string]: string[] } };
 }
 
 export interface PatreonResponse {
-  patreon: Patreon;
+    patreon: Patreon;
 }
 
 export interface Patreon {
-  campaign: Campaign | null;
-  members: Supporter[];
-  tiers: { [key: string]: SupporterTier } | null;
-  url: null | string;
+    campaign: Campaign | null;
+    members:  Supporter[];
+    tiers:    { [key: string]: SupporterTier } | null;
+    url:      null | string;
 }
 
 export interface Campaign {
-  about: string;
-  id: string;
+    about: string;
+    id:    string;
 }
 
 export interface Supporter {
-  date: string;
-  name: string;
-  tier: string;
-  usd: number;
+    date: string;
+    name: string;
+    tier: string;
+    usd:  number;
 }
 
 export interface SupporterTier {
-  description: string;
-  title: string;
-  usd: number;
+    description: string;
+    title:       string;
+    usd:         number;
 }
 
 export interface SampleCardsResponse {
-  cards: Cards;
-  [property: string]: any;
+    cards: Cards;
+    [property: string]: any;
 }
 
 export interface Cards {
-  CARD: Card[];
-  CARDBACK: Card[];
-  TOKEN: Card[];
-  [property: string]: any;
+    CARD:     Card[];
+    CARDBACK: Card[];
+    TOKEN:    Card[];
+    [property: string]: any;
 }
 
 export interface SearchEngineHealthResponse {
-  online: boolean;
+    online: boolean;
 }
 
 export interface SourcesResponse {
-  results: { [key: string]: Source };
+    results: { [key: string]: Source };
 }
 
 export interface TagsResponse {
-  tags: Tag[];
+    tags: Tag[];
 }
 
 export interface Tag {
-  aliases?: string[];
-  children: ChildElement[];
-  isEnabledByDefault?: boolean;
-  name: string;
-  parent: null | string;
+    aliases?:            string[];
+    children:            ChildElement[];
+    isEnabledByDefault?: boolean;
+    name:                string;
+    parent:              null | string;
 }
 
 export interface ChildElement {
-  aliases?: string[];
-  children: ChildElement[];
-  isEnabledByDefault?: boolean;
-  name: string;
-  parent: null | string;
+    aliases?:            string[];
+    children:            ChildElement[];
+    isEnabledByDefault?: boolean;
+    name:                string;
+    parent:              null | string;
 }
 
 // Converts JSON strings to/from your types
 // and asserts the results of JSON.parse at runtime
 export class Convert {
-  public static toCampaign(json: string): Campaign | null {
-    return cast(JSON.parse(json), u(r("Campaign"), null));
-  }
-
-  public static campaignToJson(value: Campaign | null): string {
-    return JSON.stringify(uncast(value, u(r("Campaign"), null)), null, 2);
-  }
-
-  public static toCanonicalArtist(json: string): CanonicalArtist | null {
-    return cast(JSON.parse(json), u(r("CanonicalArtist"), null));
-  }
-
-  public static canonicalArtistToJson(value: CanonicalArtist | null): string {
-    return JSON.stringify(
-      uncast(value, u(r("CanonicalArtist"), null)),
-      null,
-      2
-    );
-  }
-
-  public static toCanonicalCard(json: string): CanonicalCard | null {
-    return cast(JSON.parse(json), u(r("CanonicalCard"), null));
-  }
-
-  public static canonicalCardToJson(value: CanonicalCard | null): string {
-    return JSON.stringify(uncast(value, u(r("CanonicalCard"), null)), null, 2);
-  }
-
-  public static toCard(json: string): Card {
-    return cast(JSON.parse(json), r("Card"));
-  }
-
-  public static cardToJson(value: Card): string {
-    return JSON.stringify(uncast(value, r("Card")), null, 2);
-  }
-
-  public static toCardType(json: string): CardType {
-    return cast(JSON.parse(json), r("CardType"));
-  }
-
-  public static cardTypeToJson(value: CardType): string {
-    return JSON.stringify(uncast(value, r("CardType")), null, 2);
-  }
-
-  public static toFilterSettings(json: string): FilterSettings {
-    return cast(JSON.parse(json), r("FilterSettings"));
-  }
-
-  public static filterSettingsToJson(value: FilterSettings): string {
-    return JSON.stringify(uncast(value, r("FilterSettings")), null, 2);
-  }
-
-  public static toGame(json: string): Game {
-    return cast(JSON.parse(json), r("Game"));
-  }
-
-  public static gameToJson(value: Game): string {
-    return JSON.stringify(uncast(value, r("Game")), null, 2);
-  }
-
-  public static toImportSite(json: string): ImportSite {
-    return cast(JSON.parse(json), r("ImportSite"));
-  }
-
-  public static importSiteToJson(value: ImportSite): string {
-    return JSON.stringify(uncast(value, r("ImportSite")), null, 2);
-  }
-
-  public static toLanguage(json: string): Language {
-    return cast(JSON.parse(json), r("Language"));
-  }
-
-  public static languageToJson(value: Language): string {
-    return JSON.stringify(uncast(value, r("Language")), null, 2);
-  }
-
-  public static toNewCardsFirstPage(json: string): NewCardsFirstPage {
-    return cast(JSON.parse(json), r("NewCardsFirstPage"));
-  }
-
-  public static newCardsFirstPageToJson(value: NewCardsFirstPage): string {
-    return JSON.stringify(uncast(value, r("NewCardsFirstPage")), null, 2);
-  }
-
-  public static toSearchQuery(json: string): SearchQuery {
-    return cast(JSON.parse(json), r("SearchQuery"));
-  }
-
-  public static searchQueryToJson(value: SearchQuery): string {
-    return JSON.stringify(uncast(value, r("SearchQuery")), null, 2);
-  }
-
-  public static toSearchSettings(json: string): SearchSettings {
-    return cast(JSON.parse(json), r("SearchSettings"));
-  }
-
-  public static searchSettingsToJson(value: SearchSettings): string {
-    return JSON.stringify(uncast(value, r("SearchSettings")), null, 2);
-  }
-
-  public static toSearchTypeSettings(json: string): SearchTypeSettings {
-    return cast(JSON.parse(json), r("SearchTypeSettings"));
-  }
-
-  public static searchTypeSettingsToJson(value: SearchTypeSettings): string {
-    return JSON.stringify(uncast(value, r("SearchTypeSettings")), null, 2);
-  }
-
-  public static toSortBy(json: string): SortBy {
-    return cast(JSON.parse(json), r("SortBy"));
-  }
-
-  public static sortByToJson(value: SortBy): string {
-    return JSON.stringify(uncast(value, r("SortBy")), null, 2);
-  }
-
-  public static toSource(json: string): Source {
-    return cast(JSON.parse(json), r("Source"));
-  }
-
-  public static sourceToJson(value: Source): string {
-    return JSON.stringify(uncast(value, r("Source")), null, 2);
-  }
-
-  public static toSourceContribution(json: string): SourceContribution {
-    return cast(JSON.parse(json), r("SourceContribution"));
-  }
-
-  public static sourceContributionToJson(value: SourceContribution): string {
-    return JSON.stringify(uncast(value, r("SourceContribution")), null, 2);
-  }
-
-  public static toSourceRow(json: string): Array<boolean | number> {
-    return cast(JSON.parse(json), a(u(true, 0)));
-  }
-
-  public static sourceRowToJson(value: Array<boolean | number>): string {
-    return JSON.stringify(uncast(value, a(u(true, 0))), null, 2);
-  }
-
-  public static toSourceSettings(json: string): SourceSettings {
-    return cast(JSON.parse(json), r("SourceSettings"));
-  }
-
-  public static sourceSettingsToJson(value: SourceSettings): string {
-    return JSON.stringify(uncast(value, r("SourceSettings")), null, 2);
-  }
-
-  public static toSourceType(json: string): SourceType {
-    return cast(JSON.parse(json), r("SourceType"));
-  }
-
-  public static sourceTypeToJson(value: SourceType): string {
-    return JSON.stringify(uncast(value, r("SourceType")), null, 2);
-  }
-
-  public static toSupporter(json: string): Supporter {
-    return cast(JSON.parse(json), r("Supporter"));
-  }
-
-  public static supporterToJson(value: Supporter): string {
-    return JSON.stringify(uncast(value, r("Supporter")), null, 2);
-  }
-
-  public static toSupporterTier(json: string): SupporterTier {
-    return cast(JSON.parse(json), r("SupporterTier"));
-  }
-
-  public static supporterTierToJson(value: SupporterTier): string {
-    return JSON.stringify(uncast(value, r("SupporterTier")), null, 2);
-  }
-
-  public static toTag(json: string): Tag {
-    return cast(JSON.parse(json), r("Tag"));
-  }
-
-  public static tagToJson(value: Tag): string {
-    return JSON.stringify(uncast(value, r("Tag")), null, 2);
-  }
-
-  public static toCardbacksRequest(json: string): CardbacksRequest {
-    return cast(JSON.parse(json), r("CardbacksRequest"));
-  }
-
-  public static cardbacksRequestToJson(value: CardbacksRequest): string {
-    return JSON.stringify(uncast(value, r("CardbacksRequest")), null, 2);
-  }
-
-  public static toCardbacksResponse(json: string): CardbacksResponse {
-    return cast(JSON.parse(json), r("CardbacksResponse"));
-  }
-
-  public static cardbacksResponseToJson(value: CardbacksResponse): string {
-    return JSON.stringify(uncast(value, r("CardbacksResponse")), null, 2);
-  }
-
-  public static toCardsRequest(json: string): CardsRequest {
-    return cast(JSON.parse(json), r("CardsRequest"));
-  }
-
-  public static cardsRequestToJson(value: CardsRequest): string {
-    return JSON.stringify(uncast(value, r("CardsRequest")), null, 2);
-  }
-
-  public static toCardsResponse(json: string): CardsResponse {
-    return cast(JSON.parse(json), r("CardsResponse"));
-  }
-
-  public static cardsResponseToJson(value: CardsResponse): string {
-    return JSON.stringify(uncast(value, r("CardsResponse")), null, 2);
-  }
-
-  public static toContributionsResponse(json: string): ContributionsResponse {
-    return cast(JSON.parse(json), r("ContributionsResponse"));
-  }
-
-  public static contributionsResponseToJson(
-    value: ContributionsResponse
-  ): string {
-    return JSON.stringify(uncast(value, r("ContributionsResponse")), null, 2);
-  }
-
-  public static toDFCPairsResponse(json: string): DFCPairsResponse {
-    return cast(JSON.parse(json), r("DFCPairsResponse"));
-  }
-
-  public static dFCPairsResponseToJson(value: DFCPairsResponse): string {
-    return JSON.stringify(uncast(value, r("DFCPairsResponse")), null, 2);
-  }
-
-  public static toEditorSearchRequest(json: string): EditorSearchRequest {
-    return cast(JSON.parse(json), r("EditorSearchRequest"));
-  }
-
-  public static editorSearchRequestToJson(value: EditorSearchRequest): string {
-    return JSON.stringify(uncast(value, r("EditorSearchRequest")), null, 2);
-  }
-
-  public static toEditorSearchResponse(json: string): EditorSearchResponse {
-    return cast(JSON.parse(json), r("EditorSearchResponse"));
-  }
-
-  public static editorSearchResponseToJson(
-    value: EditorSearchResponse
-  ): string {
-    return JSON.stringify(uncast(value, r("EditorSearchResponse")), null, 2);
-  }
-
-  public static toErrorResponse(json: string): ErrorResponse {
-    return cast(JSON.parse(json), r("ErrorResponse"));
-  }
-
-  public static errorResponseToJson(value: ErrorResponse): string {
-    return JSON.stringify(uncast(value, r("ErrorResponse")), null, 2);
-  }
-
-  public static toExploreSearchRequest(json: string): ExploreSearchRequest {
-    return cast(JSON.parse(json), r("ExploreSearchRequest"));
-  }
-
-  public static exploreSearchRequestToJson(
-    value: ExploreSearchRequest
-  ): string {
-    return JSON.stringify(uncast(value, r("ExploreSearchRequest")), null, 2);
-  }
-
-  public static toExploreSearchResponse(json: string): ExploreSearchResponse {
-    return cast(JSON.parse(json), r("ExploreSearchResponse"));
-  }
-
-  public static exploreSearchResponseToJson(
-    value: ExploreSearchResponse
-  ): string {
-    return JSON.stringify(uncast(value, r("ExploreSearchResponse")), null, 2);
-  }
-
-  public static toImportSiteDecklistRequest(
-    json: string
-  ): ImportSiteDecklistRequest {
-    return cast(JSON.parse(json), r("ImportSiteDecklistRequest"));
-  }
-
-  public static importSiteDecklistRequestToJson(
-    value: ImportSiteDecklistRequest
-  ): string {
-    return JSON.stringify(
-      uncast(value, r("ImportSiteDecklistRequest")),
-      null,
-      2
-    );
-  }
-
-  public static toImportSiteDecklistResponse(
-    json: string
-  ): ImportSiteDecklistResponse {
-    return cast(JSON.parse(json), r("ImportSiteDecklistResponse"));
-  }
-
-  public static importSiteDecklistResponseToJson(
-    value: ImportSiteDecklistResponse
-  ): string {
-    return JSON.stringify(
-      uncast(value, r("ImportSiteDecklistResponse")),
-      null,
-      2
-    );
-  }
-
-  public static toImportSitesResponse(json: string): ImportSitesResponse {
-    return cast(JSON.parse(json), r("ImportSitesResponse"));
-  }
-
-  public static importSitesResponseToJson(value: ImportSitesResponse): string {
-    return JSON.stringify(uncast(value, r("ImportSitesResponse")), null, 2);
-  }
-
-  public static toInfoResponse(json: string): InfoResponse {
-    return cast(JSON.parse(json), r("InfoResponse"));
-  }
-
-  public static infoResponseToJson(value: InfoResponse): string {
-    return JSON.stringify(uncast(value, r("InfoResponse")), null, 2);
-  }
-
-  public static toLanguagesResponse(json: string): LanguagesResponse {
-    return cast(JSON.parse(json), r("LanguagesResponse"));
-  }
-
-  public static languagesResponseToJson(value: LanguagesResponse): string {
-    return JSON.stringify(uncast(value, r("LanguagesResponse")), null, 2);
-  }
-
-  public static toNewCardsFirstPagesResponse(
-    json: string
-  ): NewCardsFirstPagesResponse {
-    return cast(JSON.parse(json), r("NewCardsFirstPagesResponse"));
-  }
-
-  public static newCardsFirstPagesResponseToJson(
-    value: NewCardsFirstPagesResponse
-  ): string {
-    return JSON.stringify(
-      uncast(value, r("NewCardsFirstPagesResponse")),
-      null,
-      2
-    );
-  }
-
-  public static toNewCardsPageResponse(json: string): NewCardsPageResponse {
-    return cast(JSON.parse(json), r("NewCardsPageResponse"));
-  }
-
-  public static newCardsPageResponseToJson(
-    value: NewCardsPageResponse
-  ): string {
-    return JSON.stringify(uncast(value, r("NewCardsPageResponse")), null, 2);
-  }
-
-  public static toOldEditorSearchRequest(json: string): OldEditorSearchRequest {
-    return cast(JSON.parse(json), r("OldEditorSearchRequest"));
-  }
-
-  public static oldEditorSearchRequestToJson(
-    value: OldEditorSearchRequest
-  ): string {
-    return JSON.stringify(uncast(value, r("OldEditorSearchRequest")), null, 2);
-  }
-
-  public static toOldEditorSearchResponse(
-    json: string
-  ): OldEditorSearchResponse {
-    return cast(JSON.parse(json), r("OldEditorSearchResponse"));
-  }
-
-  public static oldEditorSearchResponseToJson(
-    value: OldEditorSearchResponse
-  ): string {
-    return JSON.stringify(uncast(value, r("OldEditorSearchResponse")), null, 2);
-  }
-
-  public static toPatreonResponse(json: string): PatreonResponse {
-    return cast(JSON.parse(json), r("PatreonResponse"));
-  }
-
-  public static patreonResponseToJson(value: PatreonResponse): string {
-    return JSON.stringify(uncast(value, r("PatreonResponse")), null, 2);
-  }
-
-  public static toSampleCardsResponse(json: string): SampleCardsResponse {
-    return cast(JSON.parse(json), r("SampleCardsResponse"));
-  }
-
-  public static sampleCardsResponseToJson(value: SampleCardsResponse): string {
-    return JSON.stringify(uncast(value, r("SampleCardsResponse")), null, 2);
-  }
-
-  public static toSearchEngineHealthResponse(
-    json: string
-  ): SearchEngineHealthResponse {
-    return cast(JSON.parse(json), r("SearchEngineHealthResponse"));
-  }
-
-  public static searchEngineHealthResponseToJson(
-    value: SearchEngineHealthResponse
-  ): string {
-    return JSON.stringify(
-      uncast(value, r("SearchEngineHealthResponse")),
-      null,
-      2
-    );
-  }
-
-  public static toSourcesResponse(json: string): SourcesResponse {
-    return cast(JSON.parse(json), r("SourcesResponse"));
-  }
-
-  public static sourcesResponseToJson(value: SourcesResponse): string {
-    return JSON.stringify(uncast(value, r("SourcesResponse")), null, 2);
-  }
-
-  public static toTagsResponse(json: string): TagsResponse {
-    return cast(JSON.parse(json), r("TagsResponse"));
-  }
-
-  public static tagsResponseToJson(value: TagsResponse): string {
-    return JSON.stringify(uncast(value, r("TagsResponse")), null, 2);
-  }
+    public static toCampaign(json: string): Campaign | null {
+        return cast(JSON.parse(json), u(r("Campaign"), null));
+    }
+
+    public static campaignToJson(value: Campaign | null): string {
+        return JSON.stringify(uncast(value, u(r("Campaign"), null)), null, 2);
+    }
+
+    public static toCanonicalArtist(json: string): CanonicalArtist | null {
+        return cast(JSON.parse(json), u(r("CanonicalArtist"), null));
+    }
+
+    public static canonicalArtistToJson(value: CanonicalArtist | null): string {
+        return JSON.stringify(uncast(value, u(r("CanonicalArtist"), null)), null, 2);
+    }
+
+    public static toCanonicalCard(json: string): CanonicalCard | null {
+        return cast(JSON.parse(json), u(r("CanonicalCard"), null));
+    }
+
+    public static canonicalCardToJson(value: CanonicalCard | null): string {
+        return JSON.stringify(uncast(value, u(r("CanonicalCard"), null)), null, 2);
+    }
+
+    public static toCard(json: string): Card {
+        return cast(JSON.parse(json), r("Card"));
+    }
+
+    public static cardToJson(value: Card): string {
+        return JSON.stringify(uncast(value, r("Card")), null, 2);
+    }
+
+    public static toCardType(json: string): CardType {
+        return cast(JSON.parse(json), r("CardType"));
+    }
+
+    public static cardTypeToJson(value: CardType): string {
+        return JSON.stringify(uncast(value, r("CardType")), null, 2);
+    }
+
+    public static toFilterSettings(json: string): FilterSettings {
+        return cast(JSON.parse(json), r("FilterSettings"));
+    }
+
+    public static filterSettingsToJson(value: FilterSettings): string {
+        return JSON.stringify(uncast(value, r("FilterSettings")), null, 2);
+    }
+
+    public static toGame(json: string): Game {
+        return cast(JSON.parse(json), r("Game"));
+    }
+
+    public static gameToJson(value: Game): string {
+        return JSON.stringify(uncast(value, r("Game")), null, 2);
+    }
+
+    public static toImportSite(json: string): ImportSite {
+        return cast(JSON.parse(json), r("ImportSite"));
+    }
+
+    public static importSiteToJson(value: ImportSite): string {
+        return JSON.stringify(uncast(value, r("ImportSite")), null, 2);
+    }
+
+    public static toLanguage(json: string): Language {
+        return cast(JSON.parse(json), r("Language"));
+    }
+
+    public static languageToJson(value: Language): string {
+        return JSON.stringify(uncast(value, r("Language")), null, 2);
+    }
+
+    public static toNewCardsFirstPage(json: string): NewCardsFirstPage {
+        return cast(JSON.parse(json), r("NewCardsFirstPage"));
+    }
+
+    public static newCardsFirstPageToJson(value: NewCardsFirstPage): string {
+        return JSON.stringify(uncast(value, r("NewCardsFirstPage")), null, 2);
+    }
+
+    public static toSearchQuery(json: string): SearchQuery {
+        return cast(JSON.parse(json), r("SearchQuery"));
+    }
+
+    public static searchQueryToJson(value: SearchQuery): string {
+        return JSON.stringify(uncast(value, r("SearchQuery")), null, 2);
+    }
+
+    public static toSearchSettings(json: string): SearchSettings {
+        return cast(JSON.parse(json), r("SearchSettings"));
+    }
+
+    public static searchSettingsToJson(value: SearchSettings): string {
+        return JSON.stringify(uncast(value, r("SearchSettings")), null, 2);
+    }
+
+    public static toSearchTypeSettings(json: string): SearchTypeSettings {
+        return cast(JSON.parse(json), r("SearchTypeSettings"));
+    }
+
+    public static searchTypeSettingsToJson(value: SearchTypeSettings): string {
+        return JSON.stringify(uncast(value, r("SearchTypeSettings")), null, 2);
+    }
+
+    public static toSortBy(json: string): SortBy {
+        return cast(JSON.parse(json), r("SortBy"));
+    }
+
+    public static sortByToJson(value: SortBy): string {
+        return JSON.stringify(uncast(value, r("SortBy")), null, 2);
+    }
+
+    public static toSource(json: string): Source {
+        return cast(JSON.parse(json), r("Source"));
+    }
+
+    public static sourceToJson(value: Source): string {
+        return JSON.stringify(uncast(value, r("Source")), null, 2);
+    }
+
+    public static toSourceContribution(json: string): SourceContribution {
+        return cast(JSON.parse(json), r("SourceContribution"));
+    }
+
+    public static sourceContributionToJson(value: SourceContribution): string {
+        return JSON.stringify(uncast(value, r("SourceContribution")), null, 2);
+    }
+
+    public static toSourceRow(json: string): Array<boolean | number> {
+        return cast(JSON.parse(json), a(u(true, 0)));
+    }
+
+    public static sourceRowToJson(value: Array<boolean | number>): string {
+        return JSON.stringify(uncast(value, a(u(true, 0))), null, 2);
+    }
+
+    public static toSourceSettings(json: string): SourceSettings {
+        return cast(JSON.parse(json), r("SourceSettings"));
+    }
+
+    public static sourceSettingsToJson(value: SourceSettings): string {
+        return JSON.stringify(uncast(value, r("SourceSettings")), null, 2);
+    }
+
+    public static toSourceType(json: string): SourceType {
+        return cast(JSON.parse(json), r("SourceType"));
+    }
+
+    public static sourceTypeToJson(value: SourceType): string {
+        return JSON.stringify(uncast(value, r("SourceType")), null, 2);
+    }
+
+    public static toSupporter(json: string): Supporter {
+        return cast(JSON.parse(json), r("Supporter"));
+    }
+
+    public static supporterToJson(value: Supporter): string {
+        return JSON.stringify(uncast(value, r("Supporter")), null, 2);
+    }
+
+    public static toSupporterTier(json: string): SupporterTier {
+        return cast(JSON.parse(json), r("SupporterTier"));
+    }
+
+    public static supporterTierToJson(value: SupporterTier): string {
+        return JSON.stringify(uncast(value, r("SupporterTier")), null, 2);
+    }
+
+    public static toTag(json: string): Tag {
+        return cast(JSON.parse(json), r("Tag"));
+    }
+
+    public static tagToJson(value: Tag): string {
+        return JSON.stringify(uncast(value, r("Tag")), null, 2);
+    }
+
+    public static toArtistsResponse(json: string): ArtistsResponse {
+        return cast(JSON.parse(json), r("ArtistsResponse"));
+    }
+
+    public static artistsResponseToJson(value: ArtistsResponse): string {
+        return JSON.stringify(uncast(value, r("ArtistsResponse")), null, 2);
+    }
+
+    public static toCardbacksRequest(json: string): CardbacksRequest {
+        return cast(JSON.parse(json), r("CardbacksRequest"));
+    }
+
+    public static cardbacksRequestToJson(value: CardbacksRequest): string {
+        return JSON.stringify(uncast(value, r("CardbacksRequest")), null, 2);
+    }
+
+    public static toCardbacksResponse(json: string): CardbacksResponse {
+        return cast(JSON.parse(json), r("CardbacksResponse"));
+    }
+
+    public static cardbacksResponseToJson(value: CardbacksResponse): string {
+        return JSON.stringify(uncast(value, r("CardbacksResponse")), null, 2);
+    }
+
+    public static toCardsRequest(json: string): CardsRequest {
+        return cast(JSON.parse(json), r("CardsRequest"));
+    }
+
+    public static cardsRequestToJson(value: CardsRequest): string {
+        return JSON.stringify(uncast(value, r("CardsRequest")), null, 2);
+    }
+
+    public static toCardsResponse(json: string): CardsResponse {
+        return cast(JSON.parse(json), r("CardsResponse"));
+    }
+
+    public static cardsResponseToJson(value: CardsResponse): string {
+        return JSON.stringify(uncast(value, r("CardsResponse")), null, 2);
+    }
+
+    public static toContributionsResponse(json: string): ContributionsResponse {
+        return cast(JSON.parse(json), r("ContributionsResponse"));
+    }
+
+    public static contributionsResponseToJson(value: ContributionsResponse): string {
+        return JSON.stringify(uncast(value, r("ContributionsResponse")), null, 2);
+    }
+
+    public static toDFCPairsResponse(json: string): DFCPairsResponse {
+        return cast(JSON.parse(json), r("DFCPairsResponse"));
+    }
+
+    public static dFCPairsResponseToJson(value: DFCPairsResponse): string {
+        return JSON.stringify(uncast(value, r("DFCPairsResponse")), null, 2);
+    }
+
+    public static toEditorSearchRequest(json: string): EditorSearchRequest {
+        return cast(JSON.parse(json), r("EditorSearchRequest"));
+    }
+
+    public static editorSearchRequestToJson(value: EditorSearchRequest): string {
+        return JSON.stringify(uncast(value, r("EditorSearchRequest")), null, 2);
+    }
+
+    public static toEditorSearchResponse(json: string): EditorSearchResponse {
+        return cast(JSON.parse(json), r("EditorSearchResponse"));
+    }
+
+    public static editorSearchResponseToJson(value: EditorSearchResponse): string {
+        return JSON.stringify(uncast(value, r("EditorSearchResponse")), null, 2);
+    }
+
+    public static toErrorResponse(json: string): ErrorResponse {
+        return cast(JSON.parse(json), r("ErrorResponse"));
+    }
+
+    public static errorResponseToJson(value: ErrorResponse): string {
+        return JSON.stringify(uncast(value, r("ErrorResponse")), null, 2);
+    }
+
+    public static toExploreSearchRequest(json: string): ExploreSearchRequest {
+        return cast(JSON.parse(json), r("ExploreSearchRequest"));
+    }
+
+    public static exploreSearchRequestToJson(value: ExploreSearchRequest): string {
+        return JSON.stringify(uncast(value, r("ExploreSearchRequest")), null, 2);
+    }
+
+    public static toExploreSearchResponse(json: string): ExploreSearchResponse {
+        return cast(JSON.parse(json), r("ExploreSearchResponse"));
+    }
+
+    public static exploreSearchResponseToJson(value: ExploreSearchResponse): string {
+        return JSON.stringify(uncast(value, r("ExploreSearchResponse")), null, 2);
+    }
+
+    public static toImportSiteDecklistRequest(json: string): ImportSiteDecklistRequest {
+        return cast(JSON.parse(json), r("ImportSiteDecklistRequest"));
+    }
+
+    public static importSiteDecklistRequestToJson(value: ImportSiteDecklistRequest): string {
+        return JSON.stringify(uncast(value, r("ImportSiteDecklistRequest")), null, 2);
+    }
+
+    public static toImportSiteDecklistResponse(json: string): ImportSiteDecklistResponse {
+        return cast(JSON.parse(json), r("ImportSiteDecklistResponse"));
+    }
+
+    public static importSiteDecklistResponseToJson(value: ImportSiteDecklistResponse): string {
+        return JSON.stringify(uncast(value, r("ImportSiteDecklistResponse")), null, 2);
+    }
+
+    public static toImportSitesResponse(json: string): ImportSitesResponse {
+        return cast(JSON.parse(json), r("ImportSitesResponse"));
+    }
+
+    public static importSitesResponseToJson(value: ImportSitesResponse): string {
+        return JSON.stringify(uncast(value, r("ImportSitesResponse")), null, 2);
+    }
+
+    public static toInfoResponse(json: string): InfoResponse {
+        return cast(JSON.parse(json), r("InfoResponse"));
+    }
+
+    public static infoResponseToJson(value: InfoResponse): string {
+        return JSON.stringify(uncast(value, r("InfoResponse")), null, 2);
+    }
+
+    public static toLanguagesResponse(json: string): LanguagesResponse {
+        return cast(JSON.parse(json), r("LanguagesResponse"));
+    }
+
+    public static languagesResponseToJson(value: LanguagesResponse): string {
+        return JSON.stringify(uncast(value, r("LanguagesResponse")), null, 2);
+    }
+
+    public static toNewCardsFirstPagesResponse(json: string): NewCardsFirstPagesResponse {
+        return cast(JSON.parse(json), r("NewCardsFirstPagesResponse"));
+    }
+
+    public static newCardsFirstPagesResponseToJson(value: NewCardsFirstPagesResponse): string {
+        return JSON.stringify(uncast(value, r("NewCardsFirstPagesResponse")), null, 2);
+    }
+
+    public static toNewCardsPageResponse(json: string): NewCardsPageResponse {
+        return cast(JSON.parse(json), r("NewCardsPageResponse"));
+    }
+
+    public static newCardsPageResponseToJson(value: NewCardsPageResponse): string {
+        return JSON.stringify(uncast(value, r("NewCardsPageResponse")), null, 2);
+    }
+
+    public static toOldEditorSearchRequest(json: string): OldEditorSearchRequest {
+        return cast(JSON.parse(json), r("OldEditorSearchRequest"));
+    }
+
+    public static oldEditorSearchRequestToJson(value: OldEditorSearchRequest): string {
+        return JSON.stringify(uncast(value, r("OldEditorSearchRequest")), null, 2);
+    }
+
+    public static toOldEditorSearchResponse(json: string): OldEditorSearchResponse {
+        return cast(JSON.parse(json), r("OldEditorSearchResponse"));
+    }
+
+    public static oldEditorSearchResponseToJson(value: OldEditorSearchResponse): string {
+        return JSON.stringify(uncast(value, r("OldEditorSearchResponse")), null, 2);
+    }
+
+    public static toPatreonResponse(json: string): PatreonResponse {
+        return cast(JSON.parse(json), r("PatreonResponse"));
+    }
+
+    public static patreonResponseToJson(value: PatreonResponse): string {
+        return JSON.stringify(uncast(value, r("PatreonResponse")), null, 2);
+    }
+
+    public static toSampleCardsResponse(json: string): SampleCardsResponse {
+        return cast(JSON.parse(json), r("SampleCardsResponse"));
+    }
+
+    public static sampleCardsResponseToJson(value: SampleCardsResponse): string {
+        return JSON.stringify(uncast(value, r("SampleCardsResponse")), null, 2);
+    }
+
+    public static toSearchEngineHealthResponse(json: string): SearchEngineHealthResponse {
+        return cast(JSON.parse(json), r("SearchEngineHealthResponse"));
+    }
+
+    public static searchEngineHealthResponseToJson(value: SearchEngineHealthResponse): string {
+        return JSON.stringify(uncast(value, r("SearchEngineHealthResponse")), null, 2);
+    }
+
+    public static toSourcesResponse(json: string): SourcesResponse {
+        return cast(JSON.parse(json), r("SourcesResponse"));
+    }
+
+    public static sourcesResponseToJson(value: SourcesResponse): string {
+        return JSON.stringify(uncast(value, r("SourcesResponse")), null, 2);
+    }
+
+    public static toTagsResponse(json: string): TagsResponse {
+        return cast(JSON.parse(json), r("TagsResponse"));
+    }
+
+    public static tagsResponseToJson(value: TagsResponse): string {
+        return JSON.stringify(uncast(value, r("TagsResponse")), null, 2);
+    }
 }
 
-function invalidValue(typ: any, val: any, key: any, parent: any = ""): never {
-  const prettyTyp = prettyTypeName(typ);
-  const parentText = parent ? ` on ${parent}` : "";
-  const keyText = key ? ` for key "${key}"` : "";
-  throw Error(
-    `Invalid value${keyText}${parentText}. Expected ${prettyTyp} but got ${JSON.stringify(
-      val
-    )}`
-  );
+function invalidValue(typ: any, val: any, key: any, parent: any = ''): never {
+    const prettyTyp = prettyTypeName(typ);
+    const parentText = parent ? ` on ${parent}` : '';
+    const keyText = key ? ` for key "${key}"` : '';
+    throw Error(`Invalid value${keyText}${parentText}. Expected ${prettyTyp} but got ${JSON.stringify(val)}`);
 }
 
 function prettyTypeName(typ: any): string {
-  if (Array.isArray(typ)) {
-    if (typ.length === 2 && typ[0] === undefined) {
-      return `an optional ${prettyTypeName(typ[1])}`;
+    if (Array.isArray(typ)) {
+        if (typ.length === 2 && typ[0] === undefined) {
+            return `an optional ${prettyTypeName(typ[1])}`;
+        } else {
+            return `one of [${typ.map(a => { return prettyTypeName(a); }).join(", ")}]`;
+        }
+    } else if (typeof typ === "object" && typ.literal !== undefined) {
+        return typ.literal;
     } else {
-      return `one of [${typ
-        .map((a) => {
-          return prettyTypeName(a);
-        })
-        .join(", ")}]`;
+        return typeof typ;
     }
-  } else if (typeof typ === "object" && typ.literal !== undefined) {
-    return typ.literal;
-  } else {
-    return typeof typ;
-  }
 }
 
 function jsonToJSProps(typ: any): any {
-  if (typ.jsonToJS === undefined) {
-    const map: any = {};
-    typ.props.forEach((p: any) => (map[p.json] = { key: p.js, typ: p.typ }));
-    typ.jsonToJS = map;
-  }
-  return typ.jsonToJS;
+    if (typ.jsonToJS === undefined) {
+        const map: any = {};
+        typ.props.forEach((p: any) => map[p.json] = { key: p.js, typ: p.typ });
+        typ.jsonToJS = map;
+    }
+    return typ.jsonToJS;
 }
 
 function jsToJSONProps(typ: any): any {
-  if (typ.jsToJSON === undefined) {
-    const map: any = {};
-    typ.props.forEach((p: any) => (map[p.js] = { key: p.json, typ: p.typ }));
-    typ.jsToJSON = map;
-  }
-  return typ.jsToJSON;
+    if (typ.jsToJSON === undefined) {
+        const map: any = {};
+        typ.props.forEach((p: any) => map[p.js] = { key: p.json, typ: p.typ });
+        typ.jsToJSON = map;
+    }
+    return typ.jsToJSON;
 }
 
-function transform(
-  val: any,
-  typ: any,
-  getProps: any,
-  key: any = "",
-  parent: any = ""
-): any {
-  function transformPrimitive(typ: string, val: any): any {
-    if (typeof typ === typeof val) return val;
-    return invalidValue(typ, val, key, parent);
-  }
-
-  function transformUnion(typs: any[], val: any): any {
-    // val must validate against one typ in typs
-    const l = typs.length;
-    for (let i = 0; i < l; i++) {
-      const typ = typs[i];
-      try {
-        return transform(val, typ, getProps);
-      } catch (_) {}
+function transform(val: any, typ: any, getProps: any, key: any = '', parent: any = ''): any {
+    function transformPrimitive(typ: string, val: any): any {
+        if (typeof typ === typeof val) return val;
+        return invalidValue(typ, val, key, parent);
     }
-    return invalidValue(typs, val, key, parent);
-  }
 
-  function transformEnum(cases: string[], val: any): any {
-    if (cases.indexOf(val) !== -1) return val;
-    return invalidValue(
-      cases.map((a) => {
-        return l(a);
-      }),
-      val,
-      key,
-      parent
-    );
-  }
-
-  function transformArray(typ: any, val: any): any {
-    // val must be an array with no invalid elements
-    if (!Array.isArray(val)) return invalidValue(l("array"), val, key, parent);
-    return val.map((el) => transform(el, typ, getProps));
-  }
-
-  function transformDate(val: any): any {
-    if (val === null) {
-      return null;
+    function transformUnion(typs: any[], val: any): any {
+        // val must validate against one typ in typs
+        const l = typs.length;
+        for (let i = 0; i < l; i++) {
+            const typ = typs[i];
+            try {
+                return transform(val, typ, getProps);
+            } catch (_) {}
+        }
+        return invalidValue(typs, val, key, parent);
     }
-    const d = new Date(val);
-    if (isNaN(d.valueOf())) {
-      return invalidValue(l("Date"), val, key, parent);
-    }
-    return d;
-  }
 
-  function transformObject(
-    props: { [k: string]: any },
-    additional: any,
-    val: any
-  ): any {
-    if (val === null || typeof val !== "object" || Array.isArray(val)) {
-      return invalidValue(l(ref || "object"), val, key, parent);
+    function transformEnum(cases: string[], val: any): any {
+        if (cases.indexOf(val) !== -1) return val;
+        return invalidValue(cases.map(a => { return l(a); }), val, key, parent);
     }
-    const result: any = {};
-    Object.getOwnPropertyNames(props).forEach((key) => {
-      const prop = props[key];
-      const v = Object.prototype.hasOwnProperty.call(val, key)
-        ? val[key]
-        : undefined;
-      result[prop.key] = transform(v, prop.typ, getProps, key, ref);
-    });
-    Object.getOwnPropertyNames(val).forEach((key) => {
-      if (!Object.prototype.hasOwnProperty.call(props, key)) {
-        result[key] = transform(val[key], additional, getProps, key, ref);
-      }
-    });
-    return result;
-  }
 
-  if (typ === "any") return val;
-  if (typ === null) {
-    if (val === null) return val;
-    return invalidValue(typ, val, key, parent);
-  }
-  if (typ === false) return invalidValue(typ, val, key, parent);
-  let ref: any = undefined;
-  while (typeof typ === "object" && typ.ref !== undefined) {
-    ref = typ.ref;
-    typ = typeMap[typ.ref];
-  }
-  if (Array.isArray(typ)) return transformEnum(typ, val);
-  if (typeof typ === "object") {
-    return typ.hasOwnProperty("unionMembers")
-      ? transformUnion(typ.unionMembers, val)
-      : typ.hasOwnProperty("arrayItems")
-      ? transformArray(typ.arrayItems, val)
-      : typ.hasOwnProperty("props")
-      ? transformObject(getProps(typ), typ.additional, val)
-      : invalidValue(typ, val, key, parent);
-  }
-  // Numbers can be parsed by Date but shouldn't be.
-  if (typ === Date && typeof val !== "number") return transformDate(val);
-  return transformPrimitive(typ, val);
+    function transformArray(typ: any, val: any): any {
+        // val must be an array with no invalid elements
+        if (!Array.isArray(val)) return invalidValue(l("array"), val, key, parent);
+        return val.map(el => transform(el, typ, getProps));
+    }
+
+    function transformDate(val: any): any {
+        if (val === null) {
+            return null;
+        }
+        const d = new Date(val);
+        if (isNaN(d.valueOf())) {
+            return invalidValue(l("Date"), val, key, parent);
+        }
+        return d;
+    }
+
+    function transformObject(props: { [k: string]: any }, additional: any, val: any): any {
+        if (val === null || typeof val !== "object" || Array.isArray(val)) {
+            return invalidValue(l(ref || "object"), val, key, parent);
+        }
+        const result: any = {};
+        Object.getOwnPropertyNames(props).forEach(key => {
+            const prop = props[key];
+            const v = Object.prototype.hasOwnProperty.call(val, key) ? val[key] : undefined;
+            result[prop.key] = transform(v, prop.typ, getProps, key, ref);
+        });
+        Object.getOwnPropertyNames(val).forEach(key => {
+            if (!Object.prototype.hasOwnProperty.call(props, key)) {
+                result[key] = transform(val[key], additional, getProps, key, ref);
+            }
+        });
+        return result;
+    }
+
+    if (typ === "any") return val;
+    if (typ === null) {
+        if (val === null) return val;
+        return invalidValue(typ, val, key, parent);
+    }
+    if (typ === false) return invalidValue(typ, val, key, parent);
+    let ref: any = undefined;
+    while (typeof typ === "object" && typ.ref !== undefined) {
+        ref = typ.ref;
+        typ = typeMap[typ.ref];
+    }
+    if (Array.isArray(typ)) return transformEnum(typ, val);
+    if (typeof typ === "object") {
+        return typ.hasOwnProperty("unionMembers") ? transformUnion(typ.unionMembers, val)
+            : typ.hasOwnProperty("arrayItems")    ? transformArray(typ.arrayItems, val)
+            : typ.hasOwnProperty("props")         ? transformObject(getProps(typ), typ.additional, val)
+            : invalidValue(typ, val, key, parent);
+    }
+    // Numbers can be parsed by Date but shouldn't be.
+    if (typ === Date && typeof val !== "number") return transformDate(val);
+    return transformPrimitive(typ, val);
 }
 
 function cast<T>(val: any, typ: any): T {
-  return transform(val, typ, jsonToJSProps);
+    return transform(val, typ, jsonToJSProps);
 }
 
 function uncast<T>(val: T, typ: any): any {
-  return transform(val, typ, jsToJSONProps);
+    return transform(val, typ, jsToJSONProps);
 }
 
 function l(typ: any) {
-  return { literal: typ };
+    return { literal: typ };
 }
 
 function a(typ: any) {
-  return { arrayItems: typ };
+    return { arrayItems: typ };
 }
 
 function u(...typs: any[]) {
-  return { unionMembers: typs };
+    return { unionMembers: typs };
 }
 
 function o(props: any[], additional: any) {
-  return { props, additional };
+    return { props, additional };
 }
 
 function m(additional: any) {
-  return { props: [], additional };
+    return { props: [], additional };
 }
 
 function r(name: string) {
-  return { ref: name };
+    return { ref: name };
 }
 
 const typeMap: any = {
-  CardbacksRequest: o(
-    [
-      {
-        json: "searchSettings",
-        js: "searchSettings",
-        typ: r("SearchSettings"),
-      },
+    "ArtistsResponse": o([
+        { json: "artists", js: "artists", typ: a("") },
+    ], false),
+    "CardbacksRequest": o([
+        { json: "searchSettings", js: "searchSettings", typ: r("SearchSettings") },
+    ], false),
+    "SearchSettings": o([
+        { json: "filterSettings", js: "filterSettings", typ: r("FilterSettings") },
+        { json: "searchTypeSettings", js: "searchTypeSettings", typ: r("SearchTypeSettings") },
+        { json: "sourceSettings", js: "sourceSettings", typ: r("SourceSettings") },
+    ], false),
+    "FilterSettings": o([
+        { json: "excludesTags", js: "excludesTags", typ: a("") },
+        { json: "includesTags", js: "includesTags", typ: a("") },
+        { json: "languages", js: "languages", typ: a("") },
+        { json: "maximumDPI", js: "maximumDPI", typ: 0 },
+        { json: "maximumSize", js: "maximumSize", typ: 0 },
+        { json: "minimumDPI", js: "minimumDPI", typ: 0 },
+    ], false),
+    "SearchTypeSettings": o([
+        { json: "filterCardbacks", js: "filterCardbacks", typ: true },
+        { json: "fuzzySearch", js: "fuzzySearch", typ: true },
+    ], false),
+    "SourceSettings": o([
+        { json: "sources", js: "sources", typ: a(a(u(true, 0))) },
+    ], false),
+    "CardbacksResponse": o([
+        { json: "cardbacks", js: "cardbacks", typ: a("") },
+    ], false),
+    "CardsRequest": o([
+        { json: "cardIdentifiers", js: "cardIdentifiers", typ: a("") },
+    ], false),
+    "CardsResponse": o([
+        { json: "results", js: "results", typ: m(r("Card")) },
+    ], false),
+    "Card": o([
+        { json: "canonicalArtist", js: "canonicalArtist", typ: u(undefined, u(r("CanonicalArtist"), null)) },
+        { json: "canonicalCard", js: "canonicalCard", typ: u(undefined, u(r("CanonicalCard"), null)) },
+        { json: "cardType", js: "cardType", typ: r("CardType") },
+        { json: "dateCreated", js: "dateCreated", typ: "" },
+        { json: "dateModified", js: "dateModified", typ: "" },
+        { json: "dpi", js: "dpi", typ: 0 },
+        { json: "extension", js: "extension", typ: "" },
+        { json: "identifier", js: "identifier", typ: "" },
+        { json: "language", js: "language", typ: "" },
+        { json: "mediumThumbnailUrl", js: "mediumThumbnailUrl", typ: "" },
+        { json: "name", js: "name", typ: "" },
+        { json: "priority", js: "priority", typ: 0 },
+        { json: "searchq", js: "searchq", typ: "" },
+        { json: "size", js: "size", typ: 0 },
+        { json: "smallThumbnailUrl", js: "smallThumbnailUrl", typ: "" },
+        { json: "source", js: "source", typ: "" },
+        { json: "sourceExternalLink", js: "sourceExternalLink", typ: u(undefined, "") },
+        { json: "sourceId", js: "sourceId", typ: 0 },
+        { json: "sourceName", js: "sourceName", typ: "" },
+        { json: "sourceType", js: "sourceType", typ: u(undefined, r("SourceType")) },
+        { json: "sourceVerbose", js: "sourceVerbose", typ: "" },
+        { json: "tags", js: "tags", typ: a("") },
+    ], false),
+    "CanonicalArtist": o([
+        { json: "name", js: "name", typ: "" },
+    ], false),
+    "CanonicalCard": o([
+        { json: "artist", js: "artist", typ: u(undefined, "") },
+        { json: "canonicalId", js: "canonicalId", typ: u(undefined, "") },
+        { json: "collectorNumber", js: "collectorNumber", typ: "" },
+        { json: "expansionCode", js: "expansionCode", typ: "" },
+        { json: "expansionName", js: "expansionName", typ: "" },
+        { json: "identifier", js: "identifier", typ: "" },
+        { json: "mediumThumbnailUrl", js: "mediumThumbnailUrl", typ: "" },
+        { json: "smallThumbnailUrl", js: "smallThumbnailUrl", typ: "" },
+    ], false),
+    "ContributionsResponse": o([
+        { json: "cardCountByType", js: "cardCountByType", typ: m(0) },
+        { json: "sources", js: "sources", typ: a(r("SourceContribution")) },
+        { json: "totalDatabaseSize", js: "totalDatabaseSize", typ: 0 },
+    ], false),
+    "SourceContribution": o([
+        { json: "avgdpi", js: "avgdpi", typ: "" },
+        { json: "description", js: "description", typ: "" },
+        { json: "externalLink", js: "externalLink", typ: u(undefined, "") },
+        { json: "name", js: "name", typ: "" },
+        { json: "qtyCardbacks", js: "qtyCardbacks", typ: "" },
+        { json: "qtyCards", js: "qtyCards", typ: "" },
+        { json: "qtyTokens", js: "qtyTokens", typ: "" },
+        { json: "size", js: "size", typ: "" },
+        { json: "sourceType", js: "sourceType", typ: r("SourceType") },
+    ], false),
+    "DFCPairsResponse": o([
+        { json: "dfcPairs", js: "dfcPairs", typ: m("") },
+    ], false),
+    "EditorSearchRequest": o([
+        { json: "queries", js: "queries", typ: m(r("SearchQuery")) },
+        { json: "searchSettings", js: "searchSettings", typ: r("SearchSettings") },
+    ], false),
+    "SearchQuery": o([
+        { json: "cardType", js: "cardType", typ: r("CardType") },
+        { json: "collectorNumber", js: "collectorNumber", typ: u(undefined, "") },
+        { json: "expansionCode", js: "expansionCode", typ: u(undefined, "") },
+        { json: "query", js: "query", typ: u(null, "") },
+    ], false),
+    "EditorSearchResponse": o([
+        { json: "results", js: "results", typ: m(a("")) },
+    ], false),
+    "ErrorResponse": o([
+        { json: "errors", js: "errors", typ: u(undefined, a(m("any"))) },
+        { json: "message", js: "message", typ: u(undefined, "") },
+        { json: "name", js: "name", typ: "" },
+    ], false),
+    "ExploreSearchRequest": o([
+        { json: "artists", js: "artists", typ: u(undefined, u(a(""), null)) },
+        { json: "cardTypes", js: "cardTypes", typ: a(r("CardType")) },
+        { json: "pageSize", js: "pageSize", typ: 0 },
+        { json: "pageStart", js: "pageStart", typ: 0 },
+        { json: "query", js: "query", typ: u(null, "") },
+        { json: "searchSettings", js: "searchSettings", typ: r("SearchSettings") },
+        { json: "sortBy", js: "sortBy", typ: r("SortBy") },
+    ], false),
+    "ExploreSearchResponse": o([
+        { json: "cards", js: "cards", typ: a(r("Card")) },
+        { json: "count", js: "count", typ: 0 },
+    ], false),
+    "ImportSiteDecklistRequest": o([
+        { json: "url", js: "url", typ: "" },
+    ], false),
+    "ImportSiteDecklistResponse": o([
+        { json: "cards", js: "cards", typ: "" },
+    ], false),
+    "ImportSitesResponse": o([
+        { json: "importSites", js: "importSites", typ: a(r("ImportSite")) },
+    ], false),
+    "ImportSite": o([
+        { json: "name", js: "name", typ: "" },
+        { json: "url", js: "url", typ: "" },
+    ], false),
+    "InfoResponse": o([
+        { json: "info", js: "info", typ: r("Info") },
+    ], false),
+    "Info": o([
+        { json: "description", js: "description", typ: u(null, "") },
+        { json: "discord", js: "discord", typ: u(null, "") },
+        { json: "email", js: "email", typ: u(null, "") },
+        { json: "name", js: "name", typ: u(null, "") },
+        { json: "reddit", js: "reddit", typ: u(null, "") },
+    ], false),
+    "LanguagesResponse": o([
+        { json: "languages", js: "languages", typ: a(r("Language")) },
+    ], false),
+    "Language": o([
+        { json: "code", js: "code", typ: "" },
+        { json: "name", js: "name", typ: "" },
+    ], false),
+    "NewCardsFirstPagesResponse": o([
+        { json: "results", js: "results", typ: m(r("NewCardsFirstPage")) },
+    ], false),
+    "NewCardsFirstPage": o([
+        { json: "cards", js: "cards", typ: a(r("Card")) },
+        { json: "hits", js: "hits", typ: 0 },
+        { json: "pages", js: "pages", typ: 0 },
+        { json: "source", js: "source", typ: r("Source") },
+    ], false),
+    "Source": o([
+        { json: "description", js: "description", typ: "" },
+        { json: "externalLink", js: "externalLink", typ: u(undefined, "") },
+        { json: "key", js: "key", typ: "" },
+        { json: "name", js: "name", typ: "" },
+        { json: "pk", js: "pk", typ: 0 },
+        { json: "sourceType", js: "sourceType", typ: r("SourceType") },
+    ], false),
+    "NewCardsPageResponse": o([
+        { json: "cards", js: "cards", typ: a(r("Card")) },
+    ], false),
+    "OldEditorSearchRequest": o([
+        { json: "queries", js: "queries", typ: a(r("SearchQuery")) },
+        { json: "searchSettings", js: "searchSettings", typ: r("SearchSettings") },
+    ], false),
+    "OldEditorSearchResponse": o([
+        { json: "results", js: "results", typ: m(m(a(""))) },
+    ], false),
+    "PatreonResponse": o([
+        { json: "patreon", js: "patreon", typ: r("Patreon") },
+    ], false),
+    "Patreon": o([
+        { json: "campaign", js: "campaign", typ: u(r("Campaign"), null) },
+        { json: "members", js: "members", typ: a(r("Supporter")) },
+        { json: "tiers", js: "tiers", typ: u(m(r("SupporterTier")), null) },
+        { json: "url", js: "url", typ: u(null, "") },
+    ], false),
+    "Campaign": o([
+        { json: "about", js: "about", typ: "" },
+        { json: "id", js: "id", typ: "" },
+    ], false),
+    "Supporter": o([
+        { json: "date", js: "date", typ: "" },
+        { json: "name", js: "name", typ: "" },
+        { json: "tier", js: "tier", typ: "" },
+        { json: "usd", js: "usd", typ: 3.14 },
+    ], false),
+    "SupporterTier": o([
+        { json: "description", js: "description", typ: "" },
+        { json: "title", js: "title", typ: "" },
+        { json: "usd", js: "usd", typ: 3.14 },
+    ], false),
+    "SampleCardsResponse": o([
+        { json: "cards", js: "cards", typ: r("Cards") },
+    ], "any"),
+    "Cards": o([
+        { json: "CARD", js: "CARD", typ: a(r("Card")) },
+        { json: "CARDBACK", js: "CARDBACK", typ: a(r("Card")) },
+        { json: "TOKEN", js: "TOKEN", typ: a(r("Card")) },
+    ], "any"),
+    "SearchEngineHealthResponse": o([
+        { json: "online", js: "online", typ: true },
+    ], false),
+    "SourcesResponse": o([
+        { json: "results", js: "results", typ: m(r("Source")) },
+    ], false),
+    "TagsResponse": o([
+        { json: "tags", js: "tags", typ: a(r("Tag")) },
+    ], false),
+    "Tag": o([
+        { json: "aliases", js: "aliases", typ: u(undefined, a("")) },
+        { json: "children", js: "children", typ: a(r("ChildElement")) },
+        { json: "isEnabledByDefault", js: "isEnabledByDefault", typ: u(undefined, true) },
+        { json: "name", js: "name", typ: "" },
+        { json: "parent", js: "parent", typ: u(null, "") },
+    ], false),
+    "ChildElement": o([
+        { json: "aliases", js: "aliases", typ: u(undefined, a("")) },
+        { json: "children", js: "children", typ: a(r("ChildElement")) },
+        { json: "isEnabledByDefault", js: "isEnabledByDefault", typ: u(undefined, true) },
+        { json: "name", js: "name", typ: "" },
+        { json: "parent", js: "parent", typ: u(null, "") },
+    ], false),
+    "Game": [
+        "MTG",
     ],
-    false
-  ),
-  SearchSettings: o(
-    [
-      {
-        json: "filterSettings",
-        js: "filterSettings",
-        typ: r("FilterSettings"),
-      },
-      {
-        json: "searchTypeSettings",
-        js: "searchTypeSettings",
-        typ: r("SearchTypeSettings"),
-      },
-      {
-        json: "sourceSettings",
-        js: "sourceSettings",
-        typ: r("SourceSettings"),
-      },
+    "CardType": [
+        "CARD",
+        "CARDBACK",
+        "TOKEN",
     ],
-    false
-  ),
-  FilterSettings: o(
-    [
-      { json: "excludesTags", js: "excludesTags", typ: a("") },
-      { json: "includesTags", js: "includesTags", typ: a("") },
-      { json: "languages", js: "languages", typ: a("") },
-      { json: "maximumDPI", js: "maximumDPI", typ: 0 },
-      { json: "maximumSize", js: "maximumSize", typ: 0 },
-      { json: "minimumDPI", js: "minimumDPI", typ: 0 },
+    "SourceType": [
+        "AWS S3",
+        "Google Drive",
+        "Local File",
     ],
-    false
-  ),
-  SearchTypeSettings: o(
-    [
-      { json: "filterCardbacks", js: "filterCardbacks", typ: true },
-      { json: "fuzzySearch", js: "fuzzySearch", typ: true },
+    "SortBy": [
+        "dateCreatedAscending",
+        "dateCreatedDescending",
+        "dateModifiedAscending",
+        "dateModifiedDescending",
+        "nameAscending",
+        "nameDescending",
     ],
-    false
-  ),
-  SourceSettings: o(
-    [{ json: "sources", js: "sources", typ: a(a(u(true, 0))) }],
-    false
-  ),
-  CardbacksResponse: o(
-    [{ json: "cardbacks", js: "cardbacks", typ: a("") }],
-    false
-  ),
-  CardsRequest: o(
-    [{ json: "cardIdentifiers", js: "cardIdentifiers", typ: a("") }],
-    false
-  ),
-  CardsResponse: o(
-    [{ json: "results", js: "results", typ: m(r("Card")) }],
-    false
-  ),
-  Card: o(
-    [
-      {
-        json: "canonicalArtist",
-        js: "canonicalArtist",
-        typ: u(undefined, u(r("CanonicalArtist"), null)),
-      },
-      {
-        json: "canonicalCard",
-        js: "canonicalCard",
-        typ: u(undefined, u(r("CanonicalCard"), null)),
-      },
-      { json: "cardType", js: "cardType", typ: r("CardType") },
-      { json: "dateCreated", js: "dateCreated", typ: "" },
-      { json: "dateModified", js: "dateModified", typ: "" },
-      { json: "dpi", js: "dpi", typ: 0 },
-      { json: "extension", js: "extension", typ: "" },
-      { json: "identifier", js: "identifier", typ: "" },
-      { json: "language", js: "language", typ: "" },
-      { json: "mediumThumbnailUrl", js: "mediumThumbnailUrl", typ: "" },
-      { json: "name", js: "name", typ: "" },
-      { json: "priority", js: "priority", typ: 0 },
-      { json: "searchq", js: "searchq", typ: "" },
-      { json: "size", js: "size", typ: 0 },
-      { json: "smallThumbnailUrl", js: "smallThumbnailUrl", typ: "" },
-      { json: "source", js: "source", typ: "" },
-      {
-        json: "sourceExternalLink",
-        js: "sourceExternalLink",
-        typ: u(undefined, ""),
-      },
-      { json: "sourceId", js: "sourceId", typ: 0 },
-      { json: "sourceName", js: "sourceName", typ: "" },
-      {
-        json: "sourceType",
-        js: "sourceType",
-        typ: u(undefined, r("SourceType")),
-      },
-      { json: "sourceVerbose", js: "sourceVerbose", typ: "" },
-      { json: "tags", js: "tags", typ: a("") },
-    ],
-    false
-  ),
-  CanonicalArtist: o([{ json: "name", js: "name", typ: "" }], false),
-  CanonicalCard: o(
-    [
-      { json: "artist", js: "artist", typ: u(undefined, "") },
-      { json: "canonicalId", js: "canonicalId", typ: u(undefined, "") },
-      { json: "collectorNumber", js: "collectorNumber", typ: "" },
-      { json: "expansionCode", js: "expansionCode", typ: "" },
-      { json: "expansionName", js: "expansionName", typ: "" },
-      { json: "identifier", js: "identifier", typ: "" },
-      { json: "mediumThumbnailUrl", js: "mediumThumbnailUrl", typ: "" },
-      { json: "smallThumbnailUrl", js: "smallThumbnailUrl", typ: "" },
-    ],
-    false
-  ),
-  ContributionsResponse: o(
-    [
-      { json: "cardCountByType", js: "cardCountByType", typ: m(0) },
-      { json: "sources", js: "sources", typ: a(r("SourceContribution")) },
-      { json: "totalDatabaseSize", js: "totalDatabaseSize", typ: 0 },
-    ],
-    false
-  ),
-  SourceContribution: o(
-    [
-      { json: "avgdpi", js: "avgdpi", typ: "" },
-      { json: "description", js: "description", typ: "" },
-      { json: "externalLink", js: "externalLink", typ: u(undefined, "") },
-      { json: "name", js: "name", typ: "" },
-      { json: "qtyCardbacks", js: "qtyCardbacks", typ: "" },
-      { json: "qtyCards", js: "qtyCards", typ: "" },
-      { json: "qtyTokens", js: "qtyTokens", typ: "" },
-      { json: "size", js: "size", typ: "" },
-      { json: "sourceType", js: "sourceType", typ: r("SourceType") },
-    ],
-    false
-  ),
-  DFCPairsResponse: o(
-    [{ json: "dfcPairs", js: "dfcPairs", typ: m("") }],
-    false
-  ),
-  EditorSearchRequest: o(
-    [
-      { json: "queries", js: "queries", typ: m(r("SearchQuery")) },
-      {
-        json: "searchSettings",
-        js: "searchSettings",
-        typ: r("SearchSettings"),
-      },
-    ],
-    false
-  ),
-  SearchQuery: o(
-    [
-      { json: "cardType", js: "cardType", typ: r("CardType") },
-      { json: "collectorNumber", js: "collectorNumber", typ: u(undefined, "") },
-      { json: "expansionCode", js: "expansionCode", typ: u(undefined, "") },
-      { json: "query", js: "query", typ: u(null, "") },
-    ],
-    false
-  ),
-  EditorSearchResponse: o(
-    [{ json: "results", js: "results", typ: m(a("")) }],
-    false
-  ),
-  ErrorResponse: o(
-    [
-      { json: "errors", js: "errors", typ: u(undefined, a(m("any"))) },
-      { json: "message", js: "message", typ: u(undefined, "") },
-      { json: "name", js: "name", typ: "" },
-    ],
-    false
-  ),
-  ExploreSearchRequest: o(
-    [
-      { json: "cardTypes", js: "cardTypes", typ: a(r("CardType")) },
-      { json: "pageSize", js: "pageSize", typ: 0 },
-      { json: "pageStart", js: "pageStart", typ: 0 },
-      { json: "query", js: "query", typ: u(null, "") },
-      {
-        json: "searchSettings",
-        js: "searchSettings",
-        typ: r("SearchSettings"),
-      },
-      { json: "sortBy", js: "sortBy", typ: r("SortBy") },
-    ],
-    false
-  ),
-  ExploreSearchResponse: o(
-    [
-      { json: "cards", js: "cards", typ: a(r("Card")) },
-      { json: "count", js: "count", typ: 0 },
-    ],
-    false
-  ),
-  ImportSiteDecklistRequest: o([{ json: "url", js: "url", typ: "" }], false),
-  ImportSiteDecklistResponse: o(
-    [{ json: "cards", js: "cards", typ: "" }],
-    false
-  ),
-  ImportSitesResponse: o(
-    [{ json: "importSites", js: "importSites", typ: a(r("ImportSite")) }],
-    false
-  ),
-  ImportSite: o(
-    [
-      { json: "name", js: "name", typ: "" },
-      { json: "url", js: "url", typ: "" },
-    ],
-    false
-  ),
-  InfoResponse: o([{ json: "info", js: "info", typ: r("Info") }], false),
-  Info: o(
-    [
-      { json: "description", js: "description", typ: u(null, "") },
-      { json: "discord", js: "discord", typ: u(null, "") },
-      { json: "email", js: "email", typ: u(null, "") },
-      { json: "name", js: "name", typ: u(null, "") },
-      { json: "reddit", js: "reddit", typ: u(null, "") },
-    ],
-    false
-  ),
-  LanguagesResponse: o(
-    [{ json: "languages", js: "languages", typ: a(r("Language")) }],
-    false
-  ),
-  Language: o(
-    [
-      { json: "code", js: "code", typ: "" },
-      { json: "name", js: "name", typ: "" },
-    ],
-    false
-  ),
-  NewCardsFirstPagesResponse: o(
-    [{ json: "results", js: "results", typ: m(r("NewCardsFirstPage")) }],
-    false
-  ),
-  NewCardsFirstPage: o(
-    [
-      { json: "cards", js: "cards", typ: a(r("Card")) },
-      { json: "hits", js: "hits", typ: 0 },
-      { json: "pages", js: "pages", typ: 0 },
-      { json: "source", js: "source", typ: r("Source") },
-    ],
-    false
-  ),
-  Source: o(
-    [
-      { json: "description", js: "description", typ: "" },
-      { json: "externalLink", js: "externalLink", typ: u(undefined, "") },
-      { json: "key", js: "key", typ: "" },
-      { json: "name", js: "name", typ: "" },
-      { json: "pk", js: "pk", typ: 0 },
-      { json: "sourceType", js: "sourceType", typ: r("SourceType") },
-    ],
-    false
-  ),
-  NewCardsPageResponse: o(
-    [{ json: "cards", js: "cards", typ: a(r("Card")) }],
-    false
-  ),
-  OldEditorSearchRequest: o(
-    [
-      { json: "queries", js: "queries", typ: a(r("SearchQuery")) },
-      {
-        json: "searchSettings",
-        js: "searchSettings",
-        typ: r("SearchSettings"),
-      },
-    ],
-    false
-  ),
-  OldEditorSearchResponse: o(
-    [{ json: "results", js: "results", typ: m(m(a(""))) }],
-    false
-  ),
-  PatreonResponse: o(
-    [{ json: "patreon", js: "patreon", typ: r("Patreon") }],
-    false
-  ),
-  Patreon: o(
-    [
-      { json: "campaign", js: "campaign", typ: u(r("Campaign"), null) },
-      { json: "members", js: "members", typ: a(r("Supporter")) },
-      { json: "tiers", js: "tiers", typ: u(m(r("SupporterTier")), null) },
-      { json: "url", js: "url", typ: u(null, "") },
-    ],
-    false
-  ),
-  Campaign: o(
-    [
-      { json: "about", js: "about", typ: "" },
-      { json: "id", js: "id", typ: "" },
-    ],
-    false
-  ),
-  Supporter: o(
-    [
-      { json: "date", js: "date", typ: "" },
-      { json: "name", js: "name", typ: "" },
-      { json: "tier", js: "tier", typ: "" },
-      { json: "usd", js: "usd", typ: 3.14 },
-    ],
-    false
-  ),
-  SupporterTier: o(
-    [
-      { json: "description", js: "description", typ: "" },
-      { json: "title", js: "title", typ: "" },
-      { json: "usd", js: "usd", typ: 3.14 },
-    ],
-    false
-  ),
-  SampleCardsResponse: o(
-    [{ json: "cards", js: "cards", typ: r("Cards") }],
-    "any"
-  ),
-  Cards: o(
-    [
-      { json: "CARD", js: "CARD", typ: a(r("Card")) },
-      { json: "CARDBACK", js: "CARDBACK", typ: a(r("Card")) },
-      { json: "TOKEN", js: "TOKEN", typ: a(r("Card")) },
-    ],
-    "any"
-  ),
-  SearchEngineHealthResponse: o(
-    [{ json: "online", js: "online", typ: true }],
-    false
-  ),
-  SourcesResponse: o(
-    [{ json: "results", js: "results", typ: m(r("Source")) }],
-    false
-  ),
-  TagsResponse: o([{ json: "tags", js: "tags", typ: a(r("Tag")) }], false),
-  Tag: o(
-    [
-      { json: "aliases", js: "aliases", typ: u(undefined, a("")) },
-      { json: "children", js: "children", typ: a(r("ChildElement")) },
-      {
-        json: "isEnabledByDefault",
-        js: "isEnabledByDefault",
-        typ: u(undefined, true),
-      },
-      { json: "name", js: "name", typ: "" },
-      { json: "parent", js: "parent", typ: u(null, "") },
-    ],
-    false
-  ),
-  ChildElement: o(
-    [
-      { json: "aliases", js: "aliases", typ: u(undefined, a("")) },
-      { json: "children", js: "children", typ: a(r("ChildElement")) },
-      {
-        json: "isEnabledByDefault",
-        js: "isEnabledByDefault",
-        typ: u(undefined, true),
-      },
-      { json: "name", js: "name", typ: "" },
-      { json: "parent", js: "parent", typ: u(null, "") },
-    ],
-    false
-  ),
-  Game: ["MTG"],
-  CardType: ["CARD", "CARDBACK", "TOKEN"],
-  SourceType: ["AWS S3", "Google Drive", "Local File"],
-  SortBy: [
-    "dateCreatedAscending",
-    "dateCreatedDescending",
-    "dateModifiedAscending",
-    "dateModifiedDescending",
-    "nameAscending",
-    "nameDescending",
-  ],
 };

--- a/frontend/src/features/clientSearch/clientSearchService.ts
+++ b/frontend/src/features/clientSearch/clientSearchService.ts
@@ -248,7 +248,8 @@ export class ClientSearchService {
     cardTypes: Array<CardType>,
     searchSettings: SearchSettings,
     pageStart: number,
-    pageSize: number
+    pageSize: number,
+    artists?: Array<string>
   ): Promise<{ cards: Array<CardDocument>; count: number }> {
     if (this.worker === undefined) {
       throw new Error("clientSearchService was not initialised!");
@@ -259,7 +260,8 @@ export class ClientSearchService {
       cardTypes,
       searchSettings,
       pageStart,
-      pageSize
+      pageSize,
+      artists
     );
   }
 

--- a/frontend/src/features/clientSearch/clientSearchService.worker.ts
+++ b/frontend/src/features/clientSearch/clientSearchService.worker.ts
@@ -258,7 +258,8 @@ export class ClientSearchService {
     cardTypes: Array<CardType>,
     sortBy?: SortBy,
     limit?: number,
-    offset?: number
+    offset?: number,
+    artists?: Array<string>
   ): OramaSearchResults | undefined {
     return [this.localFilesIndex?.index, this.googleDriveIndex?.index].reduce(
       (
@@ -275,7 +276,9 @@ export class ClientSearchService {
           cardTypes,
           sortBy,
           limit,
-          offset
+          offset,
+          undefined,
+          artists
         );
         return {
           hits: accumulated.hits.concat(searchResults?.hits ?? []),
@@ -415,7 +418,8 @@ export class ClientSearchService {
     cardTypes: Array<CardType>,
     searchSettings: SearchSettings,
     pageStart: number,
-    pageSize: number
+    pageSize: number,
+    artists?: Array<string>
   ): { cards: Array<CardDocument>; count: number } {
     const searchResults = this.search(
       searchSettings,
@@ -423,7 +427,8 @@ export class ClientSearchService {
       cardTypes,
       sortBy,
       pageSize,
-      pageStart
+      pageStart,
+      artists
     );
     const cardIds = searchResults?.hits?.map(({ id }) => id) ?? [];
     const cards = this.getCardDocumentsArray(cardIds);

--- a/frontend/src/features/explore/Explore.tsx
+++ b/frontend/src/features/explore/Explore.tsx
@@ -58,7 +58,8 @@ const useExploreSearchResults = (
           exploreSearchRequest.cardTypes,
           exploreSearchRequest.searchSettings,
           exploreSearchRequest.pageStart,
-          exploreSearchRequest.pageSize
+          exploreSearchRequest.pageSize,
+          exploreSearchRequest.artists ?? undefined
         )
         .then(setLocalResults);
     } else {
@@ -97,6 +98,7 @@ export function Explore() {
   const [backendType, setBackendType] = useState<BackendType>("remote");
   const [sortBy, setSortBy] = useState<SortBy>(SortBy.DateCreatedDescending);
   const [query, setQuery] = useState<string>("");
+  const [artist, setArtist] = useState<string>("");
   const [cardTypes, setCardTypes] = useState<Array<CardType>>([]);
   const [searchTypeSettings, setSearchTypeSettings] =
     useState<SearchTypeSettings>(defaultSettings.searchTypeSettings);
@@ -119,6 +121,7 @@ export function Explore() {
   }
   const setSortByAndResetPageStart = updateInputAndResetPageStart(setSortBy);
   const setQueryAndResetPageStart = updateInputAndResetPageStart(setQuery);
+  const setArtistAndResetPageStart = updateInputAndResetPageStart(setArtist);
   const setCardTypesAndResetPageStart =
     updateInputAndResetPageStart(setCardTypes);
   const setSearchTypeSettingsAndResetPageStart = updateInputAndResetPageStart(
@@ -145,6 +148,7 @@ export function Explore() {
       sourceSettings: sourceSettings,
     },
     query,
+    artists: artist.trim().length > 0 ? [artist.trim()] : null,
     cardTypes,
     pageStart,
     pageSize: ExplorePageSize,
@@ -193,6 +197,8 @@ export function Explore() {
           setSortBy={setSortByAndResetPageStart}
           searchQuery={query}
           setSearchQuery={setQueryAndResetPageStart}
+          artist={artist}
+          setArtist={setArtistAndResetPageStart}
           cardTypes={cardTypes}
           setCardTypes={setCardTypesAndResetPageStart}
           searchTypeSettings={searchTypeSettings}

--- a/frontend/src/features/explore/ExploreFilters.tsx
+++ b/frontend/src/features/explore/ExploreFilters.tsx
@@ -8,6 +8,7 @@ import {
   SortBy,
   SourceSettings,
 } from "@/common/types";
+import { ArtistFilter } from "@/features/filters/ArtistFilter";
 import { CardTypeFilter } from "@/features/filters/CardTypeFilter";
 import { CompressedFilter } from "@/features/filters/CompressedFilter";
 import { SearchQueryFilter } from "@/features/filters/SearchQueryFilter";
@@ -26,6 +27,8 @@ interface ExploreFiltersProps {
   setSortBy: (value: SortBy) => void;
   searchQuery: string;
   setSearchQuery: (value: string) => void;
+  artist: string;
+  setArtist: (value: string) => void;
   cardTypes: Array<CardType>;
   setCardTypes: (value: Array<CardType>) => void;
   searchTypeSettings: SearchTypeSettings;
@@ -45,6 +48,8 @@ export const ExploreFilters = ({
   setSortBy,
   searchQuery,
   setSearchQuery,
+  artist,
+  setArtist,
   cardTypes,
   setCardTypes,
   searchTypeSettings,
@@ -72,6 +77,7 @@ export const ExploreFilters = ({
         searchQuery={searchQuery}
         setSearchQuery={setSearchQuery}
       />
+      <ArtistFilter artist={artist} setArtist={setArtist} />
       <CardTypeFilter cardTypes={cardTypes} setCardTypes={setCardTypes} />
       <hr />
       <SearchTypeSettingsElement

--- a/frontend/src/features/filters/ArtistFilter.tsx
+++ b/frontend/src/features/filters/ArtistFilter.tsx
@@ -1,0 +1,36 @@
+import Form from "react-bootstrap/Form";
+
+import { useGetArtistsQuery } from "@/store/api";
+
+interface ArtistFilterProps {
+  artist: string;
+  setArtist: (value: string) => void;
+}
+
+/**
+ * A typeable artist filter. Suggestions come from the backend's list of
+ * canonical artists (when connected) via a native datalist, but any value
+ * can be typed freely.
+ */
+export const ArtistFilter = ({ artist, setArtist }: ArtistFilterProps) => {
+  const getArtistsQuery = useGetArtistsQuery();
+  const artistNames = getArtistsQuery.data ?? [];
+
+  return (
+    <Form.Group className="mb-2">
+      <Form.Label htmlFor="artist-filter">Artist</Form.Label>
+      <Form.Control
+        id="artist-filter"
+        list="artist-filter-suggestions"
+        value={artist}
+        onChange={(event) => setArtist(event.target.value)}
+        placeholder="Filter by artist..."
+      />
+      <datalist id="artist-filter-suggestions">
+        {artistNames.map((artistName) => (
+          <option key={artistName} value={artistName} />
+        ))}
+      </datalist>
+    </Form.Group>
+  );
+};

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -495,6 +495,42 @@ export const languagesTwoResults = http.get(buildRoute("2/languages/"), () =>
 
 //# endregion
 
+//# region artists
+
+export const artistsNoResults = http.get(buildRoute("2/artists/"), () =>
+  HttpResponse.json({ artists: [] }, { status: 200 })
+);
+
+export const artistsTwoResults = http.get(buildRoute("2/artists/"), () =>
+  HttpResponse.json(
+    { artists: ["Artist Alpha", "Artist Beta"] },
+    { status: 200 }
+  )
+);
+
+//# endregion
+
+//# region explore search
+
+export const exploreSearchThreeResultsFilterableByArtistAlpha = http.post(
+  buildRoute("2/exploreSearch/"),
+  async ({ request }) => {
+    const body = (await request.json()) as { artists?: Array<string> | null };
+    if ((body.artists ?? []).includes("Artist Alpha")) {
+      return HttpResponse.json(
+        { cards: [cardDocument1], count: 1 },
+        { status: 200 }
+      );
+    }
+    return HttpResponse.json(
+      { cards: [cardDocument1, cardDocument2, cardDocument3], count: 3 },
+      { status: 200 }
+    );
+  }
+);
+
+//# endregion
+
 //# region tags
 
 export const tagsNoResults = http.get(buildRoute("2/tags/"), () =>
@@ -664,6 +700,7 @@ export const defaultHandlers = [
   searchResultsNoResults,
   dfcPairsNoResults,
   languagesTwoResults,
+  artistsNoResults,
   tagsNoResults,
   importSitesOneResult,
   sampleCards,

--- a/frontend/src/store/api.ts
+++ b/frontend/src/store/api.ts
@@ -15,6 +15,7 @@ import {
   processQuery,
 } from "@/common/processing";
 import {
+  ArtistsResponse,
   Card,
   CardbacksResponse,
   CardsRequest,
@@ -107,6 +108,12 @@ export const api = createApi({
         );
       },
     }),
+    getArtists: builder.query<Array<string>, void>({
+      query: () => ({ url: `2/artists/`, method: "GET" }),
+      providesTags: [QueryTags.BackendSpecific],
+      transformResponse: (response: ArtistsResponse, meta, arg) =>
+        response.artists,
+    }),
     getLanguages: builder.query<Array<Language>, void>({
       query: () => ({ url: `2/languages/`, method: "GET" }),
       providesTags: [QueryTags.BackendSpecific],
@@ -198,6 +205,7 @@ const {
   useGetImportSitesQuery: useRawGetImportSitesQuery,
   useQueryImportSiteQuery: useRawQueryImportSiteQuery,
   useGetDFCPairsQuery: useRawGetDFCPairsQuery,
+  useGetArtistsQuery: useRawGetArtistsQuery,
   useGetLanguagesQuery: useRawGetLanguagesQuery,
   useGetTagsQuery: useRawGetTagsQuery,
   useGetSampleCardsQuery: useRawGetSampleCardsQuery,
@@ -219,6 +227,13 @@ export function useGetImportSitesQuery() {
 export function useGetDFCPairsQuery() {
   const remoteBackendConfigured = useRemoteBackendConfigured();
   return useRawGetDFCPairsQuery(undefined, {
+    skip: !remoteBackendConfigured,
+  });
+}
+
+export function useGetArtistsQuery() {
+  const remoteBackendConfigured = useRemoteBackendConfigured();
+  return useRawGetArtistsQuery(undefined, {
     skip: !remoteBackendConfigured,
   });
 }

--- a/frontend/tests/ExploreArtistFilter.spec.ts
+++ b/frontend/tests/ExploreArtistFilter.spec.ts
@@ -1,0 +1,59 @@
+import { expect } from "@playwright/test";
+
+import { cardDocument1, cardDocument2 } from "@/common/test-constants";
+import {
+  artistsTwoResults,
+  defaultHandlers,
+  exploreSearchThreeResultsFilterableByArtistAlpha,
+  sourceDocumentsOneResult,
+} from "@/mocks/handlers";
+
+import { test } from "../playwright.setup";
+import { loadPageWithDefaultBackend } from "./test-utils";
+
+test.describe("Explore artist filter", () => {
+  test("typing an artist filters explore results to their work", async ({
+    page,
+    network,
+  }) => {
+    network.use(
+      artistsTwoResults,
+      exploreSearchThreeResultsFilterableByArtistAlpha,
+      sourceDocumentsOneResult,
+      ...defaultHandlers
+    );
+    await loadPageWithDefaultBackend(page, "explore");
+
+    // unfiltered: all three cards
+    await expect(page.getByText("3 results")).toBeVisible();
+    await expect(page.getByText(cardDocument2.name)).toBeVisible();
+
+    // type an artist name into the artist filter
+    await page.getByRole("combobox", { name: "Artist" }).fill("Artist Alpha");
+
+    // filtered: only the card by that artist
+    await expect(page.getByText("1 result", { exact: false })).toBeVisible();
+    await expect(page.getByText(cardDocument1.name)).toBeVisible();
+    await expect(page.getByText(cardDocument2.name)).not.toBeVisible();
+  });
+
+  test("clearing the artist filter restores unfiltered results", async ({
+    page,
+    network,
+  }) => {
+    network.use(
+      artistsTwoResults,
+      exploreSearchThreeResultsFilterableByArtistAlpha,
+      sourceDocumentsOneResult,
+      ...defaultHandlers
+    );
+    await loadPageWithDefaultBackend(page, "explore");
+
+    const artistInput = page.getByRole("combobox", { name: "Artist" });
+    await artistInput.fill("Artist Alpha");
+    await expect(page.getByText("1 result", { exact: false })).toBeVisible();
+
+    await artistInput.clear();
+    await expect(page.getByText("3 results")).toBeVisible();
+  });
+});

--- a/schemas/schemas/endpoints/ArtistsResponse.json
+++ b/schemas/schemas/endpoints/ArtistsResponse.json
@@ -1,0 +1,15 @@
+{
+  "title": "Artists Response",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "artists": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "required": ["artists"],
+  "additionalProperties": false
+}

--- a/schemas/schemas/endpoints/ExploreSearchRequest.json
+++ b/schemas/schemas/endpoints/ExploreSearchRequest.json
@@ -9,6 +9,12 @@
     "query": {
       "type": ["string", "null"]
     },
+    "artists": {
+      "type": ["array", "null"],
+      "items": {
+        "type": "string"
+      }
+    },
     "cardTypes": {
       "type": "array",
       "items": {


### PR DESCRIPTION
## What this does

Adds a typeable **Artist** input to the Explore page that filters results to that artist's work, with autocomplete suggestions (native datalist — filter by typing rather than scrolling a dropdown). Works on both the remote backend and local (client search) paths.

## Implementation
- The canonical artist name is indexed as a new keyword field on the `cards` index — **deploying this requires a one-time `manage.py search_index --rebuild`**
- `ExploreSearchRequest` gains an optional `artists` field (schema types regenerated via the repo's quicktype setup); explore search filters on it
- New `GET /2/artists/` endpoint returns all canonical artist names for autocomplete
- Artists are threaded through the client search worker's explore path, which already supported artist filtering at the Orama level

## Testing
- 5 pytest cases against real Elasticsearch via testcontainers (explore filtered by artist, unknown artist, artists endpoint incl. empty DB and wrong-method cases)
- 2 Playwright e2e tests (typing an artist filters results; clearing restores them)

Related: #477 (fuzzy search fallback) touches some of the same search plumbing — whichever lands second will need a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)