### PR TITLE
Make backend test suite deterministic and credential-independent

### DIFF
--- a/MPCAutofill/cardpicker/tests/__snapshots__/test_views.ambr
+++ b/MPCAutofill/cardpicker/tests/__snapshots__/test_views.ambr
@@ -193,7 +193,7 @@
     'CARD': dict({
       'Brainstorm': dict({
         'canonicalArtist': dict({
-          'name': 'Artist 102',
+          'name': 'Artist 0',
         }),
         'canonicalCard': dict({
           'artist': None,
@@ -416,7 +416,7 @@
           'cards': list([
             dict({
               'canonicalArtist': dict({
-                'name': 'Artist 107',
+                'name': 'Artist 0',
               }),
               'canonicalCard': dict({
                 'artist': None,
@@ -702,7 +702,7 @@
       'cards': list([
         dict({
           'canonicalArtist': dict({
-            'name': 'Artist 109',
+            'name': 'Artist 0',
           }),
           'canonicalCard': dict({
             'artist': None,
@@ -2399,7 +2399,7 @@
       'cards': list([
         dict({
           'canonicalArtist': dict({
-            'name': 'Artist 67',
+            'name': 'Artist 0',
           }),
           'canonicalCard': dict({
             'artist': None,
@@ -2673,7 +2673,7 @@
       'cards': list([
         dict({
           'canonicalArtist': dict({
-            'name': 'Artist 66',
+            'name': 'Artist 0',
           }),
           'canonicalCard': dict({
             'artist': None,
@@ -3025,7 +3025,7 @@
       'cards': list([
         dict({
           'canonicalArtist': dict({
-            'name': 'Artist 68',
+            'name': 'Artist 0',
           }),
           'canonicalCard': dict({
             'artist': None,

--- a/MPCAutofill/cardpicker/tests/conftest.py
+++ b/MPCAutofill/cardpicker/tests/conftest.py
@@ -1,7 +1,9 @@
 import datetime as dt
+import inspect
 import uuid
 from typing import Type
 
+import factory as factory_boy
 import pytest
 from pytest_elasticsearch import factories
 from testcontainers.elasticsearch import ElasticSearchContainer
@@ -12,6 +14,7 @@ from django.core.management import call_command
 
 from cardpicker.integrations.game.base import GameIntegration
 from cardpicker.models import Card, CardTypes, DFCPair, Source, Tag
+from cardpicker.tests import factories as factories_module
 from cardpicker.tests.constants import Cards, DummyIntegration, Sources
 from cardpicker.tests.factories import (
     CanonicalCardFactory,
@@ -24,6 +27,18 @@ from cardpicker.tests.factories import (
 
 POSTGRES_PORT = 47000
 ELASTICSEARCH_PORT = 9300  # this is the default expected by `elasticsearch_nooproc`
+
+
+@pytest.fixture(autouse=True)
+def reset_factory_sequences() -> None:
+    """
+    Snapshots embed sequence-generated values (e.g. "Artist 0"), so sequences must restart for every test -
+    otherwise adding or running a subset of tests shifts the numbering and breaks unrelated snapshots.
+    """
+
+    for _, factory_class in inspect.getmembers(factories_module, inspect.isclass):
+        if issubclass(factory_class, factory_boy.django.DjangoModelFactory):
+            factory_class.reset_sequence(0)
 
 
 @pytest.fixture(scope="session")

--- a/MPCAutofill/cardpicker/tests/test_integrations.py
+++ b/MPCAutofill/cardpicker/tests/test_integrations.py
@@ -107,6 +107,8 @@ class TestMTGIntegration:
 
     @pytest.mark.parametrize("url", [item.value for item in Decks], ids=[item.name.lower() for item in Decks])
     def test_valid_url(self, client, django_settings, snapshot, url: str):
+        if "moxfield" in url and not conf_settings.MOXFIELD_SECRET:
+            pytest.skip("MOXFIELD_SECRET is not configured (e.g. fork PRs and environments without credentials)")
         decklist = MTGIntegration.query_import_site(url)
         assert decklist
         assert Counter(decklist.splitlines()) == snapshot

--- a/MPCAutofill/cardpicker/tests/test_sources.py
+++ b/MPCAutofill/cardpicker/tests/test_sources.py
@@ -1,4 +1,6 @@
 import datetime as dt
+import json
+from pathlib import Path
 
 import freezegun
 import pytest
@@ -19,6 +21,16 @@ from cardpicker.tests.factories import (
 )
 
 DEFAULT_DATE = dt.datetime(2023, 1, 1)
+
+
+def google_drive_credentials_available() -> bool:
+    # mirrors the path resolution in `cardpicker.sources.api`. fork PRs and local runs without
+    # credentials get a missing or unparseable client_secrets.json, so those tests must skip.
+    try:
+        with open(Path(__file__).parent.parent.parent / "client_secrets.json") as f:
+            return bool(json.load(f))
+    except (OSError, json.JSONDecodeError):
+        return False
 
 
 class TestAPI:
@@ -354,6 +366,10 @@ class TestAPI:
 # endregion
 
 
+@pytest.mark.skipif(
+    not google_drive_credentials_available(),
+    reason="Google Drive credentials (client_secrets.json) are not available",
+)
 class TestUpdateDatabase:
     # region tests
 

--- a/MPCAutofill/pytest.ini
+++ b/MPCAutofill/pytest.ini
@@ -1,2 +1,5 @@
 [pytest]
 DJANGO_SETTINGS_MODULE = MPCAutofill.settings
+# credential-dependent tests (update_database, Moxfield) skip when secrets are absent - e.g. on fork
+# PRs - which leaves their committed snapshots unused; warn rather than fail the run in that case
+addopts = --snapshot-warn-unused


### PR DESCRIPTION
## What this does

Two related test-infrastructure fixes:

**1. Factory sequences reset per test.** Snapshots embed sequence-generated values (e.g. `Artist 5`), and factory-boy sequences are global to the session — so adding any new test, or running a subset of the suite, shifts the numbering in every later test and breaks unrelated snapshots. An autouse fixture now resets all factory sequences before each test, making snapshots deterministic regardless of which tests run or in what order. The six affected snapshots are regenerated. (Discovered while working on #477/#478, whose CI runs broke exactly this way; running `pytest cardpicker/tests/test_views.py` alone reproduces it on master today.)

**2. Credential-dependent tests skip instead of erroring.** Fork PRs receive no repo secrets, so `client_secrets.json` is written empty and `MOXFIELD_SECRET` is blank — the Moxfield URL tests and `TestUpdateDatabase` then fail with confusing errors on every fork PR. They now skip with a clear reason when credentials are absent; on master (with secrets) they run exactly as before.

## Testing
- Full suite: 223 passed, 26 skipped, 0 failed (locally, without credentials)
- `pytest cardpicker/tests/test_views.py` alone: 138 passed, all 115 snapshots green — previously 6 snapshot failures when run as a subset

🤖 Generated with [Claude Code](https://claude.com/claude-code)